### PR TITLE
Handle tab completion when registering commands

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -1,6 +1,7 @@
 package org.example;
 
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.command.TabCompleter;
 import org.example.command.AdminCommands;
 import org.example.command.CfgDefaultCommand;
 import org.example.command.DebugToggleCommand;
@@ -62,6 +63,9 @@ public class MyPurpurPlugin extends JavaPlugin {
             return;
         }
         command.setExecutor(executor);
+        if (executor instanceof TabCompleter) {
+            command.setTabCompleter((TabCompleter) executor);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- register tab completers when command executors implement `TabCompleter`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b74e7e0228832ebbbc90cef1cb6f5a