### PR TITLE
Normalize team color persistence

### DIFF
--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -64,7 +64,8 @@ public class TeamStorage {
         String name = teamsConfig.getString("teams." + teamIdStr + ".name", "");
         String leader = teamsConfig.getString("teams." + teamIdStr + ".leader", "");
         String prefix = teamsConfig.getString("teams." + teamIdStr + ".prefix", "");
-        String color = teamsConfig.getString("teams." + teamIdStr + ".color", "WHITE");
+        String color =
+            normalizeColorKey(teamsConfig.getString("teams." + teamIdStr + ".color", "WHITE"));
         Team team = new Team(teamId, name, leader, prefix, color);
         team.setMembers(teamsConfig.getStringList("teams." + teamIdStr + ".members"));
         long deadline = teamsConfig.getLong("teams." + teamIdStr + ".deadline", 0L);
@@ -93,7 +94,7 @@ public class TeamStorage {
       teamsConfig.set(path + ".leader", team.getLeader());
       teamsConfig.set(path + ".members", team.getMembers());
       teamsConfig.set(path + ".prefix", team.getPrefix());
-      teamsConfig.set(path + ".color", team.getColor().toString().toUpperCase());
+      teamsConfig.set(path + ".color", colorKeyFor(team.getColor()));
       Long deadline = deadlines.get(teamId);
       if (deadline != null) {
         teamsConfig.set(path + ".deadline", deadline);
@@ -248,5 +249,47 @@ public class TeamStorage {
       dirtyTeams.clear();
       deadlinesDirty = false;
     }
+  }
+
+  private static final String DEFAULT_COLOR_KEY =
+      Objects.requireNonNull(NamedTextColor.NAMES.key(NamedTextColor.WHITE));
+
+  private static String colorKeyFor(NamedTextColor color) {
+    if (color == null) {
+      return DEFAULT_COLOR_KEY;
+    }
+    String key = NamedTextColor.NAMES.key(color);
+    return key != null ? key : DEFAULT_COLOR_KEY;
+  }
+
+  private static String normalizeColorKey(String rawColor) {
+    if (rawColor == null || rawColor.isBlank()) {
+      return DEFAULT_COLOR_KEY;
+    }
+    String trimmed = rawColor.trim();
+    NamedTextColor direct = NamedTextColor.NAMES.value(trimmed.toLowerCase(Locale.ROOT));
+    if (direct != null) {
+      String key = NamedTextColor.NAMES.key(direct);
+      return key != null ? key : DEFAULT_COLOR_KEY;
+    }
+    if (trimmed.startsWith("NamedTextColor{")) {
+      int nameIndex = trimmed.indexOf("name=");
+      if (nameIndex >= 0) {
+        int separatorIndex = trimmed.indexOf(',', nameIndex);
+        int endIndex = separatorIndex >= 0 ? separatorIndex : trimmed.indexOf('}', nameIndex);
+        if (endIndex > nameIndex + 5) {
+          String candidate = trimmed.substring(nameIndex + 5, endIndex).trim();
+          if (!candidate.isEmpty()) {
+            NamedTextColor named =
+                NamedTextColor.NAMES.value(candidate.toLowerCase(Locale.ROOT));
+            if (named != null) {
+              String key = NamedTextColor.NAMES.key(named);
+              return key != null ? key : DEFAULT_COLOR_KEY;
+            }
+          }
+        }
+      }
+    }
+    return DEFAULT_COLOR_KEY;
   }
 }

--- a/src/test/java/org/example/service/TeamStorageTest.java
+++ b/src/test/java/org/example/service/TeamStorageTest.java
@@ -1,0 +1,64 @@
+package org.example.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import net.kyori.adventure.text.format.NamedTextColor;
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.example.model.Team;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TeamStorageTest {
+
+  private ServerMock server;
+  private JavaPlugin plugin;
+
+  @BeforeEach
+  void setUp() {
+    server = MockBukkit.mock();
+    plugin = MockBukkit.createMockPlugin();
+    plugin.getDataFolder().mkdirs();
+  }
+
+  @AfterEach
+  void tearDown() {
+    MockBukkit.unmock();
+  }
+
+  @Test
+  void saveAndLoadPreservesTeamColor() throws IOException {
+    TeamStorage storage = new TeamStorage(plugin, null);
+    Map<UUID, Long> deadlines = new HashMap<>();
+    storage.loadTeams(deadlines);
+
+    Team team = new Team(UUID.randomUUID(), "TestTeam", "Leader", "[T]", "red");
+    storage.addTeam(team);
+    storage.saveTeams(deadlines);
+
+    File teamsFile = new File(plugin.getDataFolder(), "teams.yml");
+    assertTrue(teamsFile.exists(), "teams.yml should have been created");
+    YamlConfiguration config = YamlConfiguration.loadConfiguration(teamsFile);
+    String savedColor = config.getString("teams." + team.getId() + ".color");
+    assertEquals("red", savedColor, "Color should be saved as a stable key");
+
+    config.set("teams." + team.getId() + ".color", NamedTextColor.RED.toString());
+    config.save(teamsFile);
+
+    TeamStorage reloaded = new TeamStorage(plugin, null);
+    Map<UUID, Long> reloadedDeadlines = new HashMap<>();
+    reloaded.loadTeams(reloadedDeadlines);
+
+    Team loadedTeam = reloaded.getTeams().get(team.getId());
+    assertNotNull(loadedTeam, "Team should be present after reload");
+    assertEquals(NamedTextColor.RED, loadedTeam.getColor());
+  }
+}


### PR DESCRIPTION
## Summary
- use NamedTextColor registry keys when persisting team colors and normalize legacy string formats during load
- add a regression test to ensure team colors survive save/load cycles

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cab4cb904c832e8773b9c45a8ac474