### PR TITLE
chore: ensure YAML files end with newline

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -28,3 +28,4 @@ menu:
   sound-volume: 1.0 # Громкость звука (0.0–1.0)
   sound-pitch: 1.0 # Высота тона звука (0.5–2.0)
   particle-effect: FIREWORK # Эффект частиц при открытии меню (примеры: SMOKE, HEART, FIREWORK, EXPLOSION)
+

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -79,3 +79,4 @@ permissions:
   mypurpurplugin.getteamuuid:
     description: Доступ к команде /getteamuuid (только для OP)
     default: op
+


### PR DESCRIPTION
## Summary
- ensure plugin.yml and config.yml end with newline to avoid EOF warnings

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b84dfc2244832e80b346770cd91b5b