### PR TITLE
Adjust deadline enforcement for reload

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -134,9 +134,20 @@ public class DeadlineScheduler {
    * записи для команд с допустимым размером.
    */
   public void enforceTeamSizes() {
+    enforceTeamSizes(false);
+  }
+
+  /**
+   * Фиксирует команды, превышающие лимит участников, и назначает им дедлайны на сокращение, очищая
+   * записи для команд с допустимым размером.
+   *
+   * @param triggeredByReload {@code true}, если проверка вызвана перезагрузкой плагина или сервера
+   */
+  public void enforceTeamSizes(boolean triggeredByReload) {
     int max = pluginConfig.getMaxMembers();
     boolean changed = false;
-    boolean enforceOnReload = pluginConfig.isEnforceMaxMembersOnReload();
+    boolean enforcementEnabled =
+        !triggeredByReload || pluginConfig.isEnforceMaxMembersOnReload();
     boolean graceEnabled =
         pluginConfig.isGracePeriodEnabled() && pluginConfig.getGracePeriodMinutes() > 0;
 
@@ -152,7 +163,7 @@ public class DeadlineScheduler {
       return;
     }
 
-    if (!enforceOnReload && !deadlines.isEmpty()) {
+    if (!enforcementEnabled && !deadlines.isEmpty()) {
       deadlines.clear();
       changed = true;
       resetAllLeaderDisplays();
@@ -175,7 +186,7 @@ public class DeadlineScheduler {
           .getLogger()
           .warning("Команда " + team.getName() + " превышает лимит: " + size + " из " + max + ".");
 
-      if (!enforceOnReload) {
+      if (!enforcementEnabled) {
         Component leaderMessage = buildEnforcementDisabledMessage(max, excess);
         notifyLeader(team, leaderMessage);
         notifyAdmins(

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -57,7 +57,7 @@ public class MembershipService {
     storage.getPlayerTeams().put(leader.getName(), team.getId());
     TeamMessageUtils.sendTeamMessage(
         leader, Component.text("✅ Команда создана", NamedTextColor.GREEN));
-    scheduler.enforceTeamSizes();
+    scheduler.enforceTeamSizes(false);
   }
 
   public void addPlayerToTeam(String teamName, @NotNull Player player) {
@@ -86,7 +86,7 @@ public class MembershipService {
     storage.markTeamDirty(team);
     TeamMessageUtils.sendTeamMessage(
         player, Component.text("✅ Вы вступили в команду", NamedTextColor.GREEN));
-    scheduler.enforceTeamSizes();
+    scheduler.enforceTeamSizes(false);
     updateTeamMembersPrefixes(team);
   }
 
@@ -112,7 +112,7 @@ public class MembershipService {
     if (!removedTeam) {
       storage.markTeamDirty(team);
     }
-    scheduler.enforceTeamSizes();
+    scheduler.enforceTeamSizes(false);
     notifyPrefixUpdate(player, null);
     if (!removedTeam) {
       updateTeamMembersPrefixes(team);
@@ -133,7 +133,7 @@ public class MembershipService {
     team.removeMember(targetName);
     storage.getPlayerTeams().remove(targetName);
     storage.markTeamDirty(team);
-    scheduler.enforceTeamSizes();
+    scheduler.enforceTeamSizes(false);
     notifyPrefixUpdate(targetName, null);
     updateTeamMembersPrefixes(team);
   }
@@ -164,7 +164,7 @@ public class MembershipService {
     for (String memberName : members) {
       storage.getPlayerTeams().remove(memberName);
     }
-    scheduler.enforceTeamSizes();
+    scheduler.enforceTeamSizes(false);
   }
 
   public void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader) {

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -24,7 +24,7 @@ public class TeamManager implements TeamService {
     this.storage = new TeamStorage(plugin, pluginConfig);
     this.scheduler = new DeadlineScheduler(plugin, pluginConfig, storage);
     this.storage.loadTeams(scheduler.getDeadlines());
-    this.scheduler.enforceTeamSizes();
+    this.scheduler.enforceTeamSizes(true);
     this.storage.startAutoSave(pluginConfig.getSaveIntervalSeconds(), scheduler.getDeadlines());
     this.scheduler.start();
     this.membership = new MembershipService(plugin, pluginConfig, storage, scheduler);
@@ -152,7 +152,7 @@ public class TeamManager implements TeamService {
     storage.loadTeams(scheduler.getDeadlines());
     storage.getTeams().values().forEach(membership::updateTeamMembersPrefixes);
     scheduler.resetLeaderDisplays();
-    scheduler.enforceTeamSizes();
+    scheduler.enforceTeamSizes(true);
     scheduler.start();
     storage.startAutoSave(pluginConfig.getSaveIntervalSeconds(), scheduler.getDeadlines());
   }

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -249,6 +249,45 @@ class TeamCommandTest {
   }
 
   @Test
+  void keepsBlockingJoinsAfterReloadWhenEnforcementDisabled() {
+    config.set("team.max-members", 0);
+    config.set("team.grace-period-enabled", true);
+    config.set("team.grace-period-minutes", 5);
+    config.set("team.enforce-max-members-on-reload", false);
+
+    PlayerMock leader = server.addPlayer("ReloadLeader");
+    PlayerMock memberOne = server.addPlayer("ReloadMemberOne");
+    PlayerMock memberTwo = server.addPlayer("ReloadMemberTwo");
+
+    teamManager.createTeam("Reloaded", "RL", "WHITE", leader);
+    teamManager.addPlayerToTeam("Reloaded", memberOne);
+    teamManager.addPlayerToTeam("Reloaded", memberTwo);
+
+    assertEquals(3, teamManager.getTeamMembers("Reloaded").size());
+
+    config.set("team.max-members", 1);
+
+    scheduler.enforceTeamSizes(true);
+    assertTrue(scheduler.getDeadlines().isEmpty());
+
+    teamManager.removePlayerFromTeam("Reloaded", memberOne);
+
+    assertEquals(2, teamManager.getTeamMembers("Reloaded").size());
+    Long deadline = scheduler.getTeamDeadline("Reloaded");
+    assertNotNull(deadline);
+
+    PlayerMock lateJoiner = server.addPlayer("LateJoiner");
+    teamManager.addPlayerToTeam("Reloaded", lateJoiner);
+
+    Component msg = lateJoiner.nextComponentMessage();
+    assertNotNull(msg);
+    String plain = PlainTextComponentSerializer.plainText().serialize(msg);
+    assertTrue(plain.contains("Команда полная"));
+    assertNull(teamManager.getPlayerTeam(lateJoiner));
+    assertEquals(deadline, scheduler.getTeamDeadline("Reloaded"));
+  }
+
+  @Test
   void rejectsInvalidTeamName() {
     CommandMap commandMap = server.getCommandMap();
     PlayerMock player = server.addPlayer("Leader");


### PR DESCRIPTION
## Summary
- add a reload-aware overload of DeadlineScheduler#enforceTeamSizes so regular gameplay always applies limits
- update TeamManager and MembershipService to call the appropriate overloads for reload-time vs runtime enforcement
- cover the regression with a MockBukkit test ensuring joins remain blocked when reload enforcement is disabled

## Testing
- ./gradlew test --console=plain --stacktrace

------
https://chatgpt.com/codex/tasks/task_e_68cd92999f88832ea940b949e3eb7f97