### PR TITLE
Fix shutdown reload behavior

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -136,7 +136,6 @@ public class MyPurpurPlugin extends JavaPlugin {
   @Override
   public void onDisable() {
     if (teamManager != null) {
-      teamManager.reloadConfig();
       teamManager.shutdown();
     }
   }


### PR DESCRIPTION
## Summary
- stop reloading team data during plugin shutdown
- rely on TeamManager#shutdown to handle final persistence without restarting schedulers

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cbd5156a74832e81976230b6550171