### PR TITLE
Manage MockBukkit lifecycle in tests

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -112,4 +112,11 @@ public class MyPurpurPlugin extends JavaPlugin {
     debugMode = !debugMode;
     getLogger().info("Режим отладки " + (debugMode ? "включён" : "отключён") + "!");
   }
+
+  @Override
+  public void onDisable() {
+    if (teamManager != null) {
+      teamManager.shutdown();
+    }
+  }
 }

--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 import org.example.config.PluginConfig;
 import org.example.listener.TeamChatListener;
 import org.example.model.Team;
@@ -16,6 +17,7 @@ public class DeadlineScheduler {
   private final PluginConfig pluginConfig;
   private final TeamStorage storage;
   private final Map<UUID, Long> deadlines = new ConcurrentHashMap<>();
+  private BukkitTask task;
 
   public DeadlineScheduler(
       @NotNull JavaPlugin plugin,
@@ -30,10 +32,24 @@ public class DeadlineScheduler {
     return deadlines;
   }
 
-  public void start() {
+  public synchronized void start() {
     long seconds = pluginConfig.getDeadlineNotifyPeriodSeconds();
     long period = 20L * Math.max(1, seconds);
-    plugin.getServer().getScheduler().runTaskTimer(plugin, this::checkDeadlines, period, period);
+    if (task != null) {
+      task.cancel();
+    }
+    task =
+        plugin
+            .getServer()
+            .getScheduler()
+            .runTaskTimer(plugin, this::checkDeadlines, period, period);
+  }
+
+  public synchronized void stop() {
+    if (task != null) {
+      task.cancel();
+      task = null;
+    }
   }
 
   public void enforceTeamSizes() {

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -148,4 +148,9 @@ public class TeamManager implements TeamService {
   public Long getTeamDeadline(String teamName) {
     return scheduler.getTeamDeadline(teamName);
   }
+
+  @Override
+  public void shutdown() {
+    scheduler.stop();
+  }
 }

--- a/src/main/java/org/example/service/TeamService.java
+++ b/src/main/java/org/example/service/TeamService.java
@@ -181,4 +181,7 @@ public interface TeamService {
    * @return значение дедлайна или null
    */
   Long getTeamDeadline(String teamName);
+
+  /** Выполняет очистку ресурсов сервиса команд. */
+  default void shutdown() {}
 }

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -5,10 +5,18 @@ import static org.junit.jupiter.api.Assertions.*;
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
 import io.papermc.paper.chat.ChatRenderer;
 import io.papermc.paper.event.player.AsyncChatEvent;
+import java.io.File;
+import java.io.IOException;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.Set;
+import java.util.stream.Stream;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.chat.SignedMessage;
 import net.kyori.adventure.text.Component;
@@ -20,23 +28,29 @@ import org.example.MyPurpurPlugin;
 import org.example.config.PluginConfig;
 import org.example.service.DeadlineScheduler;
 import org.example.service.TeamManager;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /** Integration tests for team commands and related events. */
 class TeamCommandTest {
 
-  private ServerMock server;
+  private static ServerMock server;
   private MyPurpurPlugin plugin;
   private TeamManager teamManager;
   private PluginConfig pluginConfig;
   private FileConfiguration config;
   private DeadlineScheduler scheduler;
 
+  @BeforeAll
+  static void initServer() {
+    server = MockBukkit.mock();
+  }
+
   @BeforeEach
   void setUp() throws Exception {
-    server = MockBukkit.mock();
     plugin = MockBukkit.load(MyPurpurPlugin.class);
 
     Field tmField = MyPurpurPlugin.class.getDeclaredField("teamManager");
@@ -58,6 +72,45 @@ class TeamCommandTest {
 
   @AfterEach
   void tearDown() {
+    if (scheduler != null) {
+      scheduler.stop();
+      scheduler = null;
+    }
+    File dataFolder = plugin != null ? plugin.getDataFolder() : null;
+    if (plugin != null) {
+      ServerMock current = MockBukkit.getMock();
+      if (current != null) {
+        PluginManagerMock pluginManager = current.getPluginManager();
+        if (pluginManager.isPluginEnabled(plugin)) {
+          pluginManager.disablePlugin(plugin);
+        }
+        pluginManager.clearPlugins();
+      }
+      plugin = null;
+    }
+    if (dataFolder != null && dataFolder.exists()) {
+      try (Stream<Path> walk = Files.walk(dataFolder.toPath())) {
+        walk.sorted(Comparator.reverseOrder()).forEach(path -> path.toFile().delete());
+      } catch (IOException ignored) {
+      }
+    }
+    if (server != null) {
+      new ArrayList<>(server.getOnlinePlayers())
+          .forEach(
+              player -> {
+                if (player instanceof PlayerMock mockPlayer) {
+                  mockPlayer.disconnect();
+                }
+              });
+      server.getCommandMap().clearCommands();
+    }
+    teamManager = null;
+    pluginConfig = null;
+    config = null;
+  }
+
+  @AfterAll
+  static void shutdownServer() {
     MockBukkit.unmock();
   }
 
@@ -152,8 +205,7 @@ class TeamCommandTest {
             SignedMessage.system("hello", message));
     server.getPluginManager().callEvent(event);
 
-    Component rendered =
-        event.renderer().render(leader, Component.text("Leader"), message, leader);
+    Component rendered = event.renderer().render(leader, Component.text("Leader"), message, leader);
     String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
     assertEquals("[AA] Leader: hello", plain);
   }
@@ -185,4 +237,3 @@ class TeamCommandTest {
     assertNull(teamManager.getTeamDeadline("Beta"));
   }
 }
-

--- a/src/test/java/org/example/service/TeamManagerTest.java
+++ b/src/test/java/org/example/service/TeamManagerTest.java
@@ -47,6 +47,9 @@ class TeamManagerTest {
 
   @AfterAll
   static void tearDown() {
+    if (teamManager != null) {
+      teamManager.shutdown();
+    }
     MockBukkit.unmock();
   }
 
@@ -106,6 +109,22 @@ class TeamManagerTest {
       teamManager.getPlugin().getLogger().warning("Potential memory leak: " + (after - before));
     }
     assertEquals(1, teamManager.getTeamMembers("Stress").size());
+  }
+
+  @Test
+  void createsTeamAndAllowsJoin() {
+    PlayerMock leader = server.addPlayer("Captain");
+    PlayerMock member = server.addPlayer("Recruit");
+
+    String teamName = "Voyagers";
+    teamManager.createTeam(teamName, "VG", "white", leader);
+
+    assertEquals(teamName, teamManager.getPlayerTeam(leader));
+    assertTrue(teamManager.getTeamMembers(teamName).contains(leader.getName()));
+
+    teamManager.addPlayerToTeam(teamName, member);
+    assertEquals(teamName, teamManager.getPlayerTeam(member));
+    assertTrue(teamManager.getTeamMembers(teamName).contains(member.getName()));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- store and cancel the deadline scheduler task when shutting down
- add plugin and TeamManager shutdown hooks and clean up MockBukkit between tests
- add coverage for team creation and joining scenarios

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c8b0e55c98832e8b38ca21f15f1616