### PR TITLE
Update prefix updates and add tests

### DIFF
--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -6,10 +6,12 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.example.config.PluginConfig;
+import org.example.listener.TeamChatListener;
 import org.example.model.Team;
 import org.example.util.TeamMessageUtils;
 import org.example.util.TeamUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Contains operations that modify teams and player memberships. */
 public class MembershipService {
@@ -84,6 +86,7 @@ public class MembershipService {
     TeamMessageUtils.sendTeamMessage(
         player, Component.text("✅ Вы вступили в команду", NamedTextColor.GREEN));
     scheduler.enforceTeamSizes();
+    updateTeamMembersPrefixes(team);
   }
 
   public void removePlayerFromTeam(String teamName, @NotNull Player player) {
@@ -109,6 +112,10 @@ public class MembershipService {
       storage.markTeamDirty(team);
     }
     scheduler.enforceTeamSizes();
+    notifyPrefixUpdate(player, null);
+    if (!removedTeam) {
+      updateTeamMembersPrefixes(team);
+    }
   }
 
   public void kickPlayerFromTeam(
@@ -122,6 +129,8 @@ public class MembershipService {
     storage.getPlayerTeams().remove(targetName);
     storage.markTeamDirty(team);
     scheduler.enforceTeamSizes();
+    notifyPrefixUpdate(targetName, null);
+    updateTeamMembersPrefixes(team);
   }
 
   public void transferLeadership(
@@ -161,6 +170,7 @@ public class MembershipService {
     if (TeamUtils.isPrefixLengthInvalid(newPrefix, pluginConfig, leader)) return;
     team.setPrefix(newPrefix);
     storage.markTeamDirty(team);
+    updateTeamMembersPrefixes(team);
   }
 
   public void setTeamColor(String teamName, String newColor, @NotNull Player leader) {
@@ -175,23 +185,34 @@ public class MembershipService {
     }
     team.setColor(newColor);
     storage.markTeamDirty(team);
+    updateTeamMembersPrefixes(team);
   }
 
   public void updatePlayerPrefixes(String teamName) {
     Team team = storage.getTeamByName(teamName);
     // Выполняем синхронизацию префиксов только для существующей команды.
     if (team == null) return;
-    // Обновляем отображаемые префиксы у всех онлайн-участников.
+    updateTeamMembersPrefixes(team);
+  }
+
+  private void updateTeamMembersPrefixes(@NotNull Team team) {
+    Component prefixComponent = team.getPrefixComponent();
     for (String member : team.getMembers()) {
-      Player player = plugin.getServer().getPlayer(member);
-      if (player != null) {
-        plugin
-            .getServer()
-            .getPluginManager()
-            .callEvent(
-                new org.example.listener.TeamChatListener.PlayerPrefixUpdateEvent(
-                    player, team.getPrefixComponent()));
-      }
+      notifyPrefixUpdate(member, prefixComponent);
+    }
+  }
+
+  private void notifyPrefixUpdate(@NotNull Player player, @Nullable Component prefix) {
+    plugin
+        .getServer()
+        .getPluginManager()
+        .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefix));
+  }
+
+  private void notifyPrefixUpdate(@NotNull String playerName, @Nullable Component prefix) {
+    Player onlinePlayer = plugin.getServer().getPlayer(playerName);
+    if (onlinePlayer != null) {
+      notifyPrefixUpdate(onlinePlayer, prefix);
     }
   }
 }

--- a/src/test/java/org/example/service/TeamManagerTest.java
+++ b/src/test/java/org/example/service/TeamManagerTest.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 import java.util.List;
 import org.example.MyPurpurPlugin;
 import org.example.config.PluginConfig;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -143,5 +145,72 @@ class TeamManagerTest {
 
     assertNull(teamManager.getPlayerTeam(extra));
     assertEquals(5, teamManager.getTeamMembers("Beta").size());
+  }
+
+  @Test
+  void playerListNameUpdatedOnJoinAndLeave() {
+    PlayerMock leader = server.addPlayer("PrefixLeader");
+    PlayerMock member = server.addPlayer("PrefixMember");
+
+    teamManager.createTeam("PrefixTeam", "PF", "gold", leader);
+    teamManager.addPlayerToTeam("PrefixTeam", member);
+
+    Component expected =
+        Component.text("[PF] ", NamedTextColor.GOLD)
+            .append(Component.text(member.getName(), NamedTextColor.WHITE));
+    assertEquals(expected, member.playerListName());
+
+    teamManager.removePlayerFromTeam("PrefixTeam", member);
+    Component reset = Component.text(member.getName(), NamedTextColor.WHITE);
+    assertEquals(reset, member.playerListName());
+  }
+
+  @Test
+  void playerListNameResetOnKick() {
+    PlayerMock leader = server.addPlayer("KickLeader");
+    PlayerMock member = server.addPlayer("KickTarget");
+
+    teamManager.createTeam("KickTeam", "KT", "green", leader);
+    teamManager.addPlayerToTeam("KickTeam", member);
+
+    Component expected =
+        Component.text("[KT] ", NamedTextColor.GREEN)
+            .append(Component.text(member.getName(), NamedTextColor.WHITE));
+    assertEquals(expected, member.playerListName());
+
+    teamManager.kickPlayerFromTeam("KickTeam", leader, member.getName());
+    Component reset = Component.text(member.getName(), NamedTextColor.WHITE);
+    assertEquals(reset, member.playerListName());
+  }
+
+  @Test
+  void playerListNameUpdatedOnPrefixAndColorChange() {
+    PlayerMock leader = server.addPlayer("StyleLeader");
+    PlayerMock member = server.addPlayer("StyleMember");
+
+    teamManager.createTeam("Stylists", "ST", "white", leader);
+    teamManager.addPlayerToTeam("Stylists", member);
+
+    teamManager.setTeamPrefix("Stylists", "NW", leader);
+    Component newPrefix =
+        Component.text("[NW] ", NamedTextColor.WHITE)
+            .append(Component.text(member.getName(), NamedTextColor.WHITE));
+    assertEquals(newPrefix, member.playerListName());
+
+    Component leaderPrefix =
+        Component.text("[NW] ", NamedTextColor.WHITE)
+            .append(Component.text(leader.getName(), NamedTextColor.WHITE));
+    assertEquals(leaderPrefix, leader.playerListName());
+
+    teamManager.setTeamColor("Stylists", "red", leader);
+    Component recolored =
+        Component.text("[NW] ", NamedTextColor.RED)
+            .append(Component.text(member.getName(), NamedTextColor.WHITE));
+    assertEquals(recolored, member.playerListName());
+
+    Component leaderRecolored =
+        Component.text("[NW] ", NamedTextColor.RED)
+            .append(Component.text(leader.getName(), NamedTextColor.WHITE));
+    assertEquals(leaderRecolored, leader.playerListName());
   }
 }


### PR DESCRIPTION
## Summary
- trigger PlayerPrefixUpdate events after membership and appearance changes so player list names stay in sync
- reset prefixes for removed or kicked players
- add MockBukkit tests that verify player list names update for joins, kicks, and prefix/color changes

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68ca262f4794832e9b7e83d2ad98a69a