### PR TITLE
Refactor /team command into dedicated subcommands

### DIFF
--- a/src/main/java/org/example/command/TeamCommand.java
+++ b/src/main/java/org/example/command/TeamCommand.java
@@ -1,8 +1,10 @@
 package org.example.command;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.Command;
@@ -10,9 +12,15 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.example.MyPurpurPlugin;
+import org.example.command.sub.CreateSubCommand;
+import org.example.command.sub.HelpSubCommand;
+import org.example.command.sub.JoinSubCommand;
+import org.example.command.sub.LeaveSubCommand;
+import org.example.command.sub.ListSubCommand;
+import org.example.command.sub.MembersSubCommand;
+import org.example.command.sub.SubCommand;
 import org.example.config.PluginConfig;
 import org.example.service.TeamService;
-import org.example.util.TeamUtils;
 import org.jetbrains.annotations.NotNull;
 
 /** Обработчик команд, связанных с командами игроков. */
@@ -20,10 +28,21 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
 
   private final TeamService teamManager;
   private final PluginConfig pluginConfig;
+  private final Map<String, SubCommand> subCommands = new LinkedHashMap<>();
 
   public TeamCommand(@NotNull TeamService teamManager, @NotNull PluginConfig pluginConfig) {
     this.teamManager = teamManager;
     this.pluginConfig = pluginConfig;
+    registerSubCommands();
+  }
+
+  private void registerSubCommands() {
+    subCommands.put("create", new CreateSubCommand(teamManager));
+    subCommands.put("join", new JoinSubCommand(teamManager));
+    subCommands.put("leave", new LeaveSubCommand(teamManager));
+    subCommands.put("list", new ListSubCommand(teamManager, pluginConfig));
+    subCommands.put("members", new MembersSubCommand(teamManager, pluginConfig));
+    subCommands.put("help", new HelpSubCommand());
   }
 
   @Override
@@ -39,14 +58,12 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
       return true;
     }
 
-    // Проверка разрешения
     if (!player.hasPermission("mypurpurplugin.team")) {
       player.sendMessage(
           Component.text("❌ У вас нет прав для использования этой команды!", NamedTextColor.RED));
       return true;
     }
 
