### PR TITLE
Notify leader prefix update on team creation

### DIFF
--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -53,6 +53,7 @@ public class MembershipService {
     // Создаём запись команды и связываем лидера с новой структурой.
     Team team = new Team(teamName, leader.getName(), prefix, color);
     storage.addTeam(team);
+    updateTeamMembersPrefixes(team);
     storage.getPlayerTeams().put(leader.getName(), team.getId());
     TeamMessageUtils.sendTeamMessage(
         leader, Component.text("✅ Команда создана", NamedTextColor.GREEN));

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -145,6 +145,26 @@ class TeamCommandTest {
   }
 
   @Test
+  void leaderReceivesConfirmationAndTabPrefixAfterCreate() {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("Leader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+
+    assertTrue(commandMap.dispatch(leader, "team create Alpha AA WHITE"));
+
+    Component confirmation = leader.nextComponentMessage();
+    assertNotNull(confirmation, "Leader should receive confirmation message");
+    String confirmationPlain = PlainTextComponentSerializer.plainText().serialize(confirmation);
+    assertTrue(confirmationPlain.contains("Команда создана"));
+
+    Component playerListName = leader.playerListName();
+    assertNotNull(playerListName, "Tab name should not be null");
+    String playerListPlain = PlainTextComponentSerializer.plainText().serialize(playerListName);
+    assertEquals("[AA] Leader", playerListPlain);
+  }
+
+  @Test
   void deniesCommandWithoutPermission() {
     CommandMap commandMap = server.getCommandMap();
     PlayerMock player = server.addPlayer("Player");


### PR DESCRIPTION
## Summary
- trigger PlayerPrefixUpdateEvent for the leader immediately after a team is stored
- cover the behaviour with an integration test that checks the confirmation message and tab prefix after `/team create`

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cabecc70b0832e983f5d3fedc6aa7b