### PR TITLE
Handle invalid team entries in loader

### DIFF
--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -60,9 +60,31 @@ public class TeamStorage {
     var section = teamsConfig.getConfigurationSection("teams");
     if (section != null) {
       for (String teamIdStr : section.getKeys(false)) {
-        UUID teamId = UUID.fromString(teamIdStr);
+        UUID teamId;
+        try {
+          teamId = UUID.fromString(teamIdStr);
+        } catch (IllegalArgumentException ex) {
+          plugin
+              .getLogger()
+              .warning("Skipping team entry with invalid UUID '" + teamIdStr + "'.");
+          continue;
+        }
         String name = teamsConfig.getString("teams." + teamIdStr + ".name", "");
+        if (name == null || name.isBlank()) {
+          plugin
+              .getLogger()
+              .warning(
+                  "Skipping team entry " + teamId + " because it does not define a name.");
+          continue;
+        }
         String leader = teamsConfig.getString("teams." + teamIdStr + ".leader", "");
+        if (leader == null || leader.isBlank()) {
+          plugin
+              .getLogger()
+              .warning(
+                  "Skipping team entry " + teamId + " because it does not define a leader.");
+          continue;
+        }
         String prefix = teamsConfig.getString("teams." + teamIdStr + ".prefix", "");
         String color =
             normalizeColorKey(teamsConfig.getString("teams." + teamIdStr + ".color", "WHITE"));

--- a/src/test/java/org/example/service/TeamStorageTest.java
+++ b/src/test/java/org/example/service/TeamStorageTest.java
@@ -85,4 +85,32 @@ class TeamStorageTest {
 
     assertEquals(deadline, reloadedDeadlines.get(teamId));
   }
+
+  @Test
+  void loadTeamsSkipsEntriesWithInvalidUuid() throws IOException {
+    TeamStorage storage = new TeamStorage(plugin, null);
+    Map<UUID, Long> deadlines = new HashMap<>();
+    storage.loadTeams(deadlines);
+
+    File teamsFile = new File(plugin.getDataFolder(), "teams.yml");
+    YamlConfiguration config = YamlConfiguration.loadConfiguration(teamsFile);
+
+    config.set("teams.not-a-uuid.name", "BrokenTeam");
+    config.set("teams.not-a-uuid.leader", "Nobody");
+
+    UUID validId = UUID.randomUUID();
+    config.set("teams." + validId + ".name", "ValidTeam");
+    config.set("teams." + validId + ".leader", "Leader");
+    config.save(teamsFile);
+
+    TeamStorage reloaded = new TeamStorage(plugin, null);
+    Map<UUID, Long> reloadedDeadlines = new HashMap<>();
+    reloaded.loadTeams(reloadedDeadlines);
+
+    assertEquals(1, reloaded.getTeams().size(), "Only the valid team should be loaded");
+    Team loadedTeam = reloaded.getTeams().get(validId);
+    assertNotNull(loadedTeam, "Valid team should be present after reload");
+    assertEquals("ValidTeam", loadedTeam.getName());
+    assertTrue(reloadedDeadlines.isEmpty(), "Invalid entries should not add deadlines");
+  }
 }


### PR DESCRIPTION
## Summary
- skip team entries with invalid UUIDs when loading from `teams.yml`
- validate required name and leader fields before constructing team objects
- ensure a malformed entry does not block loading by adding a regression test

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cebe573df0832ea50c6ac92ffd66f6