-    // Проверка прав из конфига
     if (pluginConfig.isTeamCommandRequiresOp() && !player.isOp()) {
       player.sendMessage(
           Component.text(
@@ -60,218 +77,36 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
       return true;
     }
 
-    String subCommand = args[0].toLowerCase();
+    String subCommandName = args[0].toLowerCase(Locale.ROOT);
     ((MyPurpurPlugin) teamManager.getPlugin())
         .debugTeamAction("Команда /team выполнена игроком", player.getName(), null);
 
-    return handleSubCommand(player, subCommand, args);
-  }
-
-  private boolean handleSubCommand(Player player, String subCommand, String[] args) {
-    return switch (subCommand) {
-      case "create" -> handleCreateCommand(player, args);
-      case "join" -> handleJoinCommand(player, args);
-      case "leave" -> handleLeaveCommand(player);
-      case "list" -> handleListCommand(player);
-      case "members" -> handleMembersCommand(player);
-      case "help" -> {
-        sendHelp(player);
-        yield true;
-      }
-      default -> {
-        player.sendMessage(
-            Component.text(
-                "❌ Неизвестная подкоманда! Используйте: /team <create | join | leave | list | members | help>",
-                NamedTextColor.RED));
-        yield true;
-      }
-    };
-  }
-
-  @SuppressWarnings("BooleanMethodIsAlwaysInverted")
-  private boolean handleCreateCommand(Player player, String[] args) {
-    if (args.length < 4) {
-      player.sendMessage(
-          Component.text(
-              "❌ Использование: /team create <название> <префикс> <цвет> (цвет: RED, BLUE, GREEN и т.д.)",
-              NamedTextColor.RED));
+    SubCommand subCommand = subCommands.get(subCommandName);
+    if (subCommand == null) {
+      sendUnknownSubCommandMessage(player);
       return true;
     }
-    teamManager.createTeam(args[1], args[2], args[3], player);
-    return true; // Всегда возвращаем true, чтобы избежать лишних подсказок от Bukkit
-  }
 
-  private boolean handleJoinCommand(Player player, String[] args) {
-    if (args.length < 2) {
-      player.sendMessage(
-          Component.text("❌ Использование: /team join <название>", NamedTextColor.RED));
-      return true;
-    }
-    teamManager.addPlayerToTeam(args[1], player);
-    return true; // Всегда возвращаем true, чтобы избежать лишних подсказок от Bukkit
-  }
-
-  private boolean handleLeaveCommand(Player player) {
-    String teamName = teamManager.getPlayerTeam(player);
-    if (teamName == null) {
-      player.sendMessage(Component.text("❌ Вы не состоите в команде!", NamedTextColor.RED));
-      return true;
-    }
-    teamManager.removePlayerFromTeam(teamName, player);
-    return true; // Всегда возвращаем true, чтобы избежать лишних подсказок от Bukkit
-  }
-
-  private boolean handleListCommand(Player player) {
-    List<String> allTeams = teamManager.getTeamNames();
-    if (allTeams.isEmpty()) {
-      player.sendMessage(Component.text("❌ Нет активных команд!", NamedTextColor.RED));
-      return true;
-    }
-    int maxMembers = pluginConfig.getMaxMembers();
-    sendTeamListHeader(player, maxMembers);
-    for (String team : allTeams) {
-      sendTeamEntry(player, team, maxMembers);
-    }
-    player.sendMessage(Component.text("")); // Пустая строка после списка
-    return true;
-  }
-
-  private void sendTeamListHeader(Player player, int maxMembers) {
-    player.sendMessage(Component.text(""));
-    player.sendMessage(Component.text("📋 Список команд:", NamedTextColor.AQUA));
-    String limitText = maxMembers > 0 ? String.valueOf(maxMembers) : "без лимита";
-    player.sendMessage(
-        Component.text("Текущий лимит участников: " + limitText, NamedTextColor.AQUA));
-    player.sendMessage(Component.text(""));
-  }
-
-  private void sendTeamEntry(Player player, String team, int maxMembers) {
-    int memberCount = teamManager.getTeamMembers(team).size();
-    String prefix = teamManager.getTeamPrefix(team);
-    NamedTextColor color = teamManager.getTeamColor(team);
-    Component prefixComponent = TeamUtils.createPrefixComponent(prefix, color);
-    Component teamInfo = getTeamInfoComponent(team, memberCount, maxMembers);
-    player.sendMessage(Component.text("- ").append(prefixComponent).append(teamInfo));
-  }
-
-  private boolean handleMembersCommand(Player player) {
-    String playerTeam = teamManager.getPlayerTeam(player);
-    if (playerTeam == null) {
-      player.sendMessage(Component.text("❌ Вы не состоите в команде!", NamedTextColor.RED));
-      return true;
-    }
-    List<String> members = teamManager.getTeamMembers(playerTeam);
-    String prefix = teamManager.getTeamPrefix(playerTeam);
-    NamedTextColor color = teamManager.getTeamColor(playerTeam);
-    Component prefixComponent = TeamUtils.createPrefixComponent(prefix, color);
-    int maxMembers = pluginConfig.getMaxMembers();
-    Component teamHeader =
-        getTeamHeaderComponent(playerTeam, prefixComponent, members.size(), maxMembers);
-    player.sendMessage(Component.text("")); // Пустая строка перед заголовком
-    player.sendMessage(teamHeader);
-    player.sendMessage(Component.text("")); // Пустая строка перед списком участников
-    for (String memberName : members) {
-      Player member = teamManager.getPlugin().getServer().getPlayer(memberName);
-      if (member != null) {
-        // Игрок в сети: зелёный круг и белый цвет ника
-        player.sendMessage(
-            Component.text("● ", NamedTextColor.GREEN)
-                .append(Component.text(memberName, NamedTextColor.WHITE)));
-      } else {
-        // Игрок не в сети: серый круг и серый цвет ника
-        player.sendMessage(
-            Component.text("● ", NamedTextColor.GRAY)
-                .append(Component.text(memberName, NamedTextColor.GRAY)));
-      }
-    }
-    player.sendMessage(Component.text("")); // Пустая строка после списка
-    return true;
-  }
-
-  /**
-   * Формирует компонент с информацией о команде (количество участников, статус заполненности).
-   *
-   * @param team Название команды
-   * @param memberCount Количество участников в команде
-   * @param maxMembers Максимальное количество участников (0 — безлимит)
-   * @return Компонент с информацией о команде
-   */
-  private Component getTeamInfoComponent(String team, int memberCount, int maxMembers) {
-    if (maxMembers > 0) {
-      if (memberCount > maxMembers) {
-        return Component.text(team + " [Переполнена]", NamedTextColor.WHITE);
-      } else if (memberCount == maxMembers) {
-        return Component.text(team + " [Полная]", NamedTextColor.WHITE);
-      } else {
-        return Component.text(team + " [", NamedTextColor.WHITE)
-            .append(Component.text(memberCount, NamedTextColor.YELLOW))
-            .append(Component.text(" / ", NamedTextColor.WHITE))
-            .append(Component.text(maxMembers, NamedTextColor.YELLOW))
-            .append(Component.text("]", NamedTextColor.WHITE));
-      }
-    } else {
-      return Component.text(team + " (", NamedTextColor.WHITE)
-          .append(Component.text(memberCount, NamedTextColor.YELLOW))
-          .append(Component.text(" участников)", NamedTextColor.WHITE));
-    }
-  }
-
-  /**
-   * Формирует компонент заголовка команды для списка участников.
-   *
-   * @param playerTeam Название команды
-   * @param prefixComponent Префикс команды
-   * @param memberCount Количество участников в команде
-   * @param maxMembers Максимальное количество участников (0 — безлимит)
-   * @return Компонент заголовка команды
-   */
-  private Component getTeamHeaderComponent(
-      String playerTeam, Component prefixComponent, int memberCount, int maxMembers) {
-    if (maxMembers > 0) {
-      if (memberCount >= maxMembers) {
-        return Component.text("📋 Участники команды ", NamedTextColor.AQUA)
-            .append(prefixComponent)
-            .append(Component.text(playerTeam + " [Полная]:", NamedTextColor.WHITE));
-      } else {
-        return Component.text("📋 Участники команды ", NamedTextColor.AQUA)
-            .append(prefixComponent)
-            .append(Component.text(playerTeam + " [", NamedTextColor.WHITE))
-            .append(Component.text(memberCount, NamedTextColor.YELLOW))
-            .append(Component.text(" / ", NamedTextColor.WHITE))
-            .append(Component.text(maxMembers, NamedTextColor.YELLOW))
-            .append(Component.text("]:", NamedTextColor.WHITE));
-      }
-    } else {
-      return Component.text("📋 Участники команды ", NamedTextColor.AQUA)
-          .append(prefixComponent)
-          .append(Component.text(playerTeam + ":", NamedTextColor.WHITE));
-    }
+    return subCommand.execute(player, args);
   }
 
   private void sendUsage(Player player) {
     player.sendMessage(
         Component.text(
-            "❌ Использование: /team <create | join | leave | list | members | help> [аргументы]",
+            "❌ Использование: /team <" + getSubCommandList() + "> [аргументы]", NamedTextColor.RED));
+  }
+
+  private void sendUnknownSubCommandMessage(Player player) {
+    player.sendMessage(
+        Component.text(
+            "❌ Неизвестная подкоманда! Используйте: /team <"
+                + getSubCommandList()
+                + ">",
             NamedTextColor.RED));
   }
 
-  private void sendHelp(Player player) {
-    player.sendMessage(Component.text("")); // Пустая строка перед списком
-    player.sendMessage(Component.text("ℹ Использование /team:", NamedTextColor.AQUA));
-    player.sendMessage(Component.text(""));
-    player.sendMessage(
-        Component.text(
-            "/team create <название> <префикс> <цвет> — создать команду (цвет: RED, BLUE, GREEN и т.д.)",
-            NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text("/team join <название> — вступить в команду", NamedTextColor.AQUA));
-    player.sendMessage(Component.text("/team leave — покинуть команду", NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text("/team list — показать список всех команд", NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text("/team members — показать участников вашей команды", NamedTextColor.AQUA));
-    player.sendMessage(Component.text("/team help — показать эту справку", NamedTextColor.AQUA));
-    player.sendMessage(Component.text("")); // Пустая строка после списка
+  private String getSubCommandList() {
+    return String.join(" | ", subCommands.keySet());
   }
 
   @Override
@@ -281,36 +116,22 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
       @NotNull Command command,
       @NotNull String alias,
       @NotNull String[] args) {
-    List<String> suggestions = new ArrayList<>();
-    if (args.length == 1) {
-      suggestions.addAll(Arrays.asList("create", "join", "leave", "list", "members", "help"));
-    } else if (args.length == 2) {
-      if (sender instanceof Player player) {
-        if (args[0].equalsIgnoreCase("join")) {
-          String playerTeam = teamManager.getPlayerTeam(player);
-          if (playerTeam == null) { // Игрок не в команде
-            for (String teamName : teamManager.getTeamNames()) {
-              String leader = teamManager.getTeamLeader(teamName);
-              if (leader == null || !leader.equals(player.getName())) {
-                if (teamName.toLowerCase().startsWith(args[1].toLowerCase())) {
-                  suggestions.add(teamName);
-                }
-              }
-            }
-          }
-        } else if (args[0].equalsIgnoreCase("create")) {
-          suggestions.add("<название>");
+    if (args.length <= 1) {
+      String partial = args.length == 0 ? "" : args[0].toLowerCase(Locale.ROOT);
+      List<String> suggestions = new ArrayList<>();
+      for (String name : subCommands.keySet()) {
+        if (name.startsWith(partial)) {
+          suggestions.add(name);
         }
       }
-    } else if (args.length == 3 && args[0].equalsIgnoreCase("create")) {
-      suggestions.add("<префикс>");
-    } else if (args.length == 4 && args[0].equalsIgnoreCase("create")) {
-      for (NamedTextColor color : NamedTextColor.NAMES.values()) {
-        if (color.toString().toLowerCase().startsWith(args[3].toLowerCase())) {
-          suggestions.add(color.toString().toUpperCase());
-        }
-      }
+      return suggestions;
     }
-    return suggestions;
+
+    SubCommand subCommand = subCommands.get(args[0].toLowerCase(Locale.ROOT));
+    if (subCommand == null) {
+      return new ArrayList<>();
+    }
+
+    return subCommand.tabComplete(sender, args);
   }
 }

--- a/src/main/java/org/example/command/sub/CreateSubCommand.java
+++ b/src/main/java/org/example/command/sub/CreateSubCommand.java
@@ -1,0 +1,53 @@
+package org.example.command.sub;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.example.service.TeamService;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team create. */
+public class CreateSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public CreateSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    if (args.length < 4) {
+      player.sendMessage(
+          Component.text(
+              "❌ Использование: /team create <название> <префикс> <цвет> (цвет: RED, BLUE, GREEN и т.д.)",
+              NamedTextColor.RED));
+      return true;
+    }
+    teamService.createTeam(args[1], args[2], args[3], player);
+    return true;
+  }
+
+  @Override
+  public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    List<String> suggestions = new ArrayList<>();
+    if (args.length == 2) {
+      suggestions.add("<название>");
+    } else if (args.length == 3) {
+      suggestions.add("<префикс>");
+    } else if (args.length == 4) {
+      String partial = args[3].toLowerCase(Locale.ROOT);
+      for (NamedTextColor color : NamedTextColor.NAMES.values()) {
+        String colorName = color.toString();
+        if (colorName != null && colorName.toLowerCase(Locale.ROOT).startsWith(partial)) {
+          suggestions.add(colorName.toUpperCase(Locale.ROOT));
+        }
+      }
+    }
+    return suggestions;
+  }
+}

--- a/src/main/java/org/example/command/sub/HelpSubCommand.java
+++ b/src/main/java/org/example/command/sub/HelpSubCommand.java
@@ -1,0 +1,31 @@
+package org.example.command.sub;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team help. */
+public class HelpSubCommand implements SubCommand {
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    player.sendMessage(Component.text(""));
+    player.sendMessage(Component.text("ℹ Использование /team:", NamedTextColor.AQUA));
+    player.sendMessage(Component.text(""));
+    player.sendMessage(
+        Component.text(
+            "/team create <название> <префикс> <цвет> — создать команду (цвет: RED, BLUE, GREEN и т.д.)",
+            NamedTextColor.AQUA));
+    player.sendMessage(
+        Component.text("/team join <название> — вступить в команду", NamedTextColor.AQUA));
+    player.sendMessage(Component.text("/team leave — покинуть команду", NamedTextColor.AQUA));
+    player.sendMessage(
+        Component.text("/team list — показать список всех команд", NamedTextColor.AQUA));
+    player.sendMessage(
+        Component.text("/team members — показать участников вашей команды", NamedTextColor.AQUA));
+    player.sendMessage(Component.text("/team help — показать эту справку", NamedTextColor.AQUA));
+    player.sendMessage(Component.text(""));
+    return true;
+  }
+}

--- a/src/main/java/org/example/command/sub/JoinSubCommand.java
+++ b/src/main/java/org/example/command/sub/JoinSubCommand.java
@@ -1,0 +1,55 @@
+package org.example.command.sub;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.example.service.TeamService;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team join. */
+public class JoinSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public JoinSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    if (args.length < 2) {
+      player.sendMessage(
+          Component.text("❌ Использование: /team join <название>", NamedTextColor.RED));
+      return true;
+    }
+    teamService.addPlayerToTeam(args[1], player);
+    return true;
+  }
+
+  @Override
+  public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    List<String> suggestions = new ArrayList<>();
+    if (!(sender instanceof Player player)) {
+      return suggestions;
+    }
+    if (args.length == 2) {
+      String playerTeam = teamService.getPlayerTeam(player);
+      if (playerTeam == null) {
+        String partial = args[1].toLowerCase(Locale.ROOT);
+        for (String teamName : teamService.getTeamNames()) {
+          String leader = teamService.getTeamLeader(teamName);
+          if (leader == null || !leader.equals(player.getName())) {
+            if (teamName.toLowerCase(Locale.ROOT).startsWith(partial)) {
+              suggestions.add(teamName);
+            }
+          }
+        }
+      }
+    }
+    return suggestions;
+  }
+}

