### PR TITLE
Retarget deadline warnings when leadership changes

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -289,6 +289,46 @@ public class DeadlineScheduler {
     }
   }
 
+  public void handleLeaderTransfer(@NotNull Team team) {
+    if (team == null) {
+      return;
+    }
+    UUID teamId = team.getId();
+    Long deadlineAt = deadlines.get(teamId);
+    if (deadlineAt == null) {
+      String previousLeader = teamLeaderNames.get(teamId);
+      String currentLeader = team.getLeader();
+      if (previousLeader != null && currentLeader != null && !previousLeader.equalsIgnoreCase(currentLeader)) {
+        clearLeaderDisplay(previousLeader);
+      }
+      return;
+    }
+    int max = pluginConfig.getMaxMembers();
+    if (max <= 0) {
+      return;
+    }
+    int excess = Math.max(0, team.getMembers().size() - max);
+    if (excess <= 0) {
+      return;
+    }
+    long remainingMillis = Math.max(0L, deadlineAt - System.currentTimeMillis());
+    long minutesLeft = TimeUnit.MILLISECONDS.toMinutes(remainingMillis);
+    long secondsLeft =
+        TimeUnit.MILLISECONDS.toSeconds(remainingMillis)
+            - TimeUnit.MINUTES.toSeconds(minutesLeft);
+    Component message = TeamMessageUtils.deadlineRemainingMessage(minutesLeft, secondsLeft, excess);
+    notifyLeader(team, message);
+    if (getDisplayMode() == DeadlineDisplayMode.SCOREBOARD) {
+      String leaderName = team.getLeader();
+      if (leaderName != null && !leaderName.isBlank()) {
+        Player leader = plugin.getServer().getPlayer(leaderName);
+        if (leader != null) {
+          TeamMessageUtils.sendTeamMessage(leader, message);
+        }
+      }
+    }
+  }
+
   /**
    * Проверяет, истекли ли дедлайны команд, и при необходимости удаляет лишних игроков,
    * синхронизируя изменения с хранилищем.

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -147,6 +147,8 @@ public class MembershipService {
     if (!team.hasMember(newLeader.getName())) return;
     team.setLeader(newLeader.getName());
     storage.markTeamDirty(team);
+    scheduler.handleLeaderTransfer(team);
+    scheduler.enforceTeamSizes(false);
   }
 
   public void disbandTeam(String teamName, @NotNull Player leader) {

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -1,0 +1,91 @@
+package org.example.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.UUID;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scoreboard.DisplaySlot;
+import org.bukkit.scoreboard.Scoreboard;
+import org.example.config.PluginConfig;
+import org.example.model.Team;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class MembershipServiceTest {
+
+  private ServerMock server;
+  private JavaPlugin plugin;
+
+  @BeforeEach
+  void setUp() {
+    server = MockBukkit.mock();
+    plugin = MockBukkit.createMockPlugin();
+  }
+
+  @AfterEach
+  void tearDown() {
+    MockBukkit.unmock();
+  }
+
+  @Test
+  void transferLeadershipRetargetsDeadlineWarning() throws IOException {
+    prepareConfig();
+    PluginConfig config = new PluginConfig(plugin);
+    TeamStorage storage = new TeamStorage(plugin, config);
+    DeadlineScheduler scheduler = new DeadlineScheduler(plugin, config, storage);
+    MembershipService membershipService =
+        new MembershipService(plugin, config, storage, scheduler);
+
+    Team team = new Team(UUID.randomUUID(), "Alpha", "Captain", "AA", "WHITE");
+    team.setMembers(List.of("Captain", "Successor", "Reserve"));
+    storage.getTeams().put(team.getId(), team);
+    storage.getPlayerTeams().put("Captain", team.getId());
+    storage.getPlayerTeams().put("Successor", team.getId());
+    storage.getPlayerTeams().put("Reserve", team.getId());
+
+    PlayerMock captain = server.addPlayer("Captain");
+    PlayerMock successor = server.addPlayer("Successor");
+    Scoreboard captainOriginal = captain.getScoreboard();
+    Scoreboard successorOriginal = successor.getScoreboard();
+
+    scheduler.enforceTeamSizes(false);
+
+    assertNotNull(captain.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+    assertSame(successorOriginal, successor.getScoreboard());
+    assertNull(successor.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+
+    membershipService.transferLeadership("Alpha", captain, successor);
+
+    assertSame(captainOriginal, captain.getScoreboard());
+    assertNull(captain.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+
+    assertNotSame(successorOriginal, successor.getScoreboard());
+    assertNotNull(successor.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+  }
+
+  private void prepareConfig() throws IOException {
+    File dataFolder = plugin.getDataFolder();
+    if (!dataFolder.exists() && !dataFolder.mkdirs()) {
+      fail("Failed to create plugin data folder");
+    }
+    File configFile = new File(dataFolder, "config.yml");
+    String contents =
+        "team:\n"
+            + "  max-members: 2\n"
+            + "  enforce-max-members-on-reload: true\n"
+            + "  grace-period-enabled: true\n"
+            + "  grace-period-minutes: 5\n"
+            + "  deadline-display-mode: SCOREBOARD\n";
+    Files.writeString(configFile.toPath(), contents, StandardCharsets.UTF_8);
+  }
+}
+


### PR DESCRIPTION
## Summary
- call into the deadline scheduler whenever team leadership is transferred so limits are re-evaluated immediately
- add a scheduler helper that retargets active deadline warnings to the new captain and pings them in chat when scoreboard mode is active
- cover the leadership transfer scenario with a scoreboard deadline test to verify the warning moves to the new leader

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cdaa5e4250832eb92cf52fcc581926