### PR TITLE
Clarify team capacity indicators in list command

### DIFF
--- a/src/main/java/org/example/TeamCommand.java
+++ b/src/main/java/org/example/TeamCommand.java
@@ -111,8 +111,10 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
         }
         player.sendMessage(Component.text("")); // Пустая строка перед списком
         player.sendMessage(Component.text("📋 Список команд:", NamedTextColor.AQUA));
-        player.sendMessage(Component.text("")); // Пустая строка перед списком команд
         int maxMembers = pluginConfig.getMaxMembers();
+        String limitText = maxMembers > 0 ? String.valueOf(maxMembers) : "без лимита";
+        player.sendMessage(Component.text("Текущий лимит участников: " + limitText, NamedTextColor.AQUA));
+        player.sendMessage(Component.text("")); // Пустая строка перед списком команд
         for (String team : allTeams) {
             int memberCount = teamManager.getTeamMembers(team).size();
             String prefix = teamManager.getTeamPrefix(team);
@@ -168,7 +170,9 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
      */
     private Component getTeamInfoComponent(String team, int memberCount, int maxMembers) {
         if (maxMembers > 0) {
-            if (memberCount >= maxMembers) {
+            if (memberCount > maxMembers) {
+                return Component.text(team + " [Переполнена]", NamedTextColor.WHITE);
+            } else if (memberCount == maxMembers) {
                 return Component.text(team + " [Полная]", NamedTextColor.WHITE);
             } else {
                 return Component.text(team + " [", NamedTextColor.WHITE)


### PR DESCRIPTION
## Summary
- Show current member limit in `/team list`, treating 0 as unlimited
- Differentiate between full and overflowed teams in team info

## Testing
- `bash ./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b70c44bed8832e979b323fc2523972