### PR TITLE
Normalize team lookups and add case-insensitive join coverage

### DIFF
--- a/src/main/java/org/example/command/AdminCommands.java
+++ b/src/main/java/org/example/command/AdminCommands.java
@@ -2,6 +2,7 @@ package org.example.command;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.TextComponent;
@@ -37,7 +38,7 @@ public class AdminCommands implements CommandExecutor, TabCompleter {
       return true;
     }
 
-    String commandName = command.getName().toLowerCase();
+    String commandName = command.getName().toLowerCase(Locale.ROOT);
 
     if (commandName.equals("getteamsuuidlist")) {
       if (!player.hasPermission("mypurpurplugin.getteamsuuidlist")) {
@@ -142,12 +143,13 @@ public class AdminCommands implements CommandExecutor, TabCompleter {
       return suggestions;
     }
 
-    String commandName = command.getName().toLowerCase();
+    String commandName = command.getName().toLowerCase(Locale.ROOT);
     if (commandName.equals("getteamuuid") && args.length == 1) {
       // Предлагаем названия команд
       List<String> teamNames = teamService.getTeamNames();
+      String normalizedInput = args[0].toLowerCase(Locale.ROOT);
       for (String teamName : teamNames) {
-        if (teamName.toLowerCase().startsWith(args[0].toLowerCase())) {
+        if (teamName.toLowerCase(Locale.ROOT).startsWith(normalizedInput)) {
           suggestions.add(teamName);
         }
       }

--- a/src/main/java/org/example/command/TeamAdminCommand.java
+++ b/src/main/java/org/example/command/TeamAdminCommand.java
@@ -51,7 +51,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       return true;
     }
 
-    String subCommand = args[0].toLowerCase();
+    String subCommand = args[0].toLowerCase(Locale.ROOT);
     ((MyPurpurPlugin) teamManager.getPlugin())
         .debugTeamAction("Команда /teamadmin выполнена игроком", player.getName(), null);
 
@@ -265,7 +265,8 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
               List<String> members = teamManager.getTeamMembers(teamName);
               for (String memberName : members) {
                 if (!memberName.equals(player.getName())
-                    && memberName.toLowerCase().startsWith(args[1].toLowerCase())) {
+                  && memberName.toLowerCase(Locale.ROOT)
+                      .startsWith(args[1].toLowerCase(Locale.ROOT))) {
                   suggestions.add(memberName);
                 }
               }

--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -2,6 +2,7 @@ package org.example.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -26,7 +27,7 @@ public class Team {
     this.leader = leader;
     this.members = new ArrayList<>(List.of(leader));
     this.prefix = prefix;
-    this.color = NamedTextColor.NAMES.valueOr(color.toLowerCase(), NamedTextColor.WHITE);
+    this.color = NamedTextColor.NAMES.valueOr(color.toLowerCase(Locale.ROOT), NamedTextColor.WHITE);
   }
 
   // Геттеры
@@ -72,7 +73,7 @@ public class Team {
   }
 
   public void setColor(String color) {
-    this.color = NamedTextColor.NAMES.valueOr(color.toLowerCase(), NamedTextColor.WHITE);
+    this.color = NamedTextColor.NAMES.valueOr(color.toLowerCase(Locale.ROOT), NamedTextColor.WHITE);
   }
 
   // Методы управления участниками

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -39,7 +39,7 @@ public class MembershipService {
       return;
     }
     // Проверяем, что игрок выбрал поддерживаемый цвет для корректного отображения.
-    NamedTextColor teamColor = NamedTextColor.NAMES.value(color.toLowerCase());
+    NamedTextColor teamColor = NamedTextColor.NAMES.value(color.toLowerCase(Locale.ROOT));
     if (teamColor == null) {
       TeamMessageUtils.sendTeamMessage(
           leader, Component.text("❌ Неверный цвет команды", NamedTextColor.RED));
@@ -185,7 +185,7 @@ public class MembershipService {
     Team team = storage.getTeamByName(teamName);
     // Проверяем права и корректность цвета перед сохранением.
     if (team == null || !team.isLeader(leader.getName())) return;
-    NamedTextColor teamColor = NamedTextColor.NAMES.value(newColor.toLowerCase());
+    NamedTextColor teamColor = NamedTextColor.NAMES.value(newColor.toLowerCase(Locale.ROOT));
     if (teamColor == null) {
       TeamMessageUtils.sendTeamMessage(
           leader, Component.text("❌ Неверный цвет команды", NamedTextColor.RED));

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -117,7 +117,10 @@ public class TeamStorage {
 
   private void addTeamInternal(@NotNull Team team, boolean markDirty) {
     teams.put(team.getId(), team);
-    teamIdsByName.put(team.getName(), team.getId());
+    String normalizedName = normalizeTeamKey(team.getName());
+    if (normalizedName != null) {
+      teamIdsByName.put(normalizedName, team.getId());
+    }
     if (markDirty) {
       markTeamDirty(team);
     }
@@ -125,7 +128,10 @@ public class TeamStorage {
 
   public void removeTeam(@NotNull Team team) {
     teams.remove(team.getId());
-    teamIdsByName.remove(team.getName());
+    String normalizedName = normalizeTeamKey(team.getName());
+    if (normalizedName != null) {
+      teamIdsByName.remove(normalizedName);
+    }
     markTeamDirty(team);
   }
 
@@ -134,9 +140,21 @@ public class TeamStorage {
     if (Objects.equals(currentName, newName)) {
       return;
     }
-    teamIdsByName.remove(currentName);
+    String normalizedNewName = normalizeTeamKey(newName);
+    if (normalizedNewName != null) {
+      UUID existingId = teamIdsByName.get(normalizedNewName);
+      if (existingId != null && !existingId.equals(team.getId())) {
+        return;
+      }
+    }
+    String normalizedCurrentName = normalizeTeamKey(currentName);
+    if (normalizedCurrentName != null) {
+      teamIdsByName.remove(normalizedCurrentName);
+    }
     team.setName(newName);
-    teamIdsByName.put(newName, team.getId());
+    if (normalizedNewName != null) {
+      teamIdsByName.put(normalizedNewName, team.getId());
+    }
     markTeamDirty(team);
   }
 
@@ -145,12 +163,17 @@ public class TeamStorage {
   }
 
   public Team getTeamByName(String teamName) {
-    UUID teamId = teamIdsByName.get(teamName);
+    String normalizedName = normalizeTeamKey(teamName);
+    if (normalizedName == null) {
+      return null;
+    }
+    UUID teamId = teamIdsByName.get(normalizedName);
     return teamId != null ? teams.get(teamId) : null;
   }
 
   public UUID getTeamIdByName(String teamName) {
-    return teamIdsByName.get(teamName);
+    String normalizedName = normalizeTeamKey(teamName);
+    return normalizedName != null ? teamIdsByName.get(normalizedName) : null;
   }
 
   public String getPlayerTeam(@NotNull Player player) {
@@ -287,5 +310,9 @@ public class TeamStorage {
       }
     }
     return DEFAULT_COLOR_KEY;
+  }
+
+  private static String normalizeTeamKey(String name) {
+    return name != null ? name.toLowerCase(Locale.ROOT) : null;
   }
 }

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -167,6 +167,21 @@ class TeamCommandTest {
   }
 
   @Test
+  void joinCommandMatchesTeamNameIgnoringCase() {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("CaseLeader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    assertTrue(commandMap.dispatch(leader, "team create Alpha AA WHITE"));
+
+    PlayerMock member = server.addPlayer("CaseRecruit");
+    member.addAttachment(plugin, "mypurpurplugin.team", true);
+    assertTrue(commandMap.dispatch(member, "team join alpha"));
+
+    assertEquals("Alpha", teamManager.getPlayerTeam(member));
+  }
+
+  @Test
   void deniesCommandWithoutPermission() {
     CommandMap commandMap = server.getCommandMap();
     PlayerMock player = server.addPlayer("Player");


### PR DESCRIPTION
## Summary
- normalize team name keys inside TeamStorage and block case-insensitive duplicates when renaming
- ensure admin commands and membership color parsing use Locale.ROOT for normalized lookups
- extend team command tests with a case-insensitive join scenario

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cbcbbc25bc832ebb90f17a3d989225