### PR TITLE
Preserve team IDs when loading configuration

### DIFF
--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -20,7 +20,11 @@ public class Team {
     private NamedTextColor color;
 
     public Team(String name, String leader, String prefix, String color) {
-        this.id = UUID.randomUUID(); // Генерируем новый UUID при создании
+        this(UUID.randomUUID(), name, leader, prefix, color);
+    }
+
+    public Team(UUID id, String name, String leader, String prefix, String color) {
+        this.id = id;
         this.name = name;
         this.leader = leader;
         this.members = new ArrayList<>(List.of(leader));

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -88,13 +88,13 @@ public class TeamManager implements TeamService {
                     String leader = teamsConfig.getString("teams." + teamIdStr + ".leader", "");
                     String prefix = teamsConfig.getString("teams." + teamIdStr + ".prefix", "");
                     String color = teamsConfig.getString("teams." + teamIdStr + ".color", "WHITE");
-                    Team team = new Team(name, leader, prefix, color);
+                    Team team = new Team(teamId, name, leader, prefix, color);
                     team.setMembers(teamsConfig.getStringList("teams." + teamIdStr + ".members"));
                     long deadline = teamsConfig.getLong("teams." + teamIdStr + ".deadline", 0L);
                     if (deadline > 0L) {
-                        deadlines.put(teamId, deadline);
+                        deadlines.put(team.getId(), deadline);
                     }
-                    teams.put(teamId, team);
+                    teams.put(team.getId(), team);
                 }
             }
             ((MyPurpurPlugin) plugin).debug("📂 Файл teams.yml загружен, загружено команд: " + teams.size());


### PR DESCRIPTION
## Summary
- allow constructing a `Team` with a predefined UUID
- wire `loadTeams` to populate `Team` objects with stored IDs and use them as map keys

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b7490f7cc0832ea3ee085b304de0ee