### PR TITLE
Document deadline scheduler and annotate team handling

### DIFF
--- a/src/main/java/org/example/command/TeamCommand.java
+++ b/src/main/java/org/example/command/TeamCommand.java
@@ -52,18 +52,23 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
       @NotNull Command command,
       @NotNull String label,
       @NotNull String[] args) {
+    // Проверяем, что команду запускает игрок, потому что остальные отправители не
+    // могут взаимодействовать с командной системой корректно.
     if (!(sender instanceof Player player)) {
       sender.sendMessage(
           Component.text("❌ Эту команду может использовать только игрок!", NamedTextColor.RED));
       return true;
     }
 
+    // Убеждаемся, что у игрока есть базовое разрешение на работу с командами.
     if (!player.hasPermission("mypurpurplugin.team")) {
       player.sendMessage(
           Component.text("❌ У вас нет прав для использования этой команды!", NamedTextColor.RED));
       return true;
     }
 
+    // При необходимости проверяем статус оператора, чтобы выполнить требование
+    // конфигурации.
     if (pluginConfig.isTeamCommandRequiresOp() && !player.isOp()) {
       player.sendMessage(
           Component.text(
@@ -72,15 +77,18 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
       return true;
     }
 
+    // Без подкоманды показываем корректное использование команды.
     if (args.length < 1) {
       sendUsage(player);
       return true;
     }
 
+    // Приводим имя подкоманды к единому виду и логируем её запуск для отладки.
     String subCommandName = args[0].toLowerCase(Locale.ROOT);
     ((MyPurpurPlugin) teamManager.getPlugin())
         .debugTeamAction("Команда /team выполнена игроком", player.getName(), null);
 
+    // Находим обработчик подкоманды; если он отсутствует, уведомляем игрока.
     SubCommand subCommand = subCommands.get(subCommandName);
     if (subCommand == null) {
       sendUnknownSubCommandMessage(player);
@@ -116,6 +124,7 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
       @NotNull Command command,
       @NotNull String alias,
       @NotNull String[] args) {
+    // При вводе первой части команды предлагаем подходящие названия подкоманд.
     if (args.length <= 1) {
       String partial = args.length == 0 ? "" : args[0].toLowerCase(Locale.ROOT);
       List<String> suggestions = new ArrayList<>();
@@ -127,6 +136,8 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
       return suggestions;
     }
 
+    // Для остальных аргументов делегируем генерацию подсказок конкретной
+    // подкоманде.
     SubCommand subCommand = subCommands.get(args[0].toLowerCase(Locale.ROOT));
     if (subCommand == null) {
       return new ArrayList<>();

--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -10,7 +10,10 @@ import org.example.listener.TeamChatListener;
 import org.example.model.Team;
 import org.jetbrains.annotations.NotNull;
 
-/** Handles deadline checking and enforcement of team sizes. */
+/**
+ * Планировщик, который следит за размерами команд и временем, отведённым на их
+ * уменьшение до допустимого количества участников.
+ */
 public class DeadlineScheduler {
 
   private final JavaPlugin plugin;
@@ -19,6 +22,14 @@ public class DeadlineScheduler {
   private final Map<UUID, Long> deadlines = new ConcurrentHashMap<>();
   private BukkitTask task;
 
+  /**
+   * Создаёт планировщик, работающий поверх Bukkit, и связывает его с источниками
+   * конфигурации и хранилищем команд.
+   *
+   * @param plugin плагин, в котором выполняется расписание
+   * @param pluginConfig настройки, задающие ограничения и периоды проверок
+   * @param storage хранилище, содержащее данные по командам
+   */
   public DeadlineScheduler(
       @NotNull JavaPlugin plugin,
       @NotNull PluginConfig pluginConfig,
@@ -28,10 +39,20 @@ public class DeadlineScheduler {
     this.storage = storage;
   }
 
+  /**
+   * Возвращает отображение команд в момент времени, когда истекает их льготный
+   * период.
+   *
+   * @return изменяемая карта дедлайнов по идентификатору команды
+   */
   public Map<UUID, Long> getDeadlines() {
     return deadlines;
   }
 
+  /**
+   * Запускает периодическую проверку дедлайнов и автоматически перезапускает
+   * задачу, если она уже была активна.
+   */
   public synchronized void start() {
     long seconds = pluginConfig.getDeadlineNotifyPeriodSeconds();
     long period = 20L * Math.max(1, seconds);
@@ -45,6 +66,7 @@ public class DeadlineScheduler {
             .runTaskTimer(plugin, this::checkDeadlines, period, period);
   }
 
+  /** Останавливает проверку дедлайнов, отменяя запланированную задачу. */
   public synchronized void stop() {
     if (task != null) {
       task.cancel();
@@ -52,6 +74,10 @@ public class DeadlineScheduler {
     }
   }
 
+  /**
+   * Фиксирует команды, превышающие лимит участников, и назначает им дедлайны на
+   * сокращение, очищая записи для команд с допустимым размером.
+   */
   public void enforceTeamSizes() {
     int max = pluginConfig.getMaxMembers();
     boolean changed = false;
@@ -87,6 +113,10 @@ public class DeadlineScheduler {
     }
   }
 
+  /**
+   * Проверяет, истекли ли дедлайны команд, и при необходимости удаляет
+   * лишних игроков, синхронизируя изменения с хранилищем.
+   */
   public void checkDeadlines() {
     int max = pluginConfig.getMaxMembers();
     boolean changed = false;
@@ -138,6 +168,14 @@ public class DeadlineScheduler {
     }
   }
 
+  /**
+   * Возвращает зарегистрированный дедлайн конкретной команды по имени, если он
+   * существует.
+   *
+   * @param teamName имя команды, для которой нужен дедлайн
+   * @return отметка времени истечения льготного периода или {@code null}, если
+   *     команда в норме
+   */
   public Long getTeamDeadline(String teamName) {
     UUID id = storage.getTeamIdByName(teamName);
     return id != null ? deadlines.get(id) : null;

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -31,20 +31,24 @@ public class MembershipService {
   }
 
   public void createTeam(String teamName, String prefix, String color, @NotNull Player leader) {
+    // Убеждаемся, что имя и лидер свободны, чтобы не создавать дубликатов команд.
     if (storage.getPlayerTeam(leader) != null || storage.getTeamByName(teamName) != null) {
       TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.teamAlreadyExistsMessage(teamName));
       return;
     }
+    // Проверяем, что игрок выбрал поддерживаемый цвет для корректного отображения.
     NamedTextColor teamColor = NamedTextColor.NAMES.value(color.toLowerCase());
     if (teamColor == null) {
       TeamMessageUtils.sendTeamMessage(
           leader, Component.text("❌ Неверный цвет команды", NamedTextColor.RED));
       return;
     }
+    // Валидируем длину имени и префикса согласно настройкам плагина.
     if (TeamUtils.isTeamNameLengthInvalid(teamName, pluginConfig, leader)
         || TeamUtils.isPrefixLengthInvalid(prefix, pluginConfig, leader)) {
       return;
     }
+    // Создаём запись команды и связываем лидера с новой структурой.
     Team team = new Team(teamName, leader.getName(), prefix, color);
     storage.addTeam(team);
     storage.getPlayerTeams().put(leader.getName(), team.getId());
@@ -55,21 +59,25 @@ public class MembershipService {
 
   public void addPlayerToTeam(String teamName, @NotNull Player player) {
     Team team = storage.getTeamByName(teamName);
+    // Если команда не найдена — сообщаем игроку и прекращаем обработку.
     if (team == null) {
       TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.teamDoesNotExistMessage(teamName));
       return;
     }
+    // Не допускаем вступления игроков, у которых уже есть команда.
     if (storage.getPlayerTeam(player) != null) {
       TeamMessageUtils.sendTeamMessage(
           player, Component.text("❌ Вы уже состоите в команде", NamedTextColor.RED));
       return;
     }
+    // Учитываем ограничение на максимальное количество участников.
     int max = pluginConfig.getMaxMembers();
     if (max > 0 && team.getMembers().size() >= max) {
       TeamMessageUtils.sendTeamMessage(
           player, Component.text("❌ Команда полная", NamedTextColor.RED));
       return;
     }
+    // Добавляем игрока и фиксируем изменения в хранилище.
     team.addMember(player.getName());
     storage.getPlayerTeams().put(player.getName(), team.getId());
     storage.markTeamDirty(team);
@@ -80,11 +88,14 @@ public class MembershipService {
 
   public void removePlayerFromTeam(String teamName, @NotNull Player player) {
     Team team = storage.getTeamByName(teamName);
+    // Проводим проверки существования команды и членства игрока.
     if (team == null) return;
     if (!team.hasMember(player.getName()) && !team.isLeader(player.getName())) return;
+    // Удаляем игрока и очищаем обратные ссылки.
     team.removeMember(player.getName());
     storage.getPlayerTeams().remove(player.getName());
     boolean removedTeam = false;
+    // Если ушедший игрок был лидером, либо закрываем команду, либо назначаем нового.
     if (team.isLeader(player.getName())) {
       if (team.getMembers().isEmpty()) {
         storage.removeTeam(team);
@@ -93,6 +104,7 @@ public class MembershipService {
         team.setLeader(team.getMembers().get(0));
       }
     }
+    // Отмечаем изменившуюся команду и пересчитываем дедлайны.
     if (!removedTeam) {
       storage.markTeamDirty(team);
     }
@@ -102,8 +114,10 @@ public class MembershipService {
   public void kickPlayerFromTeam(
       String teamName, @NotNull Player leader, @NotNull String targetName) {
     Team team = storage.getTeamByName(teamName);
+    // Проверяем право лидера на это действие и наличие цели в команде.
     if (team == null || !team.isLeader(leader.getName())) return;
     if (!team.hasMember(targetName)) return;
+    // Удаляем участника и фиксируем изменения.
     team.removeMember(targetName);
     storage.getPlayerTeams().remove(targetName);
     storage.markTeamDirty(team);
@@ -113,7 +127,9 @@ public class MembershipService {
   public void transferLeadership(
       String teamName, @NotNull Player leader, @NotNull Player newLeader) {
     Team team = storage.getTeamByName(teamName);
+    // Убеждаемся, что изменение лидерства инициирует действующий лидер.
     if (team == null || !team.isLeader(leader.getName())) return;
+    // Назначать лидером можно только участника команды.
     if (!team.hasMember(newLeader.getName())) return;
     team.setLeader(newLeader.getName());
     storage.markTeamDirty(team);
@@ -121,7 +137,9 @@ public class MembershipService {
 
   public void disbandTeam(String teamName, @NotNull Player leader) {
     Team team = storage.getTeamByName(teamName);
+    // Разрешаем роспуск только лидеру существующей команды.
     if (team == null || !team.isLeader(leader.getName())) return;
+    // Удаляем команду и освобождаем всех участников.
     storage.removeTeam(team);
     for (String member : team.getMembers()) {
       storage.getPlayerTeams().remove(member);
@@ -130,6 +148,7 @@ public class MembershipService {
 
   public void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader) {
     Team team = storage.getTeamByName(oldTeamName);
+    // Проверяем полномочия и уникальность нового имени.
     if (team == null || !team.isLeader(leader.getName())) return;
     if (storage.getTeamByName(newTeamName) != null) return;
     storage.updateTeamName(team, newTeamName);
@@ -137,6 +156,7 @@ public class MembershipService {
 
   public void setTeamPrefix(String teamName, String newPrefix, @NotNull Player leader) {
     Team team = storage.getTeamByName(teamName);
+    // Изменение префикса доступно только лидеру, при этом валидируем значение.
     if (team == null || !team.isLeader(leader.getName())) return;
     if (TeamUtils.isPrefixLengthInvalid(newPrefix, pluginConfig, leader)) return;
     team.setPrefix(newPrefix);
@@ -145,6 +165,7 @@ public class MembershipService {
 
   public void setTeamColor(String teamName, String newColor, @NotNull Player leader) {
     Team team = storage.getTeamByName(teamName);
+    // Проверяем права и корректность цвета перед сохранением.
     if (team == null || !team.isLeader(leader.getName())) return;
     NamedTextColor teamColor = NamedTextColor.NAMES.value(newColor.toLowerCase());
     if (teamColor == null) {
@@ -158,7 +179,9 @@ public class MembershipService {
 
   public void updatePlayerPrefixes(String teamName) {
     Team team = storage.getTeamByName(teamName);
+    // Выполняем синхронизацию префиксов только для существующей команды.
     if (team == null) return;
+    // Обновляем отображаемые префиксы у всех онлайн-участников.
     for (String member : team.getMembers()) {
       Player player = plugin.getServer().getPlayer(member);
       if (player != null) {


### PR DESCRIPTION
## Summary
- document the DeadlineScheduler class and its public API with detailed Javadoc
- add explanatory comments to TeamCommand to clarify permission and routing checks
- annotate MembershipService methods with comments describing each major logic block

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68c945fbb82c832eb88ea375555ae86c