### PR TITLE
Cache player prefixes to skip redundant updates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     testImplementation("com.github.seeseemelk:MockBukkit-v1.21:3.133.2")
     testImplementation("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
     testImplementation("org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT")
+    testImplementation("org.mockito:mockito-core:5.12.0")
 }
 
 tasks.jar {

--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -1,6 +1,10 @@
 package org.example.listener;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -18,6 +22,7 @@ import org.jetbrains.annotations.NotNull;
 public class TeamChatListener implements Listener {
 
   private final TeamService teamManager;
+  private final Map<UUID, Component> lastPlayerPrefixes = new ConcurrentHashMap<>();
 
   public TeamChatListener(@NotNull TeamService teamManager) {
     this.teamManager = teamManager;
@@ -51,6 +56,7 @@ public class TeamChatListener implements Listener {
   @EventHandler
   public void onPlayerQuit(@NotNull PlayerQuitEvent event) {
     Player player = event.getPlayer();
+    lastPlayerPrefixes.remove(player.getUniqueId());
     ((MyPurpurPlugin) teamManager.getPlugin())
         .debugTeamAction("Игрок вышел", player.getName(), null);
   }
@@ -88,22 +94,30 @@ public class TeamChatListener implements Listener {
   public void onPlayerPrefixUpdate(@NotNull PlayerPrefixUpdateEvent event) {
     Player player = event.getPlayer();
     Component prefix = event.getPrefix();
+    UUID playerId = player.getUniqueId();
     ((MyPurpurPlugin) teamManager.getPlugin())
         .debugTeamAction("Обновление префикса для игрока", player.getName(), null);
 
     if (prefix != null) {
+      Component cachedPrefix = lastPlayerPrefixes.get(playerId);
+      if (Objects.equals(cachedPrefix, prefix)) {
+        return;
+      }
       ((MyPurpurPlugin) teamManager.getPlugin())
           .debug("Устанавливаем префикс для игрока " + player.getName() + ": " + prefix);
+      lastPlayerPrefixes.put(playerId, prefix);
       player.playerListName(prefix.append(Component.text(player.getName(), NamedTextColor.WHITE)));
     } else {
       ((MyPurpurPlugin) teamManager.getPlugin())
           .debug("Сбрасываем префикс для игрока " + player.getName());
+      lastPlayerPrefixes.remove(playerId);
       player.playerListName(Component.text(player.getName(), NamedTextColor.WHITE));
     }
   }
 
   private void updatePlayerPrefix(@NotNull Player player) {
     String teamName = teamManager.getPlayerTeam(player);
+    UUID playerId = player.getUniqueId();
     ((MyPurpurPlugin) teamManager.getPlugin())
         .debugTeamAction("Обновление префикса для игрока", player.getName(), teamName);
 
@@ -111,9 +125,11 @@ public class TeamChatListener implements Listener {
       String prefix = teamManager.getTeamPrefix(teamName);
       NamedTextColor teamColor = teamManager.getTeamColor(teamName);
       Component prefixComponent = TeamUtils.createPrefixComponent(prefix, teamColor);
+      lastPlayerPrefixes.put(playerId, prefixComponent);
       player.playerListName(
           prefixComponent.append(Component.text(player.getName(), NamedTextColor.WHITE)));
     } else {
+      lastPlayerPrefixes.remove(playerId);
       player.playerListName(Component.text(player.getName(), NamedTextColor.WHITE));
     }
   }

--- a/src/test/java/org/example/service/TeamManagerTest.java
+++ b/src/test/java/org/example/service/TeamManagerTest.java
@@ -8,15 +8,19 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.example.MyPurpurPlugin;
 import org.example.config.PluginConfig;
+import org.example.listener.TeamChatListener;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
 /** Unit tests for {@link TeamManager}. */
 class TeamManagerTest {
@@ -229,5 +233,35 @@ class TeamManagerTest {
         Component.text("[NW] ", NamedTextColor.RED)
             .append(Component.text(leader.getName(), NamedTextColor.WHITE));
     assertEquals(leaderRecolored, leader.playerListName());
+  }
+
+  @Test
+  void duplicatePrefixUpdatesTriggerSingleListNameChange() {
+    TeamChatListener listener = new TeamChatListener(teamManager);
+    org.bukkit.entity.Player player = Mockito.mock(org.bukkit.entity.Player.class);
+    UUID playerId = UUID.randomUUID();
+    Mockito.when(player.getUniqueId()).thenReturn(playerId);
+    Mockito.when(player.getName()).thenReturn("Duplicate");
+
+    Component prefix = Component.text("[DP] ", NamedTextColor.BLUE);
+
+    listener.onPlayerPrefixUpdate(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefix));
+    listener.onPlayerPrefixUpdate(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefix));
+    listener.onPlayerPrefixUpdate(new TeamChatListener.PlayerPrefixUpdateEvent(player, null));
+    listener.onPlayerPrefixUpdate(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefix));
+
+    ArgumentCaptor<Component> captor = ArgumentCaptor.forClass(Component.class);
+    Mockito.verify(player, Mockito.times(3)).playerListName(captor.capture());
+
+    List<Component> updates = captor.getAllValues();
+    Component expectedPrefix =
+        Component.text("[DP] ", NamedTextColor.BLUE)
+            .append(Component.text("Duplicate", NamedTextColor.WHITE));
+    Component expectedReset = Component.text("Duplicate", NamedTextColor.WHITE);
+
+    assertEquals(3, updates.size());
+    assertEquals(expectedPrefix, updates.get(0));
+    assertEquals(expectedReset, updates.get(1));
+    assertEquals(expectedPrefix, updates.get(2));
   }
 }


### PR DESCRIPTION
## Summary
- track the last applied prefix component per player inside `TeamChatListener`
- skip reapplying identical prefixes and clear the cache when prefixes reset
- cover the behaviour with a new MockBukkit test and add Mockito as a test dependency

## Testing
- `./gradlew spotlessApply --console=plain`
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68ce91d3a888832eab3c1df1c8737825