### PR TITLE
Collect expired deadlines before removal

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -250,6 +250,7 @@ public class DeadlineScheduler {
     }
     long now = System.currentTimeMillis();
     Iterator<Map.Entry<UUID, Long>> it = deadlines.entrySet().iterator();
+    List<UUID> expiredDeadlines = new ArrayList<>();
     while (it.hasNext()) {
       Map.Entry<UUID, Long> entry = it.next();
       if (entry.getValue() <= now) {
@@ -277,9 +278,12 @@ public class DeadlineScheduler {
                         + " игрок(ов).");
           }
         }
-        it.remove();
+        expiredDeadlines.add(entry.getKey());
         changed = true;
       }
+    }
+    if (!expiredDeadlines.isEmpty()) {
+      deadlines.keySet().removeAll(expiredDeadlines);
     }
     if (changed) {
       storage.markDeadlinesDirty();


### PR DESCRIPTION
## Summary
- gather team IDs with expired deadlines before removing them from the scheduler map
- remove expired deadlines in bulk after processing while preserving forced removal notifications

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68ca8c1685c8832eb9f3d4f71c563d66