--- a/src/main/java/org/example/command/sub/LeaveSubCommand.java
+++ b/src/main/java/org/example/command/sub/LeaveSubCommand.java
@@ -1,0 +1,28 @@
+package org.example.command.sub;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.example.service.TeamService;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team leave. */
+public class LeaveSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public LeaveSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    String teamName = teamService.getPlayerTeam(player);
+    if (teamName == null) {
+      player.sendMessage(Component.text("❌ Вы не состоите в команде!", NamedTextColor.RED));
+      return true;
+    }
+    teamService.removePlayerFromTeam(teamName, player);
+    return true;
+  }
+}

--- a/src/main/java/org/example/command/sub/ListSubCommand.java
+++ b/src/main/java/org/example/command/sub/ListSubCommand.java
@@ -1,0 +1,76 @@
+package org.example.command.sub;
+
+import java.util.List;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.example.config.PluginConfig;
+import org.example.service.TeamService;
+import org.example.util.TeamUtils;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team list. */
+public class ListSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+  private final PluginConfig pluginConfig;
+
+  public ListSubCommand(@NotNull TeamService teamService, @NotNull PluginConfig pluginConfig) {
+    this.teamService = teamService;
+    this.pluginConfig = pluginConfig;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    List<String> allTeams = teamService.getTeamNames();
+    if (allTeams.isEmpty()) {
+      player.sendMessage(Component.text("❌ Нет активных команд!", NamedTextColor.RED));
+      return true;
+    }
+
+    int maxMembers = pluginConfig.getMaxMembers();
+    sendTeamListHeader(player, maxMembers);
+    for (String team : allTeams) {
+      sendTeamEntry(player, team, maxMembers);
+    }
+    player.sendMessage(Component.text(""));
+    return true;
+  }
+
+  private void sendTeamListHeader(Player player, int maxMembers) {
+    player.sendMessage(Component.text(""));
+    player.sendMessage(Component.text("📋 Список команд:", NamedTextColor.AQUA));
+    String limitText = maxMembers > 0 ? String.valueOf(maxMembers) : "без лимита";
+    player.sendMessage(
+        Component.text("Текущий лимит участников: " + limitText, NamedTextColor.AQUA));
+    player.sendMessage(Component.text(""));
+  }
+
+  private void sendTeamEntry(Player player, String team, int maxMembers) {
+    int memberCount = teamService.getTeamMembers(team).size();
+    String prefix = teamService.getTeamPrefix(team);
+    NamedTextColor color = teamService.getTeamColor(team);
+    Component prefixComponent = TeamUtils.createPrefixComponent(prefix, color);
+    Component teamInfo = getTeamInfoComponent(team, memberCount, maxMembers);
+    player.sendMessage(Component.text("- ").append(prefixComponent).append(teamInfo));
+  }
+
+  private Component getTeamInfoComponent(String team, int memberCount, int maxMembers) {
+    if (maxMembers > 0) {
+      if (memberCount > maxMembers) {
+        return Component.text(team + " [Переполнена]", NamedTextColor.WHITE);
+      } else if (memberCount == maxMembers) {
+        return Component.text(team + " [Полная]", NamedTextColor.WHITE);
+      } else {
+        return Component.text(team + " [", NamedTextColor.WHITE)
+            .append(Component.text(memberCount, NamedTextColor.YELLOW))
+            .append(Component.text(" / ", NamedTextColor.WHITE))
+            .append(Component.text(maxMembers, NamedTextColor.YELLOW))
+            .append(Component.text("]", NamedTextColor.WHITE));
+      }
+    }
+    return Component.text(team + " (", NamedTextColor.WHITE)
+        .append(Component.text(memberCount, NamedTextColor.YELLOW))
+        .append(Component.text(" участников)", NamedTextColor.WHITE));
+  }
+}

