### PR TITLE
Replace deprecated getFirst usage with compatibility method

### DIFF
--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -46,6 +46,10 @@ public class Team {
     return new ArrayList<>(members);
   }
 
+  public String getFirstMember() {
+    return members.isEmpty() ? null : members.get(0);
+  }
+
   public String getPrefix() {
     return prefix;
   }

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -492,7 +492,7 @@ public class TeamManager implements TeamService {
             "",
             Component.empty());
       } else {
-        String newLeader = team.getMembers().getFirst();
+        String newLeader = team.getFirstMember();
         team.setLeader(newLeader);
         saveTeams();
         Component leaderMessage =


### PR DESCRIPTION
## Summary
- add `getFirstMember` method to Team to access first member without relying on List#getFirst
- use new helper when reassigning team leader

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68b82a587efc832e9e5a77b41377fd69