### PR TITLE
Make debug and cleanup behaviour configurable

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -30,6 +30,7 @@ public class MyPurpurPlugin extends JavaPlugin {
   public void onEnable() {
     // Инициализация конфигурации
     pluginConfig = new PluginConfig(this);
+    applyDebugModeFromConfig();
     // Инициализация менеджера команд
     teamManager = new TeamManager(this, pluginConfig);
 
@@ -38,7 +39,7 @@ public class MyPurpurPlugin extends JavaPlugin {
     registerCommand("teamadmin", new TeamAdminCommand(teamManager));
     registerCommand("getteamsuuidlist", new AdminCommands(teamManager));
     registerCommand("getteamuuid", new AdminCommands(teamManager));
-    registerCommand("teamreload", new TeamReloadCommand(teamManager, pluginConfig));
+    registerCommand("teamreload", new TeamReloadCommand(this, teamManager, pluginConfig));
     registerCommand("cfgDefault", new CfgDefaultCommand(this, pluginConfig, teamManager));
     registerCommand("menu", new MenuCommand(this, pluginConfig));
     registerCommand("debugtoggle", new DebugToggleCommand(this));
@@ -109,7 +110,28 @@ public class MyPurpurPlugin extends JavaPlugin {
 
   /** Переключает состояние debugMode. */
   public void toggleDebugMode() {
-    debugMode = !debugMode;
+    setDebugMode(!debugMode);
+  }
+
+  /**
+   * Применяет состояние режима отладки на основе текущей конфигурации.
+   */
+  public void applyDebugModeFromConfig() {
+    if (pluginConfig != null) {
+      setDebugMode(pluginConfig.isDebugModeEnabled());
+    }
+  }
+
+  /**
+   * Устанавливает состояние режима отладки.
+   *
+   * @param enabled новое состояние режима отладки
+   */
+  public void setDebugMode(boolean enabled) {
+    if (this.debugMode == enabled) {
+      return;
+    }
+    this.debugMode = enabled;
     getLogger().info("Режим отладки " + (debugMode ? "включён" : "отключён") + "!");
   }
 

--- a/src/main/java/org/example/command/CfgDefaultCommand.java
+++ b/src/main/java/org/example/command/CfgDefaultCommand.java
@@ -6,7 +6,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
-import org.bukkit.plugin.java.JavaPlugin;
+import org.example.MyPurpurPlugin;
 import org.example.config.PluginConfig;
 import org.example.service.TeamService;
 import org.jetbrains.annotations.NotNull;
@@ -14,12 +14,12 @@ import org.jetbrains.annotations.NotNull;
 /** Обработчик команды /cfgDefault для сброса конфигурации плагина до дефолтных настроек. */
 public class CfgDefaultCommand implements CommandExecutor {
 
-  private final JavaPlugin plugin;
+  private final MyPurpurPlugin plugin;
   private final PluginConfig pluginConfig;
   private final TeamService teamManager;
 
   public CfgDefaultCommand(
-      @NotNull JavaPlugin plugin,
+      @NotNull MyPurpurPlugin plugin,
       @NotNull PluginConfig pluginConfig,
       @NotNull TeamService teamManager) {
     this.plugin = plugin;
@@ -44,6 +44,7 @@ public class CfgDefaultCommand implements CommandExecutor {
     // Перезагружаем конфигурацию
     pluginConfig.reloadConfig();
     teamManager.reloadConfig();
+    plugin.applyDebugModeFromConfig();
     sender.sendMessage(
         Component.text(
             "✅ Конфигурация плагина успешно сброшена до дефолтных настроек!",

--- a/src/main/java/org/example/command/TeamReloadCommand.java
+++ b/src/main/java/org/example/command/TeamReloadCommand.java
@@ -6,6 +6,7 @@ import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
+import org.example.MyPurpurPlugin;
 import org.example.config.PluginConfig;
 import org.example.service.TeamService;
 import org.jetbrains.annotations.NotNull;
@@ -13,10 +14,15 @@ import org.jetbrains.annotations.NotNull;
 /** Обработчик команды /teamreload для перезагрузки конфигурации плагина. */
 public class TeamReloadCommand implements CommandExecutor {
 
+  private final MyPurpurPlugin plugin;
   private final TeamService teamManager;
   private final PluginConfig pluginConfig;
 
-  public TeamReloadCommand(@NotNull TeamService teamManager, @NotNull PluginConfig pluginConfig) {
+  public TeamReloadCommand(
+      @NotNull MyPurpurPlugin plugin,
+      @NotNull TeamService teamManager,
+      @NotNull PluginConfig pluginConfig) {
+    this.plugin = plugin;
     this.teamManager = teamManager;
     this.pluginConfig = pluginConfig;
   }
@@ -37,6 +43,7 @@ public class TeamReloadCommand implements CommandExecutor {
     pluginConfig.reloadConfig();
     // Перезагружаем состояние TeamManager
     teamManager.reloadConfig();
+    plugin.applyDebugModeFromConfig();
     sender.sendMessage(
         Component.text("✅ Конфигурация плагина успешно перезагружена!", NamedTextColor.GREEN));
     return true;

--- a/src/main/java/org/example/config/PluginConfig.java
+++ b/src/main/java/org/example/config/PluginConfig.java
@@ -2,6 +2,7 @@ package org.example.config;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Locale;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -44,6 +45,9 @@ public class PluginConfig {
 
   /** Устанавливает значения по умолчанию для конфигурации. */
   private void setDefaults() {
+    // Глобальные настройки
+    config.addDefault("debug-mode", true);
+
     // Основные настройки
     config.addDefault("team.requires-op", false);
     config.addDefault("team.notify-admins", true);
@@ -57,6 +61,7 @@ public class PluginConfig {
     config.addDefault("team.deadline-notify-period-seconds", 300L);
     config.addDefault("team.save-interval-seconds", 60L);
     config.addDefault("team.deadline-display-mode", "CHAT");
+    config.addDefault("team.deadline-removal-policy", "last-joined");
 
     // Настройки меню
     config.addDefault("menu.open-sound", "BLOCK_NOTE_BLOCK_PLING");
@@ -80,6 +85,15 @@ public class PluginConfig {
   /** Перезагружает конфигурацию из файла. */
   public void reloadConfig() {
     config = YamlConfiguration.loadConfiguration(configFile);
+  }
+
+  /**
+   * Проверяет, включён ли режим отладки.
+   *
+   * @return true, если режим отладки активен, иначе false
+   */
+  public boolean isDebugModeEnabled() {
+    return config.getBoolean("debug-mode", true);
   }
 
   /**
@@ -152,6 +166,30 @@ public class PluginConfig {
    */
   public String getDeadlineDisplayMode() {
     return config.getString("team.deadline-display-mode", "CHAT");
+  }
+
+  /**
+   * Возвращает стратегию удаления лишних игроков в команде.
+   *
+   * @return стратегия удаления игроков
+   */
+  public @NotNull RemovalPolicy getExcessPlayerRemovalPolicy() {
+    String rawValue = config.getString("team.deadline-removal-policy", "last-joined");
+    if (rawValue == null) {
+      return RemovalPolicy.LAST_JOINED;
+    }
+    String normalized = rawValue.trim().replace('-', '_').toUpperCase(Locale.ROOT);
+    try {
+      return RemovalPolicy.valueOf(normalized);
+    } catch (IllegalArgumentException ex) {
+      plugin
+          .getLogger()
+          .warning(
+              "Некорректное значение team.deadline-removal-policy: "
+                  + rawValue
+                  + ". Используем LAST_JOINED.");
+      return RemovalPolicy.LAST_JOINED;
+    }
   }
 
   /**

--- a/src/main/java/org/example/config/RemovalPolicy.java
+++ b/src/main/java/org/example/config/RemovalPolicy.java
@@ -1,0 +1,7 @@
+package org.example.config;
+
+/** Возможные стратегии удаления лишних игроков из команды. */
+public enum RemovalPolicy {
+  OFFLINE_FIRST,
+  LAST_JOINED
+}

--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -6,6 +6,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.example.config.PluginConfig;
+import org.example.config.RemovalPolicy;
 import org.example.listener.TeamChatListener;
 import org.example.model.Team;
 import org.jetbrains.annotations.NotNull;
@@ -148,10 +149,13 @@ public class DeadlineScheduler {
   private void removeExtraPlayers(UUID teamId, int max) {
     Team team = storage.getTeams().get(teamId);
     if (team == null) return;
-    List<String> members = new ArrayList<>(team.getMembers());
     boolean changed = false;
-    while (members.size() > max) {
-      String removed = members.remove(members.size() - 1);
+    RemovalPolicy policy = pluginConfig.getExcessPlayerRemovalPolicy();
+    while (team.getMembers().size() > max) {
+      String removed = selectMemberToRemove(team, policy);
+      if (removed == null) {
+        break;
+      }
       team.removeMember(removed);
       storage.getPlayerTeams().remove(removed);
       changed = true;
@@ -166,6 +170,49 @@ public class DeadlineScheduler {
     if (changed) {
       storage.markTeamDirty(team);
     }
+  }
+
+  private String selectMemberToRemove(@NotNull Team team, @NotNull RemovalPolicy policy) {
+    List<String> members = team.getMembers();
+    if (members.isEmpty()) {
+      return null;
+    }
+    String leader = team.getLeader();
+    if (policy == RemovalPolicy.OFFLINE_FIRST) {
+      String offlineCandidate = findOfflineCandidate(members, leader);
+      if (offlineCandidate != null) {
+        return offlineCandidate;
+      }
+    }
+    return findLastJoinedCandidate(members, leader);
+  }
+
+  private String findOfflineCandidate(@NotNull List<String> members, String leader) {
+    for (int i = members.size() - 1; i >= 0; i--) {
+      String candidate = members.get(i);
+      if (isLeader(candidate, leader)) {
+        continue;
+      }
+      Player player = plugin.getServer().getPlayer(candidate);
+      if (player == null || !player.isOnline()) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  private String findLastJoinedCandidate(@NotNull List<String> members, String leader) {
+    for (int i = members.size() - 1; i >= 0; i--) {
+      String candidate = members.get(i);
+      if (!isLeader(candidate, leader)) {
+        return candidate;
+      }
+    }
+    return members.get(members.size() - 1);
+  }
+
+  private boolean isLeader(String candidate, String leader) {
+    return leader != null && leader.equalsIgnoreCase(candidate);
   }
 
   /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,9 @@
 # Список всех звуков можно найти здесь: https://jd.papermc.io/paper/1.21/org/bukkit/Sound.html
 # Список всех частиц: https://jd.papermc.io/paper/1.21/org/bukkit/Particle.html
 
+# Общие настройки
+debug-mode: true # Включает подробное логирование действий плагина
+
 # Настройки команды /team
 team:
   requires-op: false # Если true, команды /team доступны только OP; если false — всем игрокам
@@ -18,9 +21,10 @@ team:
 
   grace-period-enabled: true # Давать время на удаление лишних участников
   deadline-notify-period-seconds: 300 # Период проверки дедлайнов и оповещения (в секундах)
-  save-interval-seconds: 60 # Интервал автосохранения команд (0 — мгновенное сохранение)
+  save-interval-seconds: 60 # Интервал автосохранения команд (в секундах, 0 — мгновенное сохранение)
   deadline-display-mode: CHAT # CHAT, ACTION_BAR или SCOREBOARD
   grace-period-minutes: 10 # Длительность периода (в минутах, 0 — отключено)
+  deadline-removal-policy: last-joined # Способ удаления лишних игроков: offline-first или last-joined
 
 
 # Настройки меню


### PR DESCRIPTION
## Summary
- allow the plugin debug mode to be configured and applied on reload/reset commands
- add a configurable policy for trimming extra team members (offline-first or last-joined)
- document the new options in `config.yml` and wire PluginConfig getters

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68c947d23414832eb89c0dc38903f6be