### PR TITLE
Sync team member prefixes on reload

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -442,6 +442,10 @@ public class DeadlineScheduler {
     return DeadlineDisplayMode.fromConfig(pluginConfig.getDeadlineDisplayMode());
   }
 
+  public void resetLeaderDisplays() {
+    resetAllLeaderDisplays();
+  }
+
   private void resetAllLeaderDisplays() {
     storage.getTeams().values().forEach(this::clearLeaderDisplay);
     leaderOriginalScoreboards.clear();

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -203,7 +203,7 @@ public class MembershipService {
     updateTeamMembersPrefixes(team);
   }
 
-  private void updateTeamMembersPrefixes(@NotNull Team team) {
+  public void updateTeamMembersPrefixes(@NotNull Team team) {
     Component prefixComponent = team.getPrefixComponent();
     for (String member : team.getMembers()) {
       notifyPrefixUpdate(member, prefixComponent);

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -150,6 +150,8 @@ public class TeamManager implements TeamService {
     scheduler.stop();
     pluginConfig.reloadConfig();
     storage.loadTeams(scheduler.getDeadlines());
+    storage.getTeams().values().forEach(membership::updateTeamMembersPrefixes);
+    scheduler.resetLeaderDisplays();
     scheduler.enforceTeamSizes();
     scheduler.start();
     storage.startAutoSave(pluginConfig.getSaveIntervalSeconds(), scheduler.getDeadlines());


### PR DESCRIPTION
## Summary
- refresh player prefixes for all loaded teams during /teamreload to apply updated names instantly
- expose membership prefix sync helper for reuse during reload
- provide a public reset hook for deadline displays and invoke it while reloading

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ccb4ba14d8832eaa3676cd1e9cd3e7