### PR TITLE
Align team defaults with configuration

### DIFF
--- a/src/main/java/org/example/config/PluginConfig.java
+++ b/src/main/java/org/example/config/PluginConfig.java
@@ -52,9 +52,9 @@ public class PluginConfig {
     // Основные настройки
     config.addDefault("team.requires-op", false);
     config.addDefault("team.notify-admins", true);
-    config.addDefault("team.max-members", 5);
-    config.addDefault("team.min-prefix-length", 2);
-    config.addDefault("team.max-prefix-length", 5);
+    config.addDefault("team.max-members", 0);
+    config.addDefault("team.min-prefix-length", 1);
+    config.addDefault("team.max-prefix-length", 16);
     config.addDefault("team.min-team-name-length", 3);
     config.addDefault("team.max-team-name-length", 16);
     config.addDefault("team.enforce-max-members-on-reload", true);
@@ -131,7 +131,7 @@ public class PluginConfig {
    * @return Максимальное количество участников (0 — без ограничений)
    */
   public int getMaxMembers() {
-    return config.getInt("team.max-members", 5);
+    return config.getInt("team.max-members", 0);
   }
 
   /**
@@ -218,7 +218,7 @@ public class PluginConfig {
    * @return Минимальная длина префикса
    */
   public int getMinPrefixLength() {
-    return config.getInt("team.min-prefix-length", 2);
+    return config.getInt("team.min-prefix-length", 1);
   }
 
   /**
@@ -227,7 +227,7 @@ public class PluginConfig {
    * @return Максимальная длина префикса
    */
   public int getMaxPrefixLength() {
-    return config.getInt("team.max-prefix-length", 5);
+    return config.getInt("team.max-prefix-length", 16);
   }
 
   /**

--- a/src/test/java/org/example/config/PluginConfigTest.java
+++ b/src/test/java/org/example/config/PluginConfigTest.java
@@ -1,0 +1,70 @@
+package org.example.config;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
+import java.io.File;
+import java.lang.reflect.Field;
+import org.bukkit.command.CommandMap;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.example.MyPurpurPlugin;
+import org.example.service.TeamManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+/** Tests covering PluginConfig default regeneration logic. */
+class PluginConfigTest {
+
+  private ServerMock server;
+
+  @AfterEach
+  void tearDown() {
+    if (MockBukkit.getMock() != null) {
+      MockBukkit.unmock();
+    }
+    server = null;
+  }
+
+  @Test
+  void regeneratesConfigWithDefaultsAfterDeletion() throws Exception {
+    server = MockBukkit.mock();
+    MyPurpurPlugin plugin = MockBukkit.load(MyPurpurPlugin.class);
+
+    File dataFolder = plugin.getDataFolder();
+    File configFile = new File(dataFolder, "config.yml");
+    assertTrue(configFile.exists(), "Config file should be created on first load");
+    assertTrue(configFile.delete(), "Config file should be deletable");
+
+    PluginManagerMock pluginManager = server.getPluginManager();
+    pluginManager.disablePlugin(plugin);
+    pluginManager.clearPlugins();
+
+    MockBukkit.unmock();
+
+    server = MockBukkit.mock();
+    plugin = MockBukkit.load(MyPurpurPlugin.class);
+    CommandMap commandMap = server.getCommandMap();
+
+    File regenerated = new File(plugin.getDataFolder(), "config.yml");
+    assertTrue(regenerated.exists(), "Config file should be regenerated on reload");
+
+    YamlConfiguration yaml = YamlConfiguration.loadConfiguration(regenerated);
+    assertEquals(1, yaml.getInt("team.min-prefix-length"));
+    assertEquals(16, yaml.getInt("team.max-prefix-length"));
+    assertEquals(0, yaml.getInt("team.max-members"));
+
+    PlayerMock leader = server.addPlayer("Leader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+
+    assertTrue(commandMap.dispatch(leader, "team create Zeta Z WHITE"));
+
+    Field teamManagerField = MyPurpurPlugin.class.getDeclaredField("teamManager");
+    teamManagerField.setAccessible(true);
+    TeamManager teamManager = (TeamManager) teamManagerField.get(plugin);
+
+    assertEquals("Zeta", teamManager.getPlayerTeam(leader));
+  }
+}


### PR DESCRIPTION
## Summary
- update PluginConfig defaults to mirror the documented min/max team limits
- ensure getter fallbacks follow the same minimum and maximum values
- add a regression test that rebuilds the config after deletion and exercises /team create

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cbdac6c778832e957ffa8450ebbc47