### PR TITLE
Prevent leaders from self-kicking

### DIFF
--- a/src/main/java/org/example/command/TeamAdminCommand.java
+++ b/src/main/java/org/example/command/TeamAdminCommand.java
@@ -123,6 +123,13 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       return true;
     }
     String targetName = args[1];
+    if (targetName.equalsIgnoreCase(player.getName())) {
+      TeamMessageUtils.sendTeamMessage(
+          player,
+          Component.text(
+              "❌ Вы не можете исключить себя из команды!", NamedTextColor.RED));
+      return true;
+    }
     teamManager.kickPlayerFromTeam(teamName, player, targetName);
     return true;
   }

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -125,6 +125,10 @@ public class MembershipService {
     // Проверяем право лидера на это действие и наличие цели в команде.
     if (team == null || !team.isLeader(leader.getName())) return;
     if (!team.hasMember(targetName)) return;
+    if (team.isLeader(targetName)) {
+      removePlayerFromTeam(teamName, leader);
+      return;
+    }
     // Удаляем участника и фиксируем изменения.
     team.removeMember(targetName);
     storage.getPlayerTeams().remove(targetName);

--- a/src/test/java/org/example/service/TeamManagerTest.java
+++ b/src/test/java/org/example/service/TeamManagerTest.java
@@ -184,6 +184,23 @@ class TeamManagerTest {
   }
 
   @Test
+  void leaderKickSelfDelegatesToRemovalFlow() {
+    PlayerMock leader = server.addPlayer("SelfKickLeader");
+    PlayerMock successor = server.addPlayer("SelfKickMember");
+
+    String teamName = "SelfKickTeam";
+    teamManager.createTeam(teamName, "SK", "blue", leader);
+    teamManager.addPlayerToTeam(teamName, successor);
+
+    teamManager.kickPlayerFromTeam(teamName, leader, leader.getName());
+
+    assertNull(teamManager.getPlayerTeam(leader));
+    assertEquals(teamName, teamManager.getPlayerTeam(successor));
+    assertEquals(successor.getName(), teamManager.getTeamLeader(teamName));
+    assertFalse(teamManager.getTeamMembers(teamName).contains(leader.getName()));
+  }
+
+  @Test
   void playerListNameUpdatedOnPrefixAndColorChange() {
     PlayerMock leader = server.addPlayer("StyleLeader");
     PlayerMock member = server.addPlayer("StyleMember");


### PR DESCRIPTION
## Summary
- block team admins from issuing /teamadmin kick against themselves with a warning
- delegate self-kick attempts at the service layer to the removal flow so leadership is reassigned
- add a regression test ensuring the team remains consistent when a leader tries to kick themself

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cd6a475f2c832e9d15b0448f7bc6c3