### PR TITLE
Handle deadline handoff when leaders leave

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -293,15 +293,15 @@ public class DeadlineScheduler {
       return;
     }
     UUID teamId = team.getId();
+    String currentLeader = team.getLeader();
+    String previousLeader = teamLeaderNames.get(teamId);
+    if (previousLeader != null
+        && (currentLeader == null || !previousLeader.equalsIgnoreCase(currentLeader))) {
+      teamLeaderNames.remove(teamId, previousLeader);
+      clearLeaderDisplay(previousLeader);
+    }
     Long deadlineAt = deadlines.get(teamId);
     if (deadlineAt == null) {
-      String previousLeader = teamLeaderNames.get(teamId);
-      String currentLeader = team.getLeader();
-      if (previousLeader != null
-          && currentLeader != null
-          && !previousLeader.equalsIgnoreCase(currentLeader)) {
-        clearLeaderDisplay(previousLeader);
-      }
       return;
     }
     int max = pluginConfig.getMaxMembers();

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -106,6 +106,7 @@ public class MembershipService {
         removedTeam = true;
       } else {
         team.setLeader(team.getMembers().get(0));
+        scheduler.handleLeaderTransfer(team);
       }
     }
     // Отмечаем изменившуюся команду и пересчитываем дедлайны.

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -71,6 +71,41 @@ class MembershipServiceTest {
     assertNotNull(successor.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
   }
 
+  @Test
+  void removingLeaderRetargetsDeadlineWarning() throws IOException {
+    prepareConfig();
+    PluginConfig config = new PluginConfig(plugin);
+    TeamStorage storage = new TeamStorage(plugin, config);
+    DeadlineScheduler scheduler = new DeadlineScheduler(plugin, config, storage);
+    MembershipService membershipService = new MembershipService(plugin, config, storage, scheduler);
+
+    Team team = new Team(UUID.randomUUID(), "Alpha", "Captain", "AA", "WHITE");
+    team.setMembers(List.of("Captain", "Successor", "Reserve"));
+    storage.getTeams().put(team.getId(), team);
+    storage.getPlayerTeams().put("Captain", team.getId());
+    storage.getPlayerTeams().put("Successor", team.getId());
+    storage.getPlayerTeams().put("Reserve", team.getId());
+
+    PlayerMock captain = server.addPlayer("Captain");
+    PlayerMock successor = server.addPlayer("Successor");
+    Scoreboard captainOriginal = captain.getScoreboard();
+    Scoreboard successorOriginal = successor.getScoreboard();
+
+    scheduler.enforceTeamSizes(false);
+
+    assertNotNull(captain.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+    assertNull(successor.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+
+    membershipService.removePlayerFromTeam("Alpha", captain);
+
+    assertSame(captainOriginal, captain.getScoreboard());
+    assertNull(captain.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+
+    assertEquals("Successor", team.getLeader());
+    assertNotSame(successorOriginal, successor.getScoreboard());
+    assertNotNull(successor.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+  }
+
   private void prepareConfig() throws IOException {
     File dataFolder = plugin.getDataFolder();
     if (!dataFolder.exists() && !dataFolder.mkdirs()) {


### PR DESCRIPTION
## Summary
- call `DeadlineScheduler.handleLeaderTransfer` when a leader leaves and a successor is promoted
- clear cached deadline displays for the previous leader before notifying the replacement
- cover the leader departure deadline handoff with a regression test

## Testing
- ./gradlew clean test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ce8ed9cd48832e9dad6c2de10cb345