### PR TITLE
Clear deadline warnings when teams disband

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -105,6 +105,27 @@ public class DeadlineScheduler {
   }
 
   /**
+   * Принудительно завершает льготный период указанной команды, очищая связанные уведомления
+   * лидера.
+   */
+  public void cancelDeadline(@NotNull Team team) {
+    if (team == null) {
+      return;
+    }
+    UUID teamId = team.getId();
+    boolean removed = deadlines.remove(teamId) != null;
+    String leaderName = teamLeaderNames.remove(teamId);
+    if (leaderName != null) {
+      clearLeaderDisplay(leaderName);
+    } else {
+      clearLeaderDisplay(team);
+    }
+    if (removed) {
+      storage.markDeadlinesDirty();
+    }
+  }
+
+  /**
    * Запускает периодическую проверку дедлайнов и автоматически перезапускает задачу, если она уже
    * была активна.
    */

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -102,6 +102,7 @@ public class MembershipService {
     // Если ушедший игрок был лидером, либо закрываем команду, либо назначаем нового.
     if (team.isLeader(player.getName())) {
       if (team.getMembers().isEmpty()) {
+        scheduler.cancelDeadline(team);
         storage.removeTeam(team);
         removedTeam = true;
       } else {
@@ -158,6 +159,7 @@ public class MembershipService {
     if (team == null || !team.isLeader(leader.getName())) return;
     // Сохраняем список участников до удаления, чтобы очистить их отображаемые префиксы.
     List<String> members = team.getMembers();
+    scheduler.cancelDeadline(team);
     // Удаляем команду и уведомляем игроков о сбросе префикса.
     storage.removeTeam(team);
     for (String memberName : members) {

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -106,6 +106,36 @@ class MembershipServiceTest {
     assertNotNull(successor.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
   }
 
+  @Test
+  void disbandingTeamClearsDeadlineWarningImmediately() throws IOException {
+    prepareConfig();
+    PluginConfig config = new PluginConfig(plugin);
+    TeamStorage storage = new TeamStorage(plugin, config);
+    DeadlineScheduler scheduler = new DeadlineScheduler(plugin, config, storage);
+    MembershipService membershipService = new MembershipService(plugin, config, storage, scheduler);
+
+    Team team = new Team(UUID.randomUUID(), "Alpha", "Captain", "AA", "WHITE");
+    team.setMembers(List.of("Captain", "MemberOne", "MemberTwo"));
+    storage.getTeams().put(team.getId(), team);
+    storage.getPlayerTeams().put("Captain", team.getId());
+    storage.getPlayerTeams().put("MemberOne", team.getId());
+    storage.getPlayerTeams().put("MemberTwo", team.getId());
+
+    PlayerMock captain = server.addPlayer("Captain");
+    Scoreboard captainOriginal = captain.getScoreboard();
+
+    scheduler.enforceTeamSizes(false);
+
+    assertNotNull(captain.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+    assertNotSame(captainOriginal, captain.getScoreboard());
+
+    membershipService.disbandTeam("Alpha", captain);
+
+    assertTrue(scheduler.getDeadlines().isEmpty());
+    assertSame(captainOriginal, captain.getScoreboard());
+    assertNull(captain.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
+  }
+
   private void prepareConfig() throws IOException {
     File dataFolder = plugin.getDataFolder();
     if (!dataFolder.exists() && !dataFolder.mkdirs()) {


### PR DESCRIPTION
## Summary
- add a `cancelDeadline` helper that removes deadline metadata and clears leader warnings immediately
- call the helper when a leader leaves a team or disbands it so warnings disappear right away
- cover the regression with a membership service test that ensures a disbanded team loses its warning in the same tick

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cea8c3bdb8832e99040064bb1eab0f