### PR TITLE
Notify leaders about deadline progress

### DIFF
--- a/src/main/java/org/example/PluginConfig.java
+++ b/src/main/java/org/example/PluginConfig.java
@@ -59,6 +59,8 @@ public class PluginConfig {
         config.addDefault("team.enforce-max-members-on-reload", true);
         config.addDefault("team.grace-period-enabled", true);
         config.addDefault("team.grace-period-minutes", 10);
+        config.addDefault("team.deadline-notify-period-seconds", 300L);
+        config.addDefault("team.deadline-display-mode", "CHAT");
 
         // Настройки меню
         config.addDefault("menu.sound", "BLOCK_NOTE_BLOCK_PLING");
@@ -140,6 +142,24 @@ public class PluginConfig {
      */
     public int getGracePeriodMinutes() {
         return config.getInt("team.grace-period-minutes", 10);
+    }
+
+    /**
+     * Получает период проверки дедлайнов в секундах.
+     *
+     * @return период проверки в секундах
+     */
+    public long getDeadlineNotifyPeriodSeconds() {
+        return config.getLong("team.deadline-notify-period-seconds", 300L);
+    }
+
+    /**
+     * Получает способ отображения уведомлений о дедлайне.
+     *
+     * @return режим отображения
+     */
+    public String getDeadlineDisplayMode() {
+        return config.getString("team.deadline-display-mode", "CHAT");
     }
 
     /**

--- a/src/main/java/org/example/TeamManager.java
+++ b/src/main/java/org/example/TeamManager.java
@@ -6,6 +6,10 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.scoreboard.ScoreboardManager;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -808,7 +812,8 @@ public class TeamManager implements TeamService {
     }
 
     private void startDeadlineTask() {
-        long period = 20L * 60 * 5; // каждые 5 минут
+        long seconds = pluginConfig.getDeadlineNotifyPeriodSeconds();
+        long period = 20L * Math.max(1, seconds);
         plugin.getServer().getScheduler().runTaskTimer(plugin, this::checkDeadlines, period, period);
     }
 
@@ -877,17 +882,60 @@ public class TeamManager implements TeamService {
             if (size <= max) {
                 it.remove();
                 changed = true;
+                Player leader = plugin.getServer().getPlayer(team.getLeader());
+                if (leader != null && pluginConfig.getDeadlineDisplayMode().equalsIgnoreCase("SCOREBOARD")) {
+                    ScoreboardManager manager = plugin.getServer().getScoreboardManager();
+                    if (manager != null) {
+                        leader.setScoreboard(manager.getMainScoreboard());
+                    }
+                }
                 continue;
             }
             if (deadline <= now) {
                 removeExtraPlayers(teamId, max);
                 it.remove();
                 changed = true;
+                Player leader = plugin.getServer().getPlayer(team.getLeader());
+                if (leader != null && pluginConfig.getDeadlineDisplayMode().equalsIgnoreCase("SCOREBOARD")) {
+                    ScoreboardManager manager = plugin.getServer().getScoreboardManager();
+                    if (manager != null) {
+                        leader.setScoreboard(manager.getMainScoreboard());
+                    }
+                }
+            } else {
+                Player leader = plugin.getServer().getPlayer(team.getLeader());
+                if (leader != null) {
+                    long remainingMillis = deadline - now;
+                    long remainingSeconds = remainingMillis / 1000;
+                    long minutes = remainingSeconds / 60;
+                    long seconds = remainingSeconds % 60;
+                    int excess = size - max;
+                    Component message = TeamMessageUtils.deadlineRemainingMessage(minutes, seconds, excess);
+                    String mode = pluginConfig.getDeadlineDisplayMode();
+                    if ("ACTION_BAR".equalsIgnoreCase(mode)) {
+                        leader.sendActionBar(message);
+                    } else if ("SCOREBOARD".equalsIgnoreCase(mode)) {
+                        showDeadlineScoreboard(leader, minutes, seconds, excess);
+                    } else {
+                        TeamMessageUtils.sendTeamMessage(leader, message);
+                    }
+                }
             }
         }
         if (changed) {
             saveTeams();
         }
+    }
+
+    private void showDeadlineScoreboard(Player player, long minutes, long seconds, int excess) {
+        ScoreboardManager manager = plugin.getServer().getScoreboardManager();
+        if (manager == null) return;
+        Scoreboard board = manager.getNewScoreboard();
+        Objective obj = board.registerNewObjective("deadline", "dummy", Component.text("Deadline"));
+        obj.setDisplaySlot(DisplaySlot.SIDEBAR);
+        obj.getScore("Осталось: " + minutes + "m " + seconds + "s").setScore(2);
+        obj.getScore("Удалить: " + excess).setScore(1);
+        player.setScoreboard(board);
     }
 
     private void removeExtraPlayers(UUID teamId, int max) {

--- a/src/main/java/org/example/TeamMessageUtils.java
+++ b/src/main/java/org/example/TeamMessageUtils.java
@@ -104,4 +104,20 @@ public class TeamMessageUtils {
                 .append(Component.text(removed + " участника(ов)", NamedTextColor.WHITE))
                 .append(Component.text(" из-за превышения лимита.", NamedTextColor.RED));
     }
+
+    /**
+     * Сообщение с оставшимся временем для удаления лишних участников.
+     *
+     * @param minutes оставшиеся минуты
+     * @param seconds оставшиеся секунды
+     * @param excess  количество лишних участников
+     * @return сообщение для лидера
+     */
+    public static Component deadlineRemainingMessage(long minutes, long seconds, int excess) {
+        return Component.text("Осталось ", NamedTextColor.YELLOW)
+                .append(Component.text(String.format("%d:%02d", minutes, seconds), NamedTextColor.WHITE))
+                .append(Component.text(" чтобы исключить ", NamedTextColor.YELLOW))
+                .append(Component.text(excess + " участника(ов)", NamedTextColor.WHITE))
+                .append(Component.text(".", NamedTextColor.YELLOW));
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -17,6 +17,8 @@ team:
   enforce-max-members-on-reload: true # Применять ограничение при перезагрузке
   grace-period-enabled: true # Давать время на удаление лишних участников
   grace-period-minutes: 10 # Длительность периода (в минутах)
+  deadline-notify-period-seconds: 300 # Период проверки дедлайнов и оповещения (в секундах)
+  deadline-display-mode: CHAT # CHAT, ACTION_BAR или SCOREBOARD
 
 # Настройки меню
 menu:


### PR DESCRIPTION
## Summary
- send periodic reminders with remaining time to team leaders
- add optional action bar or scoreboard notifications
- make deadline check period configurable in config

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68b70c3a44c8832eac4009a4bf3c576d