--- a/src/main/java/org/example/command/sub/MembersSubCommand.java
+++ b/src/main/java/org/example/command/sub/MembersSubCommand.java
@@ -1,0 +1,79 @@
+package org.example.command.sub;
+
+import java.util.List;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+import org.example.config.PluginConfig;
+import org.example.service.TeamService;
+import org.example.util.TeamUtils;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team members. */
+public class MembersSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+  private final PluginConfig pluginConfig;
+
+  public MembersSubCommand(@NotNull TeamService teamService, @NotNull PluginConfig pluginConfig) {
+    this.teamService = teamService;
+    this.pluginConfig = pluginConfig;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    String playerTeam = teamService.getPlayerTeam(player);
+    if (playerTeam == null) {
+      player.sendMessage(Component.text("❌ Вы не состоите в команде!", NamedTextColor.RED));
+      return true;
+    }
+
+    List<String> members = teamService.getTeamMembers(playerTeam);
+    String prefix = teamService.getTeamPrefix(playerTeam);
+    NamedTextColor color = teamService.getTeamColor(playerTeam);
+    Component prefixComponent = TeamUtils.createPrefixComponent(prefix, color);
+    int maxMembers = pluginConfig.getMaxMembers();
+    Component teamHeader =
+        getTeamHeaderComponent(playerTeam, prefixComponent, members.size(), maxMembers);
+
+    player.sendMessage(Component.text(""));
+    player.sendMessage(teamHeader);
+    player.sendMessage(Component.text(""));
+    for (String memberName : members) {
+      Player member = teamService.getPlugin().getServer().getPlayer(memberName);
+      if (member != null) {
+        player.sendMessage(
+            Component.text("● ", NamedTextColor.GREEN)
+                .append(Component.text(memberName, NamedTextColor.WHITE)));
+      } else {
+        player.sendMessage(
+            Component.text("● ", NamedTextColor.GRAY)
+                .append(Component.text(memberName, NamedTextColor.GRAY)));
+      }
+    }
+    player.sendMessage(Component.text(""));
+    return true;
+  }
+
+  private Component getTeamHeaderComponent(
+      String playerTeam, Component prefixComponent, int memberCount, int maxMembers) {
+    if (maxMembers > 0) {
+      if (memberCount >= maxMembers) {
+        return Component.text("📋 Участники команды ", NamedTextColor.AQUA)
+            .append(prefixComponent)
+            .append(Component.text(playerTeam + " [Полная]:", NamedTextColor.WHITE));
+      } else {
+        return Component.text("📋 Участники команды ", NamedTextColor.AQUA)
+            .append(prefixComponent)
+            .append(Component.text(playerTeam + " [", NamedTextColor.WHITE))
+            .append(Component.text(memberCount, NamedTextColor.YELLOW))
+            .append(Component.text(" / ", NamedTextColor.WHITE))
+            .append(Component.text(maxMembers, NamedTextColor.YELLOW))
+            .append(Component.text("]:", NamedTextColor.WHITE));
+      }
+    }
+    return Component.text("📋 Участники команды ", NamedTextColor.AQUA)
+        .append(prefixComponent)
+        .append(Component.text(playerTeam + ":", NamedTextColor.WHITE));
+  }
+}

--- a/src/main/java/org/example/command/sub/SubCommand.java
+++ b/src/main/java/org/example/command/sub/SubCommand.java
@@ -1,0 +1,31 @@
+package org.example.command.sub;
+
+import java.util.Collections;
+import java.util.List;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+/** Интерфейс для обработки подкоманд /team. */
+public interface SubCommand {
+
+  /**
+   * Выполняет подкоманду.
+   *
+   * @param player игрок, вызвавший команду
+   * @param args аргументы команды
+   * @return всегда {@code true}, чтобы Bukkit не выводил сообщение об ошибке
+   */
+  boolean execute(@NotNull Player player, @NotNull String[] args);
+
+  /**
+   * Возвращает варианты автодополнения для подкоманды.
+   *
+   * @param sender отправитель команды
+   * @param args аргументы команды
+   * @return список вариантов автодополнения
+   */
+  default List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    return Collections.emptyList();
+  }
+}


### PR DESCRIPTION
## Summary
- register /team subcommands in a reusable map and delegate execution from `TeamCommand`
- extract create, join, leave, list, members and help logic into dedicated classes under `org.example.command.sub`
- add a shared `SubCommand` interface to support execution and tab completion hooks

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c8c39cac30832ea69fc027f335e9c0