### PR TITLE
Increase default max team name length

### DIFF
--- a/src/main/java/org/example/config/PluginConfig.java
+++ b/src/main/java/org/example/config/PluginConfig.java
@@ -56,7 +56,7 @@ public class PluginConfig {
     config.addDefault("team.min-prefix-length", 1);
     config.addDefault("team.max-prefix-length", 16);
     config.addDefault("team.min-team-name-length", 3);
-    config.addDefault("team.max-team-name-length", 16);
+    config.addDefault("team.max-team-name-length", 32);
     config.addDefault("team.enforce-max-members-on-reload", true);
     config.addDefault("team.grace-period-enabled", true);
     config.addDefault("team.grace-period-minutes", 10);
@@ -245,7 +245,7 @@ public class PluginConfig {
    * @return Максимальная длина названия команды
    */
   public int getMaxTeamNameLength() {
-    return config.getInt("team.max-team-name-length", 16);
+    return config.getInt("team.max-team-name-length", 32);
   }
 
   /**

--- a/src/test/java/org/example/config/PluginConfigTest.java
+++ b/src/test/java/org/example/config/PluginConfigTest.java
@@ -9,6 +9,7 @@ import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
 import java.io.File;
 import java.lang.reflect.Field;
 import org.bukkit.command.CommandMap;
+import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.example.MyPurpurPlugin;
 import org.example.service.TeamManager;
@@ -54,6 +55,7 @@ class PluginConfigTest {
     YamlConfiguration yaml = YamlConfiguration.loadConfiguration(regenerated);
     assertEquals(1, yaml.getInt("team.min-prefix-length"));
     assertEquals(16, yaml.getInt("team.max-prefix-length"));
+    assertEquals(32, yaml.getInt("team.max-team-name-length"));
     assertEquals(0, yaml.getInt("team.max-members"));
 
     PlayerMock leader = server.addPlayer("Leader");
@@ -66,5 +68,30 @@ class PluginConfigTest {
     TeamManager teamManager = (TeamManager) teamManagerField.get(plugin);
 
     assertEquals("Zeta", teamManager.getPlayerTeam(leader));
+  }
+
+  @Test
+  void returnsDefaultMaxTeamNameLengthWhenMissing() throws Exception {
+    server = MockBukkit.mock();
+    MyPurpurPlugin plugin = MockBukkit.load(MyPurpurPlugin.class);
+
+    Field cfgField = MyPurpurPlugin.class.getDeclaredField("pluginConfig");
+    cfgField.setAccessible(true);
+    PluginConfig pluginConfig = (PluginConfig) cfgField.get(plugin);
+
+    Field configField = PluginConfig.class.getDeclaredField("config");
+    configField.setAccessible(true);
+    FileConfiguration configuration = (FileConfiguration) configField.get(pluginConfig);
+
+    Field fileField = PluginConfig.class.getDeclaredField("configFile");
+    fileField.setAccessible(true);
+    File configFile = (File) fileField.get(pluginConfig);
+
+    configuration.set("team.max-team-name-length", null);
+    configuration.save(configFile);
+
+    pluginConfig.reloadConfig();
+
+    assertEquals(32, pluginConfig.getMaxTeamNameLength());
   }
 }


### PR DESCRIPTION
## Summary
- raise the default team name length limit to 32 in PluginConfig
- ensure regenerated configurations include the updated limit
- add a regression test that validates the fallback value when the key is absent

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ccbb55252c832ea074b26f2e5aeccb