### PR TITLE
Add buffered team saving with autosave timer

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -116,6 +116,7 @@ public class MyPurpurPlugin extends JavaPlugin {
   @Override
   public void onDisable() {
     if (teamManager != null) {
+      teamManager.reloadConfig();
       teamManager.shutdown();
     }
   }

--- a/src/main/java/org/example/config/PluginConfig.java
+++ b/src/main/java/org/example/config/PluginConfig.java
@@ -55,6 +55,7 @@ public class PluginConfig {
     config.addDefault("team.enforce-max-members-on-reload", true);
     config.addDefault("team.grace-period-minutes", 10);
     config.addDefault("team.deadline-notify-period-seconds", 300L);
+    config.addDefault("team.save-interval-seconds", 60L);
     config.addDefault("team.deadline-display-mode", "CHAT");
 
     // Настройки меню
@@ -133,6 +134,15 @@ public class PluginConfig {
    */
   public long getDeadlineNotifyPeriodSeconds() {
     return config.getLong("team.deadline-notify-period-seconds", 300L);
+  }
+
+  /**
+   * Получает интервал автосохранения команд в секундах.
+   *
+   * @return интервал автосохранения
+   */
+  public long getSaveIntervalSeconds() {
+    return config.getLong("team.save-interval-seconds", 60L);
   }
 
   /**

--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -54,28 +54,50 @@ public class DeadlineScheduler {
 
   public void enforceTeamSizes() {
     int max = pluginConfig.getMaxMembers();
+    boolean changed = false;
     if (max <= 0) {
-      deadlines.clear();
+      if (!deadlines.isEmpty()) {
+        deadlines.clear();
+        changed = true;
+      }
+      if (changed) {
+        storage.markDeadlinesDirty();
+      }
       return;
     }
     for (Map.Entry<UUID, Team> entry : storage.getTeams().entrySet()) {
       Team team = entry.getValue();
       int size = team.getMembers().size();
       if (size > max) {
-        deadlines.putIfAbsent(
-            entry.getKey(),
-            System.currentTimeMillis() + pluginConfig.getGracePeriodMinutes() * 60L * 1000L);
+        Long previous =
+            deadlines.putIfAbsent(
+                entry.getKey(),
+                System.currentTimeMillis() + pluginConfig.getGracePeriodMinutes() * 60L * 1000L);
+        if (previous == null) {
+          changed = true;
+        }
       } else {
-        deadlines.remove(entry.getKey());
+        if (deadlines.remove(entry.getKey()) != null) {
+          changed = true;
+        }
       }
     }
-    storage.saveTeams(deadlines);
+    if (changed) {
+      storage.markDeadlinesDirty();
+    }
   }
 
   public void checkDeadlines() {
     int max = pluginConfig.getMaxMembers();
+    boolean changed = false;
     if (max <= 0) {
-      deadlines.clear();
+      if (!deadlines.isEmpty()) {
+        deadlines.clear();
+        changed = true;
+      }
+      if (changed) {
+        storage.markDeadlinesDirty();
+      }
       return;
     }
     long now = System.currentTimeMillis();
@@ -85,19 +107,24 @@ public class DeadlineScheduler {
       if (entry.getValue() <= now) {
         removeExtraPlayers(entry.getKey(), max);
         it.remove();
+        changed = true;
       }
     }
-    storage.saveTeams(deadlines);
+    if (changed) {
+      storage.markDeadlinesDirty();
+    }
   }
 
   private void removeExtraPlayers(UUID teamId, int max) {
     Team team = storage.getTeams().get(teamId);
     if (team == null) return;
     List<String> members = new ArrayList<>(team.getMembers());
+    boolean changed = false;
     while (members.size() > max) {
       String removed = members.remove(members.size() - 1);
       team.removeMember(removed);
       storage.getPlayerTeams().remove(removed);
+      changed = true;
       Player player = plugin.getServer().getPlayer(removed);
       if (player != null) {
         plugin
@@ -105,6 +132,9 @@ public class DeadlineScheduler {
             .getPluginManager()
             .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, null));
       }
+    }
+    if (changed) {
+      storage.markTeamDirty(team);
     }
   }
 

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -48,7 +48,6 @@ public class MembershipService {
     Team team = new Team(teamName, leader.getName(), prefix, color);
     storage.addTeam(team);
     storage.getPlayerTeams().put(leader.getName(), team.getId());
-    storage.saveTeams(scheduler.getDeadlines());
     TeamMessageUtils.sendTeamMessage(
         leader, Component.text("✅ Команда создана", NamedTextColor.GREEN));
     scheduler.enforceTeamSizes();
@@ -73,7 +72,7 @@ public class MembershipService {
     }
     team.addMember(player.getName());
     storage.getPlayerTeams().put(player.getName(), team.getId());
-    storage.saveTeams(scheduler.getDeadlines());
+    storage.markTeamDirty(team);
     TeamMessageUtils.sendTeamMessage(
         player, Component.text("✅ Вы вступили в команду", NamedTextColor.GREEN));
     scheduler.enforceTeamSizes();
@@ -85,14 +84,18 @@ public class MembershipService {
     if (!team.hasMember(player.getName()) && !team.isLeader(player.getName())) return;
     team.removeMember(player.getName());
     storage.getPlayerTeams().remove(player.getName());
+    boolean removedTeam = false;
     if (team.isLeader(player.getName())) {
       if (team.getMembers().isEmpty()) {
         storage.removeTeam(team);
+        removedTeam = true;
       } else {
         team.setLeader(team.getMembers().get(0));
       }
     }
-    storage.saveTeams(scheduler.getDeadlines());
+    if (!removedTeam) {
+      storage.markTeamDirty(team);
+    }
     scheduler.enforceTeamSizes();
   }
 
@@ -103,7 +106,7 @@ public class MembershipService {
     if (!team.hasMember(targetName)) return;
     team.removeMember(targetName);
     storage.getPlayerTeams().remove(targetName);
-    storage.saveTeams(scheduler.getDeadlines());
+    storage.markTeamDirty(team);
     scheduler.enforceTeamSizes();
   }
 
@@ -113,7 +116,7 @@ public class MembershipService {
     if (team == null || !team.isLeader(leader.getName())) return;
     if (!team.hasMember(newLeader.getName())) return;
     team.setLeader(newLeader.getName());
-    storage.saveTeams(scheduler.getDeadlines());
+    storage.markTeamDirty(team);
   }
 
   public void disbandTeam(String teamName, @NotNull Player leader) {
@@ -123,7 +126,6 @@ public class MembershipService {
     for (String member : team.getMembers()) {
       storage.getPlayerTeams().remove(member);
     }
-    storage.saveTeams(scheduler.getDeadlines());
   }
 
   public void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader) {
@@ -131,7 +133,6 @@ public class MembershipService {
     if (team == null || !team.isLeader(leader.getName())) return;
     if (storage.getTeamByName(newTeamName) != null) return;
     storage.updateTeamName(team, newTeamName);
-    storage.saveTeams(scheduler.getDeadlines());
   }
 
   public void setTeamPrefix(String teamName, String newPrefix, @NotNull Player leader) {
@@ -139,7 +140,7 @@ public class MembershipService {
     if (team == null || !team.isLeader(leader.getName())) return;
     if (TeamUtils.isPrefixLengthInvalid(newPrefix, pluginConfig, leader)) return;
     team.setPrefix(newPrefix);
-    storage.saveTeams(scheduler.getDeadlines());
+    storage.markTeamDirty(team);
   }
 
   public void setTeamColor(String teamName, String newColor, @NotNull Player leader) {
@@ -148,7 +149,7 @@ public class MembershipService {
     NamedTextColor teamColor = NamedTextColor.NAMES.value(newColor.toLowerCase());
     if (teamColor == null) return;
     team.setColor(newColor);
-    storage.saveTeams(scheduler.getDeadlines());
+    storage.markTeamDirty(team);
   }
 
   public void updatePlayerPrefixes(String teamName) {

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -25,6 +25,7 @@ public class TeamManager implements TeamService {
     this.scheduler = new DeadlineScheduler(plugin, pluginConfig, storage);
     this.storage.loadTeams(scheduler.getDeadlines());
     this.scheduler.enforceTeamSizes();
+    this.storage.startAutoSave(pluginConfig.getSaveIntervalSeconds(), scheduler.getDeadlines());
     this.scheduler.start();
     this.membership = new MembershipService(plugin, pluginConfig, storage, scheduler);
   }
@@ -134,9 +135,14 @@ public class TeamManager implements TeamService {
 
   @Override
   public void reloadConfig() {
+    storage.flushNow();
+    storage.stopAutoSave();
+    scheduler.stop();
     pluginConfig.reloadConfig();
     storage.loadTeams(scheduler.getDeadlines());
     scheduler.enforceTeamSizes();
+    scheduler.start();
+    storage.startAutoSave(pluginConfig.getSaveIntervalSeconds(), scheduler.getDeadlines());
   }
 
   @Override
@@ -151,6 +157,8 @@ public class TeamManager implements TeamService {
 
   @Override
   public void shutdown() {
+    storage.stopAutoSave();
     scheduler.stop();
+    storage.flushNow();
   }
 }

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -10,6 +10,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 import org.example.config.PluginConfig;
 import org.example.model.Team;
 import org.jetbrains.annotations.NotNull;
@@ -27,6 +28,13 @@ public class TeamStorage {
   private FileConfiguration teamsConfig;
   private File teamsFile;
 
+  private final Set<UUID> dirtyTeams = ConcurrentHashMap.newKeySet();
+  private volatile boolean deadlinesDirty;
+  private BukkitTask autoSaveTask;
+  private final Object saveLock = new Object();
+  private Map<UUID, Long> deadlinesReference = Collections.emptyMap();
+  private boolean autoSaveEnabled;
+
   public TeamStorage(@NotNull JavaPlugin plugin, @NotNull PluginConfig pluginConfig) {
     this.plugin = plugin;
     this.pluginConfig = pluginConfig;
@@ -34,6 +42,7 @@ public class TeamStorage {
 
   /** Loads team information from teams.yml and fills provided deadlines map. */
   public void loadTeams(Map<UUID, Long> deadlines) {
+    deadlinesReference = deadlines;
     teamsFile = new File(plugin.getDataFolder(), "teams.yml");
     if (!teamsFile.exists()) {
       try {
@@ -62,12 +71,14 @@ public class TeamStorage {
         if (deadline > 0L) {
           deadlines.put(team.getId(), deadline);
         }
-        addTeam(team);
+        addTeamInternal(team, false);
         for (String member : team.getMembers()) {
           playerTeams.put(member, team.getId());
         }
       }
     }
+    dirtyTeams.clear();
+    deadlinesDirty = false;
   }
 
   /** Saves teams and deadlines back to teams.yml. */
@@ -100,13 +111,21 @@ public class TeamStorage {
   }
 
   public void addTeam(@NotNull Team team) {
+    addTeamInternal(team, true);
+  }
+
+  private void addTeamInternal(@NotNull Team team, boolean markDirty) {
     teams.put(team.getId(), team);
     teamIdsByName.put(team.getName(), team.getId());
+    if (markDirty) {
+      markTeamDirty(team);
+    }
   }
 
   public void removeTeam(@NotNull Team team) {
     teams.remove(team.getId());
     teamIdsByName.remove(team.getName());
+    markTeamDirty(team);
   }
 
   public void updateTeamName(@NotNull Team team, @NotNull String newName) {
@@ -117,6 +136,7 @@ public class TeamStorage {
     teamIdsByName.remove(currentName);
     team.setName(newName);
     teamIdsByName.put(newName, team.getId());
+    markTeamDirty(team);
   }
 
   public Map<String, UUID> getPlayerTeams() {
@@ -163,5 +183,70 @@ public class TeamStorage {
   public String getTeamLeader(String teamName) {
     Team team = getTeamByName(teamName);
     return team != null ? team.getLeader() : null;
+  }
+
+  public void markTeamDirty(@NotNull Team team) {
+    markTeamDirty(team.getId());
+  }
+
+  public void markTeamDirty(@NotNull UUID teamId) {
+    dirtyTeams.add(teamId);
+    scheduleImmediateSaveIfDisabled();
+  }
+
+  public void markDeadlinesDirty() {
+    deadlinesDirty = true;
+    scheduleImmediateSaveIfDisabled();
+  }
+
+  private void scheduleImmediateSaveIfDisabled() {
+    if (!autoSaveEnabled) {
+      flushIfDirty(deadlinesReference);
+    }
+  }
+
+  public synchronized void startAutoSave(long intervalSeconds, @NotNull Map<UUID, Long> deadlines) {
+    deadlinesReference = deadlines;
+    if (autoSaveTask != null) {
+      autoSaveTask.cancel();
+      autoSaveTask = null;
+    }
+    autoSaveEnabled = intervalSeconds > 0;
+    if (!autoSaveEnabled) {
+      flushIfDirty(deadlinesReference);
+      return;
+    }
+    long ticks = Math.max(1L, intervalSeconds) * 20L;
+    autoSaveTask =
+        plugin
+            .getServer()
+            .getScheduler()
+            .runTaskTimer(plugin, this::flushNow, ticks, ticks);
+  }
+
+  public synchronized void stopAutoSave() {
+    if (autoSaveTask != null) {
+      autoSaveTask.cancel();
+      autoSaveTask = null;
+    }
+    autoSaveEnabled = false;
+  }
+
+  public void flushNow() {
+    flushIfDirty(deadlinesReference);
+  }
+
+  public void flushIfDirty(Map<UUID, Long> deadlines) {
+    if (!deadlinesDirty && dirtyTeams.isEmpty()) {
+      return;
+    }
+    synchronized (saveLock) {
+      if (!deadlinesDirty && dirtyTeams.isEmpty()) {
+        return;
+      }
+      saveTeams(deadlines != null ? deadlines : deadlinesReference);
+      dirtyTeams.clear();
+      deadlinesDirty = false;
+    }
   }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -18,6 +18,7 @@ team:
 
   grace-period-enabled: true # Давать время на удаление лишних участников
   deadline-notify-period-seconds: 300 # Период проверки дедлайнов и оповещения (в секундах)
+  save-interval-seconds: 60 # Интервал автосохранения команд (0 — мгновенное сохранение)
   deadline-display-mode: CHAT # CHAT, ACTION_BAR или SCOREBOARD
   grace-period-minutes: 10 # Длительность периода (в минутах, 0 — отключено)
 


### PR DESCRIPTION
## Summary
- add change tracking and an autosave scheduler in `TeamStorage` and wire it through `TeamManager`
- mark team and deadline mutations as dirty instead of writing immediately across membership and deadline logic
- expose the autosave interval in the config and ensure shutdown reloads and persists buffered data

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68c9145fd698832e88a41f4f992fcaf4