### PR TITLE
refactor: inject plugin config into team manager

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -31,7 +31,7 @@ public class MyPurpurPlugin extends JavaPlugin {
     // Инициализация конфигурации
     pluginConfig = new PluginConfig(this);
     // Инициализация менеджера команд
-    teamManager = new TeamManager(this);
+    teamManager = new TeamManager(this, pluginConfig);
 
     // Регистрация команд
     registerCommand("team", new TeamCommand(teamManager, pluginConfig));

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -36,9 +36,9 @@ public class TeamManager implements TeamService {
   private FileConfiguration teamsConfig;
   private File teamsFile;
 
-  public TeamManager(@NotNull JavaPlugin plugin) {
+  public TeamManager(@NotNull JavaPlugin plugin, @NotNull PluginConfig pluginConfig) {
     this.plugin = plugin;
-    this.pluginConfig = new PluginConfig(plugin);
+    this.pluginConfig = pluginConfig;
     this.teams = new ConcurrentHashMap<>();
     this.deadlines = new ConcurrentHashMap<>();
     this.playerTeams = new ConcurrentHashMap<>();


### PR DESCRIPTION
## Summary
- Pass `PluginConfig` from `MyPurpurPlugin` to `TeamManager`
- Remove internal `new PluginConfig(plugin)` to keep configuration in sync

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b84cc6e7ac832e98481c380ce1ed25