### PR TITLE
Configure Java toolchain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,12 @@ plugins {
     id("com.diffplug.spotless") version "6.25.0"
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
 group = "org.example"
 version = "1.0"
 


### PR DESCRIPTION
## Summary
- ensure Gradle uses Java 17 toolchain for compilation

## Testing
- `./gradlew build` *(fails: `Dependency resolution is looking for a library compatible with JVM runtime version 17, but 'org.purpurmc.purpur:purpur-api:1.21.3-R0.1-SNAPSHOT:20241204.125848-28' is only compatible with JVM runtime version 21 or newer`)*

------
https://chatgpt.com/codex/tasks/task_e_68b8768b2250832e8b90096a23268557