### PR TITLE
Handle deadline scoreboard leader changes

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -449,8 +449,12 @@ public class DeadlineScheduler {
   }
 
   private void clearLeaderDisplay(@NotNull Team team) {
-    teamLeaderNames.remove(team.getId());
-    clearLeaderDisplay(team.getLeader());
+    String notifiedLeader = teamLeaderNames.remove(team.getId());
+    if (notifiedLeader != null) {
+      clearLeaderDisplay(notifiedLeader);
+    } else {
+      clearLeaderDisplay(team.getLeader());
+    }
   }
 
   private void clearLeaderDisplay(String leaderName) {
@@ -487,9 +491,15 @@ public class DeadlineScheduler {
     }
     DeadlineDisplayMode mode = getDisplayMode();
     if (mode == DeadlineDisplayMode.SCOREBOARD) {
-      teamLeaderNames.put(team.getId(), leaderName);
+      String previousLeader = teamLeaderNames.put(team.getId(), leaderName);
+      if (previousLeader != null && !previousLeader.equalsIgnoreCase(leaderName)) {
+        clearLeaderDisplay(previousLeader);
+      }
     } else {
-      teamLeaderNames.remove(team.getId());
+      String previousLeader = teamLeaderNames.remove(team.getId());
+      if (previousLeader != null) {
+        clearLeaderDisplay(previousLeader);
+      }
     }
     switch (mode) {
       case ACTION_BAR -> leader.sendActionBar(message);

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -25,6 +25,7 @@ import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.command.CommandMap;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.scoreboard.Scoreboard;
 import org.example.MyPurpurPlugin;
 import org.example.config.PluginConfig;
 import org.example.service.DeadlineScheduler;
@@ -173,6 +174,42 @@ class TeamCommandTest {
     player.addAttachment(plugin, "mypurpurplugin.team", false);
     commandMap.dispatch(player, "team create Bravo BB WHITE");
     assertFalse(teamManager.getTeamNames().contains("Bravo"));
+  }
+
+  @Test
+  void transfersLeadershipRestoresScoreboardForPreviousLeader() {
+    config.set("team.deadline-display-mode", "SCOREBOARD");
+    config.set("team.max-members", 0);
+    config.set("team.grace-period-enabled", true);
+    config.set("team.grace-period-minutes", 5);
+
+    PlayerMock oldLeader = server.addPlayer("OldLeader");
+    PlayerMock newLeader = server.addPlayer("NewLeader");
+
+    teamManager.createTeam("Omega", "OM", "WHITE", oldLeader);
+    teamManager.addPlayerToTeam("Omega", newLeader);
+
+    Scoreboard oldLeaderOriginal = oldLeader.getScoreboard();
+    Scoreboard newLeaderOriginal = newLeader.getScoreboard();
+
+    config.set("team.max-members", 1);
+    scheduler.enforceTeamSizes();
+
+    Scoreboard warnedOldLeaderBoard = oldLeader.getScoreboard();
+    assertNotSame(oldLeaderOriginal, warnedOldLeaderBoard);
+    assertNotNull(warnedOldLeaderBoard.getObjective("deadlineWarn"));
+
+    teamManager.transferLeadership("Omega", oldLeader, newLeader);
+
+    scheduler.checkDeadlines();
+
+    Scoreboard restoredOldLeaderBoard = oldLeader.getScoreboard();
+    assertSame(oldLeaderOriginal, restoredOldLeaderBoard);
+    assertNull(restoredOldLeaderBoard.getObjective("deadlineWarn"));
+
+    Scoreboard warnedNewLeaderBoard = newLeader.getScoreboard();
+    assertNotSame(newLeaderOriginal, warnedNewLeaderBoard);
+    assertNotNull(warnedNewLeaderBoard.getObjective("deadlineWarn"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- restore the previous leader's scoreboard when a deadline warning switches leaders
- send warnings to the new leader while clearing displays for leaders when display mode changes
- add a regression test covering scoreboard warnings during leadership transfer

## Testing
- ./gradlew test --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68cbc58bcef8832e930ee6b37c97b612