### PR TITLE
Ensure leader displays are reset on shutdown

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -448,6 +448,8 @@ public class DeadlineScheduler {
 
   private void resetAllLeaderDisplays() {
     storage.getTeams().values().forEach(this::clearLeaderDisplay);
+    // Полностью очищаем кеш, чтобы при перезапуске/отключении не осталось привязок к
+    // временным табло лидеров и их именам.
     leaderOriginalScoreboards.clear();
     teamLeaderNames.clear();
   }

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -170,6 +170,7 @@ public class TeamManager implements TeamService {
   @Override
   public void shutdown() {
     storage.stopAutoSave();
+    scheduler.resetLeaderDisplays();
     scheduler.stop();
     storage.flushNow();
   }


### PR DESCRIPTION
## Summary
- reset leader notifications in the scheduler before stopping it during shutdown
- document that the scheduler clears cached leader scoreboards and names when resetting displays

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ccc86bca44832ea69ca85370ac820f