### PR TITLE
Add parameterized and stress tests for TeamManager with performance logging

### DIFF
--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -16,6 +16,7 @@ public class TeamManager implements TeamService {
   private final TeamStorage storage;
   private final DeadlineScheduler scheduler;
   private final MembershipService membership;
+  private static final long EXECUTION_THRESHOLD_MS = 50;
 
   public TeamManager(@NotNull JavaPlugin plugin, @NotNull PluginConfig pluginConfig) {
     this.plugin = plugin;
@@ -28,56 +29,67 @@ public class TeamManager implements TeamService {
     this.membership = new MembershipService(plugin, pluginConfig, storage, scheduler);
   }
 
+  private void runWithTiming(String methodName, Runnable action) {
+    long start = System.nanoTime();
+    action.run();
+    long durationMs = (System.nanoTime() - start) / 1_000_000;
+    if (durationMs > EXECUTION_THRESHOLD_MS) {
+      plugin.getLogger().warning(methodName + " took " + durationMs + " ms");
+    }
+  }
+
   @Override
   public void createTeam(String teamName, String prefix, String color, @NotNull Player leader) {
-    membership.createTeam(teamName, prefix, color, leader);
+    runWithTiming("createTeam", () -> membership.createTeam(teamName, prefix, color, leader));
   }
 
   @Override
   public void addPlayerToTeam(String teamName, @NotNull Player player) {
-    membership.addPlayerToTeam(teamName, player);
+    runWithTiming("addPlayerToTeam", () -> membership.addPlayerToTeam(teamName, player));
   }
 
   @Override
   public void removePlayerFromTeam(String teamName, @NotNull Player player) {
-    membership.removePlayerFromTeam(teamName, player);
+    runWithTiming("removePlayerFromTeam", () -> membership.removePlayerFromTeam(teamName, player));
   }
 
   @Override
   public void kickPlayerFromTeam(
       String teamName, @NotNull Player leader, @NotNull String targetName) {
-    membership.kickPlayerFromTeam(teamName, leader, targetName);
+    runWithTiming(
+        "kickPlayerFromTeam", () -> membership.kickPlayerFromTeam(teamName, leader, targetName));
   }
 
   @Override
   public void transferLeadership(
       String teamName, @NotNull Player leader, @NotNull Player newLeader) {
-    membership.transferLeadership(teamName, leader, newLeader);
+    runWithTiming(
+        "transferLeadership", () -> membership.transferLeadership(teamName, leader, newLeader));
   }
 
   @Override
   public void disbandTeam(String teamName, @NotNull Player leader) {
-    membership.disbandTeam(teamName, leader);
+    runWithTiming("disbandTeam", () -> membership.disbandTeam(teamName, leader));
   }
 
   @Override
   public void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader) {
-    membership.renameTeam(oldTeamName, newTeamName, leader);
+    runWithTiming("renameTeam", () -> membership.renameTeam(oldTeamName, newTeamName, leader));
   }
 
   @Override
   public void setTeamPrefix(String teamName, String newPrefix, @NotNull Player leader) {
-    membership.setTeamPrefix(teamName, newPrefix, leader);
+    runWithTiming("setTeamPrefix", () -> membership.setTeamPrefix(teamName, newPrefix, leader));
   }
 
   @Override
   public void setTeamColor(String teamName, String newColor, @NotNull Player leader) {
-    membership.setTeamColor(teamName, newColor, leader);
+    runWithTiming("setTeamColor", () -> membership.setTeamColor(teamName, newColor, leader));
   }
 
   @Override
   public void updatePlayerPrefixes(String teamName) {
-    membership.updatePlayerPrefixes(teamName);
+    runWithTiming("updatePlayerPrefixes", () -> membership.updatePlayerPrefixes(teamName));
   }
 
   @Override

--- a/src/test/java/org/example/service/TeamManagerTest.java
+++ b/src/test/java/org/example/service/TeamManagerTest.java
@@ -6,11 +6,15 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
 import org.example.MyPurpurPlugin;
 import org.example.config.PluginConfig;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /** Unit tests for {@link TeamManager}. */
 class TeamManagerTest {
@@ -46,6 +50,19 @@ class TeamManagerTest {
     MockBukkit.unmock();
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"Alice", "Bob", "Charlie"})
+  void playersJoinAndLeaveTeam(String playerName) {
+    PlayerMock leader = server.addPlayer("Leader" + playerName);
+    String teamName = "Team" + playerName;
+    teamManager.createTeam(teamName, "PX", "white", leader);
+    PlayerMock player = server.addPlayer(playerName);
+    teamManager.addPlayerToTeam(teamName, player);
+    assertEquals(teamName, teamManager.getPlayerTeam(player));
+    teamManager.removePlayerFromTeam(teamName, player);
+    assertNull(teamManager.getPlayerTeam(player));
+  }
+
   @Test
   void createsAndManagesTeamMembership() {
     PlayerMock leader = server.addPlayer("Leader1");
@@ -60,6 +77,35 @@ class TeamManagerTest {
 
     teamManager.removePlayerFromTeam("Alpha", member);
     assertNull(teamManager.getPlayerTeam(member));
+  }
+
+  @Test
+  void stressTestAddRemovePlayers() {
+    PlayerMock leader = server.addPlayer("StressLeader");
+    teamManager.createTeam("Stress", "ST", "white", leader);
+    List<PlayerMock> players = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      players.add(server.addPlayer("Stress" + i));
+    }
+    Runtime runtime = Runtime.getRuntime();
+    long before = runtime.totalMemory() - runtime.freeMemory();
+    assertDoesNotThrow(
+        () -> {
+          for (int i = 0; i < 100; i++) {
+            for (PlayerMock p : players) {
+              teamManager.addPlayerToTeam("Stress", p);
+            }
+            for (PlayerMock p : players) {
+              teamManager.removePlayerFromTeam("Stress", p);
+            }
+          }
+        });
+    System.gc();
+    long after = runtime.totalMemory() - runtime.freeMemory();
+    if (after - before > 10_000_000) {
+      teamManager.getPlugin().getLogger().warning("Potential memory leak: " + (after - before));
+    }
+    assertEquals(1, teamManager.getTeamMembers("Stress").size());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Instrument TeamManager operations to log warnings when execution time exceeds a threshold
- Add parameterized tests for player join/leave scenarios
- Stress-test TeamManager with repeated add/remove operations to catch concurrency or memory issues

## Testing
- `./gradlew spotlessApply`
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c75898d284832ead6c885d43e3d1c3