### PR TITLE
Use display names when rendering team chat

### DIFF
--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -69,13 +69,13 @@ public class TeamChatListener implements Listener {
       event.renderer(
           (source, sourceDisplayName, message, viewer) ->
               prefixComponent
-                  .append(Component.text(source.getName(), NamedTextColor.WHITE))
+                  .append(sourceDisplayName)
                   .append(Component.text(": "))
                   .append(message.color(NamedTextColor.WHITE)));
     } else {
       event.renderer(
           (source, sourceDisplayName, message, viewer) ->
-              Component.text(source.getName(), NamedTextColor.WHITE)
+              sourceDisplayName
                   .append(Component.text(": "))
                   .append(message.color(NamedTextColor.WHITE)));
     }

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -20,6 +20,7 @@ import java.util.stream.Stream;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.chat.SignedMessage;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.command.CommandMap;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -249,6 +250,38 @@ class TeamCommandTest {
     Component rendered = event.renderer().render(leader, Component.text("Leader"), message, leader);
     String plain = PlainTextComponentSerializer.plainText().serialize(rendered);
     assertEquals("[AA] Leader: hello", plain);
+  }
+
+  @Test
+  void asyncChatEventUsesDisplayNameWithPrefix() {
+    CommandMap commandMap = server.getCommandMap();
+    PlayerMock leader = server.addPlayer("Leader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    commandMap.dispatch(leader, "team create Alpha AA WHITE");
+
+    Component message = Component.text("hello");
+    Component displayName = Component.text("Captain", NamedTextColor.GOLD);
+    AsyncChatEvent event =
+        new AsyncChatEvent(
+            false,
+            leader,
+            Set.<Audience>of(),
+            ChatRenderer.defaultRenderer(),
+            message,
+            message,
+            SignedMessage.system("hello", message));
+    server.getPluginManager().callEvent(event);
+
+    PlainTextComponentSerializer plainSerializer = PlainTextComponentSerializer.plainText();
+    Component rendered = event.renderer().render(leader, displayName, message, leader);
+
+    assertEquals("[AA] Captain: hello", plainSerializer.serialize(rendered));
+    Component nameComponent =
+        rendered.children().stream()
+            .filter(component -> "Captain".equals(plainSerializer.serialize(component)))
+            .findFirst()
+            .orElseThrow();
+    assertEquals(NamedTextColor.GOLD, nameComponent.color());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- render team chat messages using the provided display name component so nickname formatting is preserved
- add a regression test ensuring prefixed chat output keeps the viewer-facing nickname and its color

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cba9bbe180832e8f7123aa08cbad0c