### PR TITLE
Use TeamUtils for team prefix components

### DIFF
--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -11,6 +11,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.example.MyPurpurPlugin;
 import org.example.service.TeamService;
 import org.example.util.TeamMessageUtils;
+import org.example.util.TeamUtils;
 import org.jetbrains.annotations.NotNull;
 
 /** Слушатель событий, связанных с командами и чатом игроков. */
@@ -66,7 +67,7 @@ public class TeamChatListener implements Listener {
     if (teamName != null) {
       String prefix = teamManager.getTeamPrefix(teamName);
       NamedTextColor teamColor = teamManager.getTeamColor(teamName);
-      Component prefixComponent = Component.text("[" + prefix + "] ", teamColor);
+      Component prefixComponent = TeamUtils.createPrefixComponent(prefix, teamColor);
 
       event.renderer(
           (source, sourceDisplayName, message, viewer) ->
@@ -109,7 +110,7 @@ public class TeamChatListener implements Listener {
     if (teamName != null) {
       String prefix = teamManager.getTeamPrefix(teamName);
       NamedTextColor teamColor = teamManager.getTeamColor(teamName);
-      Component prefixComponent = Component.text("[" + prefix + "] ", teamColor);
+      Component prefixComponent = TeamUtils.createPrefixComponent(prefix, teamColor);
       player.playerListName(
           prefixComponent.append(Component.text(player.getName(), NamedTextColor.WHITE)));
     } else {


### PR DESCRIPTION
## Summary
- reuse TeamUtils.createPrefixComponent when building team prefixes in TeamChatListener
- ensure both chat messages and tab-list prefixes append the shared component helper

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ce7b35e7c8832ebf041e50e3ca2e4a