### PR TITLE
Handle invalid team color and guard leader lookups

### DIFF
--- a/src/main/java/org/example/command/TeamAdminCommand.java
+++ b/src/main/java/org/example/command/TeamAdminCommand.java
@@ -250,7 +250,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       if (sender instanceof Player player) {
         if (args[0].equalsIgnoreCase("transfer") || args[0].equalsIgnoreCase("kick")) {
           String teamName = teamManager.getPlayerTeam(player);
-          if (teamName != null) {
+          if (teamName != null && teamManager.getTeamIdByName(teamName) != null) {
             String leaderName = teamManager.getTeamLeader(teamName);
             if (player.getName().equals(leaderName)) {
               List<String> members = teamManager.getTeamMembers(teamName);

--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -27,16 +27,19 @@ public class TeamChatListener implements Listener {
     Player player = event.getPlayer();
     updatePlayerPrefix(player);
     String teamName = teamManager.getPlayerTeam(player);
-    if (teamName != null && player.getName().equals(teamManager.getTeamLeader(teamName))) {
-      Long deadline = teamManager.getTeamDeadline(teamName);
-      if (deadline != null) {
-        long remaining = deadline - System.currentTimeMillis();
-        if (remaining > 0) {
-          int minutes = (int) Math.ceil(remaining / 60000.0);
-          int max = teamManager.getPluginConfig().getMaxMembers();
-          int excess = teamManager.getTeamMembers(teamName).size() - max;
-          TeamMessageUtils.sendTeamMessage(
-              player, TeamMessageUtils.deadlineWarningMessage(max, minutes, excess));
+    if (teamName != null && teamManager.getTeamIdByName(teamName) != null) {
+      String leaderName = teamManager.getTeamLeader(teamName);
+      if (player.getName().equals(leaderName)) {
+        Long deadline = teamManager.getTeamDeadline(teamName);
+        if (deadline != null) {
+          long remaining = deadline - System.currentTimeMillis();
+          if (remaining > 0) {
+            int minutes = (int) Math.ceil(remaining / 60000.0);
+            int max = teamManager.getPluginConfig().getMaxMembers();
+            int excess = teamManager.getTeamMembers(teamName).size() - max;
+            TeamMessageUtils.sendTeamMessage(
+                player, TeamMessageUtils.deadlineWarningMessage(max, minutes, excess));
+          }
         }
       }
     }

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -147,7 +147,11 @@ public class MembershipService {
     Team team = storage.getTeamByName(teamName);
     if (team == null || !team.isLeader(leader.getName())) return;
     NamedTextColor teamColor = NamedTextColor.NAMES.value(newColor.toLowerCase());
-    if (teamColor == null) return;
+    if (teamColor == null) {
+      TeamMessageUtils.sendTeamMessage(
+          leader, Component.text("❌ Неверный цвет команды", NamedTextColor.RED));
+      return;
+    }
     team.setColor(newColor);
     storage.markTeamDirty(team);
   }


### PR DESCRIPTION
## Summary
- send an error message when an invalid color is provided while changing the team color
- avoid looking up a team leader when the player's team no longer exists before performing join logic or tab completion

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68c941d73e74832e94ea5ac8943f14fe