### PR TITLE
Preserve existing grace period deadlines across reloads

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -214,8 +214,12 @@ public class DeadlineScheduler {
         continue;
       }
 
-      long deadlineAt =
-          System.currentTimeMillis() + pluginConfig.getGracePeriodMinutes() * 60L * 1000L;
+      Long existingDeadline = deadlines.get(teamId);
+      long now = System.currentTimeMillis();
+      if (existingDeadline != null && existingDeadline > now) {
+        continue;
+      }
+      long deadlineAt = now + pluginConfig.getGracePeriodMinutes() * 60L * 1000L;
       Long previous = deadlines.put(teamId, deadlineAt);
       boolean deadlineUpdated = !Objects.equals(previous, deadlineAt);
       if (deadlineUpdated) {

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -277,4 +277,70 @@ class TeamCommandTest {
     teamManager.removePlayerFromTeam("Beta", member);
     assertNull(teamManager.getTeamDeadline("Beta"));
   }
+
+  @Test
+  void enforceTeamSizesReusesExistingDeadline() throws Exception {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("Leader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    assertTrue(commandMap.dispatch(leader, "team create Beta BB WHITE"));
+
+    PlayerMock member = server.addPlayer("Member");
+    member.addAttachment(plugin, "mypurpurplugin.team", true);
+    assertTrue(commandMap.dispatch(member, "team join Beta"));
+
+    config.set("team.max-members", 1);
+    config.set("team.grace-period-minutes", 5);
+    assertEquals(2, teamManager.getTeamMembers("Beta").size());
+    assertEquals(1, pluginConfig.getMaxMembers());
+
+    while (leader.nextComponentMessage() != null) {}
+
+    scheduler.enforceTeamSizes();
+    Long firstDeadline = teamManager.getTeamDeadline("Beta");
+    assertNotNull(firstDeadline);
+    Component firstWarning = leader.nextComponentMessage();
+    assertNotNull(firstWarning);
+    assertNull(leader.nextComponentMessage());
+
+    scheduler.enforceTeamSizes();
+    Long secondDeadline = teamManager.getTeamDeadline("Beta");
+    assertEquals(firstDeadline, secondDeadline);
+    assertNull(leader.nextComponentMessage());
+  }
+
+  @Test
+  void reloadKeepsExistingDeadlineTimestamp() throws Exception {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("Leader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    assertTrue(commandMap.dispatch(leader, "team create Beta BB WHITE"));
+
+    PlayerMock member = server.addPlayer("Member");
+    member.addAttachment(plugin, "mypurpurplugin.team", true);
+    assertTrue(commandMap.dispatch(member, "team join Beta"));
+
+    config.set("team.max-members", 1);
+    config.set("team.grace-period-minutes", 5);
+    assertEquals(2, teamManager.getTeamMembers("Beta").size());
+    assertEquals(1, pluginConfig.getMaxMembers());
+    config.save(new File(plugin.getDataFolder(), "config.yml"));
+
+    while (leader.nextComponentMessage() != null) {}
+
+    scheduler.enforceTeamSizes();
+    Long originalDeadline = teamManager.getTeamDeadline("Beta");
+    assertNotNull(originalDeadline);
+    Component warning = leader.nextComponentMessage();
+    assertNotNull(warning);
+    assertNull(leader.nextComponentMessage());
+
+    teamManager.reloadConfig();
+
+    Long reloadedDeadline = teamManager.getTeamDeadline("Beta");
+    assertEquals(originalDeadline, reloadedDeadline);
+    assertNull(leader.nextComponentMessage());
+  }
 }

--- a/src/test/java/org/example/service/TeamStorageTest.java
+++ b/src/test/java/org/example/service/TeamStorageTest.java
@@ -6,7 +6,9 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -60,5 +62,27 @@ class TeamStorageTest {
     Team loadedTeam = reloaded.getTeams().get(team.getId());
     assertNotNull(loadedTeam, "Team should be present after reload");
     assertEquals(NamedTextColor.RED, loadedTeam.getColor());
+  }
+
+  @Test
+  void saveAndReloadKeepsDeadlineTimestamps() throws IOException {
+    TeamStorage storage = new TeamStorage(plugin, null);
+    Map<UUID, Long> deadlines = new HashMap<>();
+    storage.loadTeams(deadlines);
+
+    UUID teamId = UUID.randomUUID();
+    Team team = new Team(teamId, "DeadlineTeam", "Leader", "[D]", "blue");
+    team.setMembers(new ArrayList<>(List.of("Leader", "Member")));
+    storage.addTeam(team);
+
+    long deadline = System.currentTimeMillis() + 60000L;
+    deadlines.put(teamId, deadline);
+    storage.saveTeams(deadlines);
+
+    TeamStorage reloaded = new TeamStorage(plugin, null);
+    Map<UUID, Long> reloadedDeadlines = new HashMap<>();
+    reloaded.loadTeams(reloadedDeadlines);
+
+    assertEquals(deadline, reloadedDeadlines.get(teamId));
   }
 }


### PR DESCRIPTION
## Summary
- prevent `DeadlineScheduler` from overwriting future deadlines when a team remains over the limit
- add coverage around keeping the same grace-period warning across reloads and repeated enforcement
- ensure team storage writes and reloads deadline timestamps unchanged

## Testing
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cb9a8ee764832eb20ef846486e3f9b