### PR TITLE
Add CI workflow with Gradle cache and build badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'gradle'
+      - name: Build with Gradle
+        run: ./gradlew test build

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# MyPurpurPlugin
+
+[![CI](https://github.com/OWNER/MyPurpurPlugin-V12-github/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/MyPurpurPlugin-V12-github/actions/workflows/ci.yml)
+
+A Purpur plugin project.


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow that caches Gradle dependencies and runs `./gradlew test build`
- document build status with a CI badge in the README

## Testing
- `./gradlew test build --console=plain` *(fails: Execution failed for task ':spotlessJavaCheck'. Run './gradlew :spotlessApply' to fix these violations.)*

------
https://chatgpt.com/codex/tasks/task_e_68c75e39345c832e87b88d4b922d6482