### PR TITLE
Check permissions for admin UUID commands

### DIFF
--- a/src/main/java/org/example/command/AdminCommands.java
+++ b/src/main/java/org/example/command/AdminCommands.java
@@ -33,16 +33,19 @@ public class AdminCommands implements CommandExecutor, TabCompleter {
             return true;
         }
 
-        if (!player.isOp()) {
-            player.sendMessage(Component.text("❌ У вас нет прав для выполнения этой команды!", NamedTextColor.RED));
-            return true;
-        }
-
         String commandName = command.getName().toLowerCase();
 
         if (commandName.equals("getteamsuuidlist")) {
+            if (!player.hasPermission("mypurpurplugin.getteamsuuidlist")) {
+                player.sendMessage(Component.text("❌ У вас нет прав для выполнения этой команды!", NamedTextColor.RED));
+                return true;
+            }
             return handleGetTeamsUUIDListCommand(player);
         } else if (commandName.equals("getteamuuid")) {
+            if (!player.hasPermission("mypurpurplugin.getteamuuid")) {
+                player.sendMessage(Component.text("❌ У вас нет прав для выполнения этой команды!", NamedTextColor.RED));
+                return true;
+            }
             return handleGetTeamUUIDCommand(player, args);
         }
 


### PR DESCRIPTION
## Summary
- require dedicated permissions for `getteamsuuidlist` and `getteamuuid`
- notify players when they lack permission

## Testing
- `bash ./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b774cab88c832e84da0fb422bfc649