### PR TITLE
Handle deadlines removal only during deadline checks

### DIFF
--- a/src/main/java/org/example/TeamManager.java
+++ b/src/main/java/org/example/TeamManager.java
@@ -926,6 +926,5 @@ public class TeamManager implements TeamService {
             }
             plugin.getLogger().info("Из команды " + team.getName() + " удалено " + removed.size() + " участника(ов): " + removed);
         }
-        deadlines.remove(teamId);
     }
 }


### PR DESCRIPTION
## Summary
- Avoid concurrent modification by no longer mutating the deadlines map inside `removeExtraPlayers`
- Let `checkDeadlines` prune deadlines via iterator removal and persist changes with `saveTeams()`

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68b70f758e70832e8fdbc155e23229d1