### PR TITLE
Handle overfilled teams in members subcommand

### DIFF
--- a/src/main/java/org/example/command/sub/MembersSubCommand.java
+++ b/src/main/java/org/example/command/sub/MembersSubCommand.java
@@ -58,7 +58,11 @@ public class MembersSubCommand implements SubCommand {
   private Component getTeamHeaderComponent(
       String playerTeam, Component prefixComponent, int memberCount, int maxMembers) {
     if (maxMembers > 0) {
-      if (memberCount >= maxMembers) {
+      if (memberCount > maxMembers) {
+        return Component.text("📋 Участники команды ", NamedTextColor.AQUA)
+            .append(prefixComponent)
+            .append(Component.text(playerTeam + " [Переполнена]:", NamedTextColor.WHITE));
+      } else if (memberCount == maxMembers) {
         return Component.text("📋 Участники команды ", NamedTextColor.AQUA)
             .append(prefixComponent)
             .append(Component.text(playerTeam + " [Полная]:", NamedTextColor.WHITE));


### PR DESCRIPTION
## Summary
- add an overfilled status to the /team members header when a team exceeds its limit
- keep the displayed statuses in sync with the /team list command

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ca2b976150832eb1122fce6042d81e