### PR TITLE
Validate team admin rename command respects name length limits

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -36,7 +36,7 @@ public class MyPurpurPlugin extends JavaPlugin {
 
     // Регистрация команд
     registerCommand("team", new TeamCommand(teamManager, pluginConfig));
-    registerCommand("teamadmin", new TeamAdminCommand(teamManager));
+    registerCommand("teamadmin", new TeamAdminCommand(teamManager, pluginConfig));
     registerCommand("getteamsuuidlist", new AdminCommands(teamManager));
     registerCommand("getteamuuid", new AdminCommands(teamManager));
     registerCommand("teamreload", new TeamReloadCommand(this, teamManager, pluginConfig));

--- a/src/main/java/org/example/command/TeamAdminCommand.java
+++ b/src/main/java/org/example/command/TeamAdminCommand.java
@@ -10,16 +10,21 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.example.MyPurpurPlugin;
+import org.example.config.PluginConfig;
 import org.example.service.TeamService;
 import org.example.util.TeamMessageUtils;
+import org.example.util.TeamUtils;
 import org.jetbrains.annotations.NotNull;
 
 public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, TabCompleter {
 
   private final TeamService teamManager;
+  private final PluginConfig pluginConfig;
 
-  public TeamAdminCommand(@NotNull TeamService teamManager) {
+  public TeamAdminCommand(
+      @NotNull TeamService teamManager, @NotNull PluginConfig pluginConfig) {
     this.teamManager = teamManager;
+    this.pluginConfig = pluginConfig;
   }
 
   @Override
@@ -151,6 +156,9 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       return true;
     }
     String newTeamName = args[1];
+    if (TeamUtils.isTeamNameLengthInvalid(newTeamName, pluginConfig, player)) {
+      return true;
+    }
     teamManager.renameTeam(oldTeamName, newTeamName, player);
     return true;
   }

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -187,6 +187,27 @@ class TeamCommandTest {
   }
 
   @Test
+  void adminRenameRejectsInvalidTeamNameLength() {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("AdminLeader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    leader.addAttachment(plugin, "mypurpurplugin.teamadmin", true);
+
+    assertTrue(commandMap.dispatch(leader, "team create Alpha AA WHITE"));
+    assertEquals("Alpha", teamManager.getPlayerTeam(leader));
+
+    while (leader.nextComponentMessage() != null) {}
+
+    assertTrue(commandMap.dispatch(leader, "teamadmin rename AB"));
+    Component msg = leader.nextComponentMessage();
+    assertNotNull(msg);
+    String plain = PlainTextComponentSerializer.plainText().serialize(msg);
+    assertTrue(plain.contains("Название команды слишком короткое"));
+    assertEquals("Alpha", teamManager.getPlayerTeam(leader));
+  }
+
+  @Test
   void asyncChatEventAddsTeamPrefix() {
     CommandMap commandMap = server.getCommandMap();
     PlayerMock leader = server.addPlayer("Leader");


### PR DESCRIPTION
## Summary
- inject `PluginConfig` into `TeamAdminCommand` to validate rename input
- block `/teamadmin rename` when the new name violates configured length rules
- cover the admin rename command with an integration test for invalid name length

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68caaa980944832eaa4ea376cea47389