### PR TITLE
Handle overdue team deadlines immediately

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -216,7 +216,33 @@ public class DeadlineScheduler {
 
       Long existingDeadline = deadlines.get(teamId);
       long now = System.currentTimeMillis();
-      if (existingDeadline != null && existingDeadline > now) {
+      if (existingDeadline != null) {
+        if (existingDeadline <= now) {
+          changed = true;
+          deadlines.remove(teamId);
+          clearLeaderDisplay(team);
+          int removed = removeExtraPlayers(team, max);
+          if (removed > 0) {
+            Component leaderMessage = TeamMessageUtils.forcedRemovalMessage(removed);
+            notifyLeader(team, leaderMessage);
+            notifyAdmins(
+                adminBaseMessage(team, size, max)
+                    .append(Component.space())
+                    .append(
+                        Component.text(
+                            "Льготный период истёк, удалено " + removed + " участника(ов).",
+                            NamedTextColor.RED)));
+            plugin
+                .getLogger()
+                .info(
+                    "Льготный период команды "
+                        + team.getName()
+                        + " истёк, удалено "
+                        + removed
+                        + " игрок(ов).");
+          }
+          continue;
+        }
         continue;
       }
       long deadlineAt = now + pluginConfig.getGracePeriodMinutes() * 60L * 1000L;

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -16,6 +16,8 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.chat.SignedMessage;
@@ -426,6 +428,53 @@ class TeamCommandTest {
 
     Long reloadedDeadline = teamManager.getTeamDeadline("Beta");
     assertEquals(originalDeadline, reloadedDeadline);
+    assertNull(leader.nextComponentMessage());
+  }
+
+  @Test
+  void enforceTeamSizesRemovesOverdueTeamImmediately() throws Exception {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("Leader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    assertTrue(commandMap.dispatch(leader, "team create Beta BB WHITE"));
+
+    PlayerMock member = server.addPlayer("Member");
+    member.addAttachment(plugin, "mypurpurplugin.team", true);
+    assertTrue(commandMap.dispatch(member, "team join Beta"));
+
+    PlayerMock extra = server.addPlayer("Extra");
+    extra.addAttachment(plugin, "mypurpurplugin.team", true);
+    assertTrue(commandMap.dispatch(extra, "team join Beta"));
+
+    config.set("team.max-members", 1);
+    config.set("team.grace-period-minutes", 5);
+
+    while (leader.nextComponentMessage() != null) {}
+
+    scheduler.enforceTeamSizes();
+    Long firstDeadline = teamManager.getTeamDeadline("Beta");
+    assertNotNull(firstDeadline);
+
+    UUID teamId = teamManager.getTeamIdByName("Beta");
+    assertNotNull(teamId);
+    scheduler
+        .getDeadlines()
+        .put(teamId, System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(1));
+
+    while (leader.nextComponentMessage() != null) {}
+
+    scheduler.enforceTeamSizes();
+
+    assertEquals(1, teamManager.getTeamMembers("Beta").size());
+    assertNull(teamManager.getTeamDeadline("Beta"));
+
+    Component forcedMessage = leader.nextComponentMessage();
+    assertNotNull(forcedMessage);
+    PlainTextComponentSerializer serializer = PlainTextComponentSerializer.plainText();
+    assertEquals(
+        "Из вашей команды удалено 2 участника(ов) из-за превышения лимита.",
+        serializer.serialize(forcedMessage));
     assertNull(leader.nextComponentMessage());
   }
 }


### PR DESCRIPTION
## Summary
- prevent `DeadlineScheduler.enforceTeamSizes` from rescheduling already-expired deadlines and reuse the stored timestamp
- trigger immediate member removal when an overdue deadline is encountered so teams are trimmed without delay
- add an integration test that simulates an overdue team and verifies the deadline is cleared and surplus members are removed

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cd2af60b60832eaa81018ccda6a21c