### PR TITLE
Index teams by name for faster lookups

### DIFF
--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -46,7 +46,7 @@ public class MembershipService {
       return;
     }
     Team team = new Team(teamName, leader.getName(), prefix, color);
-    storage.getTeams().put(team.getId(), team);
+    storage.addTeam(team);
     storage.getPlayerTeams().put(leader.getName(), team.getId());
     storage.saveTeams(scheduler.getDeadlines());
     TeamMessageUtils.sendTeamMessage(
@@ -87,7 +87,7 @@ public class MembershipService {
     storage.getPlayerTeams().remove(player.getName());
     if (team.isLeader(player.getName())) {
       if (team.getMembers().isEmpty()) {
-        storage.getTeams().remove(team.getId());
+        storage.removeTeam(team);
       } else {
         team.setLeader(team.getMembers().get(0));
       }
@@ -119,7 +119,7 @@ public class MembershipService {
   public void disbandTeam(String teamName, @NotNull Player leader) {
     Team team = storage.getTeamByName(teamName);
     if (team == null || !team.isLeader(leader.getName())) return;
-    storage.getTeams().remove(team.getId());
+    storage.removeTeam(team);
     for (String member : team.getMembers()) {
       storage.getPlayerTeams().remove(member);
     }
@@ -130,7 +130,7 @@ public class MembershipService {
     Team team = storage.getTeamByName(oldTeamName);
     if (team == null || !team.isLeader(leader.getName())) return;
     if (storage.getTeamByName(newTeamName) != null) return;
-    team.setName(newTeamName);
+    storage.updateTeamName(team, newTeamName);
     storage.saveTeams(scheduler.getDeadlines());
   }
 

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -21,6 +21,7 @@ public class TeamStorage {
   private final PluginConfig pluginConfig;
 
   private final Map<UUID, Team> teams = new ConcurrentHashMap<>();
+  private final Map<String, UUID> teamIdsByName = new ConcurrentHashMap<>();
   private final Map<String, UUID> playerTeams = new ConcurrentHashMap<>();
 
   private FileConfiguration teamsConfig;
@@ -44,6 +45,7 @@ public class TeamStorage {
     }
     teamsConfig = YamlConfiguration.loadConfiguration(teamsFile);
     teams.clear();
+    teamIdsByName.clear();
     playerTeams.clear();
     deadlines.clear();
     var section = teamsConfig.getConfigurationSection("teams");
@@ -60,7 +62,7 @@ public class TeamStorage {
         if (deadline > 0L) {
           deadlines.put(team.getId(), deadline);
         }
-        teams.put(team.getId(), team);
+        addTeam(team);
         for (String member : team.getMembers()) {
           playerTeams.put(member, team.getId());
         }
@@ -97,23 +99,37 @@ public class TeamStorage {
     return teams;
   }
 
+  public void addTeam(@NotNull Team team) {
+    teams.put(team.getId(), team);
+    teamIdsByName.put(team.getName(), team.getId());
+  }
+
+  public void removeTeam(@NotNull Team team) {
+    teams.remove(team.getId());
+    teamIdsByName.remove(team.getName());
+  }
+
+  public void updateTeamName(@NotNull Team team, @NotNull String newName) {
+    String currentName = team.getName();
+    if (Objects.equals(currentName, newName)) {
+      return;
+    }
+    teamIdsByName.remove(currentName);
+    team.setName(newName);
+    teamIdsByName.put(newName, team.getId());
+  }
+
   public Map<String, UUID> getPlayerTeams() {
     return playerTeams;
   }
 
   public Team getTeamByName(String teamName) {
-    return teams.values().stream()
-        .filter(t -> t.getName().equals(teamName))
-        .findFirst()
-        .orElse(null);
+    UUID teamId = teamIdsByName.get(teamName);
+    return teamId != null ? teams.get(teamId) : null;
   }
 
   public UUID getTeamIdByName(String teamName) {
-    return teams.entrySet().stream()
-        .filter(e -> e.getValue().getName().equals(teamName))
-        .map(Map.Entry::getKey)
-        .findFirst()
-        .orElse(null);
+    return teamIdsByName.get(teamName);
   }
 
   public String getPlayerTeam(@NotNull Player player) {


### PR DESCRIPTION
## Summary
- index teams by name inside TeamStorage for constant time lookups
- keep the index in sync when teams are created, renamed, deleted or loaded
- switch MembershipService to the new helpers so team name lookups remain consistent

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68c90dd4e124832ea1950b119ae8a2aa