### PR TITLE
Handle scoreboard cleanup when enforcement disabled

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,7 @@ repositories {
     maven("https://repo.purpurmc.org/snapshots/") // Репозиторий для Purpur
     maven("https://hub.spigotmc.org/nexus/content/repositories/snapshots/") // Репозиторий для Spigot
     maven("https://papermc.io/repo/repository/maven-public/")
+    maven("https://repo.codemc.org/repository/maven-public/")
     mavenCentral() // Репозиторий для библиотек, таких как Kyori Adventure
 }
 
@@ -25,6 +26,8 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
     testImplementation("com.github.seeseemelk:MockBukkit-v1.21:3.133.2")
+    testImplementation("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
+    testImplementation("org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT")
 }
 
 tasks.jar {

--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -176,8 +176,8 @@ public class DeadlineScheduler {
       if (size <= max) {
         if (deadlines.remove(teamId) != null) {
           changed = true;
-          clearLeaderDisplay(team);
         }
+        clearLeaderDisplay(team);
         continue;
       }
 
@@ -188,7 +188,13 @@ public class DeadlineScheduler {
 
       if (!enforcementEnabled) {
         Component leaderMessage = buildEnforcementDisabledMessage(max, excess);
-        notifyLeader(team, leaderMessage);
+        DeadlineDisplayMode mode = getDisplayMode();
+        if (mode == DeadlineDisplayMode.SCOREBOARD) {
+          notifyLeaderWithoutScoreboard(team, leaderMessage);
+          clearLeaderDisplay(team);
+        } else {
+          notifyLeader(team, leaderMessage);
+        }
         notifyAdmins(
             adminBaseMessage(team, size, max)
                 .append(Component.space())
@@ -549,6 +555,18 @@ public class DeadlineScheduler {
       case SCOREBOARD -> sendScoreboardMessage(leader, message);
       case CHAT -> TeamMessageUtils.sendTeamMessage(leader, message);
     }
+  }
+
+  private void notifyLeaderWithoutScoreboard(@NotNull Team team, @NotNull Component message) {
+    String leaderName = team.getLeader();
+    if (leaderName == null || leaderName.isBlank()) {
+      return;
+    }
+    Player leader = plugin.getServer().getPlayer(leaderName);
+    if (leader == null) {
+      return;
+    }
+    TeamMessageUtils.sendTeamMessage(leader, message);
   }
 
   private void notifyAdmins(Component message) {

--- a/src/test/java/org/example/service/DeadlineSchedulerTest.java
+++ b/src/test/java/org/example/service/DeadlineSchedulerTest.java
@@ -1,0 +1,81 @@
+package org.example.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.UUID;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.example.config.PluginConfig;
+import org.example.model.Team;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+
+class DeadlineSchedulerTest {
+
+  private ServerMock server;
+  private JavaPlugin plugin;
+
+  @BeforeEach
+  void setUp() {
+    server = MockBukkit.mock();
+    plugin = MockBukkit.createMockPlugin();
+  }
+
+  @AfterEach
+  void tearDown() {
+    MockBukkit.unmock();
+  }
+
+  @Test
+  void clearsScoreboardWhenTeamTrimmedAfterReloadWithEnforcementDisabled() throws IOException {
+    prepareConfig();
+    PluginConfig config = new PluginConfig(plugin);
+    TeamStorage storage = new TeamStorage(plugin, config);
+    DeadlineScheduler scheduler = new DeadlineScheduler(plugin, config, storage);
+
+    Team team = new Team(UUID.randomUUID(), "Alpha", "Leader", "", "WHITE");
+    team.setMembers(List.of("Leader", "MemberOne", "MemberTwo"));
+    storage.getTeams().put(team.getId(), team);
+
+    PlayerMock leader = server.addPlayer("Leader");
+    Scoreboard original = leader.getScoreboard();
+
+    scheduler.enforceTeamSizes(false);
+    assertNotNull(leader.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+
+    scheduler.getDeadlines().clear();
+    assertNotNull(leader.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+
+    team.setMembers(List.of("Leader", "MemberOne"));
+    scheduler.enforceTeamSizes(true);
+
+    assertNull(leader.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+    assertSame(original, leader.getScoreboard());
+  }
+
+  private void prepareConfig() throws IOException {
+    File dataFolder = plugin.getDataFolder();
+    if (!dataFolder.exists() && !dataFolder.mkdirs()) {
+      fail("Failed to create plugin data folder");
+    }
+    File configFile = new File(dataFolder, "config.yml");
+    String contents =
+        "team:\n"
+            + "  max-members: 2\n"
+            + "  enforce-max-members-on-reload: false\n"
+            + "  grace-period-enabled: true\n"
+            + "  grace-period-minutes: 5\n"
+            + "  deadline-display-mode: SCOREBOARD\n";
+    Files.writeString(configFile.toPath(), contents, StandardCharsets.UTF_8);
+  }
+}


### PR DESCRIPTION
## Summary
- always clear leader displays when teams drop back under the size limit
- fall back to chat messaging when enforcement is disabled and deadline display mode is SCOREBOARD
- cover the regression with a MockBukkit-based test and wire test dependencies

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68cd9f822f14832ea336a70f173e3d8c