### PR TITLE
chore: target Java 21 toolchain

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,9 +4,7 @@ plugins {
 }
 
 java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(17))
-    }
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
 group = "org.example"


### PR DESCRIPTION
## Summary
- target Java 21 in Gradle toolchain

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68b895295d18832eb9ae75cefc6d83df