### PR TITLE
Notify players of prefix reset when disbanding teams

### DIFF
--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -148,11 +148,18 @@ public class MembershipService {
     Team team = storage.getTeamByName(teamName);
     // Разрешаем роспуск только лидеру существующей команды.
     if (team == null || !team.isLeader(leader.getName())) return;
-    // Удаляем команду и освобождаем всех участников.
+    // Сохраняем список участников до удаления, чтобы очистить их отображаемые префиксы.
+    List<String> members = team.getMembers();
+    // Удаляем команду и уведомляем игроков о сбросе префикса.
     storage.removeTeam(team);
-    for (String member : team.getMembers()) {
-      storage.getPlayerTeams().remove(member);
+    for (String memberName : members) {
+      notifyPrefixUpdate(memberName, null);
     }
+    // После уведомления очищаем соответствия игроков и команд.
+    for (String memberName : members) {
+      storage.getPlayerTeams().remove(memberName);
+    }
+    scheduler.enforceTeamSizes();
   }
 
   public void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader) {


### PR DESCRIPTION
## Summary
- collect team members before removing a team and notify them of prefix resets
- clean player-to-team mappings after notifications and enforce team size checks

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68caa66dce6c832e91bb6fbbbf42c225