### PR TITLE
Use UUID-backed team members and migrate storage

### DIFF
--- a/src/main/java/org/example/command/TeamAdminCommand.java
+++ b/src/main/java/org/example/command/TeamAdminCommand.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.Command;
@@ -265,14 +266,16 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
         if (args[0].equalsIgnoreCase("transfer") || args[0].equalsIgnoreCase("kick")) {
           String teamName = teamManager.getPlayerTeam(player);
           if (teamName != null && teamManager.getTeamIdByName(teamName) != null) {
-            String leaderName = teamManager.getTeamLeader(teamName);
-            if (player.getName().equals(leaderName)) {
-              List<String> members = teamManager.getTeamMembers(teamName);
-              for (String memberName : members) {
-                if (!memberName.equals(player.getName())
-                    && memberName
-                        .toLowerCase(Locale.ROOT)
-                        .startsWith(args[1].toLowerCase(Locale.ROOT))) {
+            UUID leaderId = teamManager.getTeamLeaderId(teamName);
+            if (player.getUniqueId().equals(leaderId)) {
+              List<UUID> members = teamManager.getTeamMembers(teamName);
+              String lowerInput = args[1].toLowerCase(Locale.ROOT);
+              for (UUID memberId : members) {
+                if (memberId.equals(player.getUniqueId())) {
+                  continue;
+                }
+                String memberName = resolveName(memberId);
+                if (memberName.toLowerCase(Locale.ROOT).startsWith(lowerInput)) {
                   suggestions.add(memberName);
                 }
               }
@@ -297,5 +300,13 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       Collections.sort(suggestions);
     }
     return suggestions;
+  }
+
+  private String resolveName(UUID playerId) {
+    if (playerId == null) {
+      return "";
+    }
+    String name = teamManager.getPlugin().getServer().getOfflinePlayer(playerId).getName();
+    return name != null ? name : playerId.toString();
   }
 }

--- a/src/main/java/org/example/command/sub/JoinSubCommand.java
+++ b/src/main/java/org/example/command/sub/JoinSubCommand.java
@@ -3,6 +3,7 @@ package org.example.command.sub;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
@@ -41,8 +42,8 @@ public class JoinSubCommand implements SubCommand {
       if (playerTeam == null) {
         String partial = args[1].toLowerCase(Locale.ROOT);
         for (String teamName : teamService.getTeamNames()) {
-          String leader = teamService.getTeamLeader(teamName);
-          if (leader == null || !leader.equals(player.getName())) {
+          UUID leaderId = teamService.getTeamLeaderId(teamName);
+          if (leaderId == null || !leaderId.equals(player.getUniqueId())) {
             if (teamName.toLowerCase(Locale.ROOT).startsWith(partial)) {
               suggestions.add(teamName);
             }

--- a/src/main/java/org/example/command/sub/MembersSubCommand.java
+++ b/src/main/java/org/example/command/sub/MembersSubCommand.java
@@ -1,6 +1,7 @@
 package org.example.command.sub;
 
 import java.util.List;
+import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -28,7 +29,7 @@ public class MembersSubCommand implements SubCommand {
       return true;
     }
 
-    List<String> members = teamService.getTeamMembers(playerTeam);
+    List<UUID> members = teamService.getTeamMembers(playerTeam);
     String prefix = teamService.getTeamPrefix(playerTeam);
     NamedTextColor color = teamService.getTeamColor(playerTeam);
     Component prefixComponent = TeamUtils.createPrefixComponent(prefix, color);
@@ -39,8 +40,9 @@ public class MembersSubCommand implements SubCommand {
     player.sendMessage(Component.text(""));
     player.sendMessage(teamHeader);
     player.sendMessage(Component.text(""));
-    for (String memberName : members) {
-      Player member = teamService.getPlugin().getServer().getPlayer(memberName);
+    for (UUID memberId : members) {
+      String memberName = resolveName(memberId);
+      Player member = teamService.getPlugin().getServer().getPlayer(memberId);
       if (member != null) {
         player.sendMessage(
             Component.text("● ", NamedTextColor.GREEN)
@@ -79,5 +81,13 @@ public class MembersSubCommand implements SubCommand {
     return Component.text("📋 Участники команды ", NamedTextColor.AQUA)
         .append(prefixComponent)
         .append(Component.text(playerTeam + ":", NamedTextColor.WHITE));
+  }
+
+  private String resolveName(UUID playerId) {
+    if (playerId == null) {
+      return "Unknown";
+    }
+    String name = teamService.getPlugin().getServer().getOfflinePlayer(playerId).getName();
+    return name != null ? name : playerId.toString();
   }
 }

--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -34,8 +34,8 @@ public class TeamChatListener implements Listener {
     updatePlayerPrefix(player);
     String teamName = teamManager.getPlayerTeam(player);
     if (teamName != null && teamManager.getTeamIdByName(teamName) != null) {
-      String leaderName = teamManager.getTeamLeader(teamName);
-      if (player.getName().equals(leaderName)) {
+      UUID leaderId = teamManager.getTeamLeaderId(teamName);
+      if (leaderId != null && player.getUniqueId().equals(leaderId)) {
         Long deadline = teamManager.getTeamDeadline(teamName);
         if (deadline != null) {
           long remaining = deadline - System.currentTimeMillis();

--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -12,16 +12,16 @@ import org.example.util.TeamUtils;
 public class Team {
   private final UUID id; // Уникальный неизменяемый идентификатор
   private String name; // Название команды, теперь изменяемое
-  private String leader;
-  private final List<String> members;
+  private UUID leader;
+  private final List<UUID> members;
   private String prefix;
   private NamedTextColor color;
 
-  public Team(String name, String leader, String prefix, String color) {
+  public Team(String name, UUID leader, String prefix, String color) {
     this(UUID.randomUUID(), name, leader, prefix, color);
   }
 
-  public Team(UUID id, String name, String leader, String prefix, String color) {
+  public Team(UUID id, String name, UUID leader, String prefix, String color) {
     this.id = id;
     this.name = name;
     this.leader = leader;
@@ -39,15 +39,15 @@ public class Team {
     return name;
   }
 
-  public String getLeader() {
+  public UUID getLeaderId() {
     return leader;
   }
 
-  public List<String> getMembers() {
+  public List<UUID> getMembers() {
     return new ArrayList<>(members);
   }
 
-  public String getFirstMember() {
+  public UUID getFirstMember() {
     return members.isEmpty() ? null : members.get(0);
   }
 
@@ -64,7 +64,7 @@ public class Team {
     this.name = name;
   }
 
-  public void setLeader(String leader) {
+  public void setLeader(UUID leader) {
     this.leader = leader;
   }
 
@@ -77,17 +77,17 @@ public class Team {
   }
 
   // Методы управления участниками
-  public void addMember(String member) {
+  public void addMember(UUID member) {
     if (!members.contains(member)) {
       members.add(member);
     }
   }
 
-  public void removeMember(String member) {
+  public void removeMember(UUID member) {
     members.remove(member);
   }
 
-  public void setMembers(List<String> newMembers) {
+  public void setMembers(List<UUID> newMembers) {
     members.clear();
     members.addAll(newMembers);
   }
@@ -98,12 +98,12 @@ public class Team {
   }
 
   // Проверка, является ли игрок участником
-  public boolean hasMember(String playerName) {
-    return members.contains(playerName);
+  public boolean hasMember(UUID playerId) {
+    return members.contains(playerId);
   }
 
   // Проверка, является ли игрок лидером
-  public boolean isLeader(String playerName) {
-    return leader.equals(playerName);
+  public boolean isLeader(UUID playerId) {
+    return leader.equals(playerId);
   }
 }

--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -8,6 +8,7 @@ import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
@@ -36,7 +37,7 @@ public class DeadlineScheduler {
   private final TeamStorage storage;
   private final Map<UUID, Long> deadlines = new ConcurrentHashMap<>();
   private final Map<String, Scoreboard> leaderOriginalScoreboards = new ConcurrentHashMap<>();
-  private final Map<UUID, String> teamLeaderNames = new ConcurrentHashMap<>();
+  private final Map<UUID, UUID> teamLeaderIds = new ConcurrentHashMap<>();
   private BukkitTask task;
 
   private static final String SCOREBOARD_OBJECTIVE = "deadlineWarn";
@@ -113,9 +114,9 @@ public class DeadlineScheduler {
     }
     UUID teamId = team.getId();
     boolean removed = deadlines.remove(teamId) != null;
-    String leaderName = teamLeaderNames.remove(teamId);
-    if (leaderName != null) {
-      clearLeaderDisplay(leaderName);
+    UUID leaderId = teamLeaderIds.remove(teamId);
+    if (leaderId != null) {
+      clearLeaderDisplay(resolvePlayerName(leaderId));
     } else {
       clearLeaderDisplay(team);
     }
@@ -313,12 +314,12 @@ public class DeadlineScheduler {
       return;
     }
     UUID teamId = team.getId();
-    String currentLeader = team.getLeader();
-    String previousLeader = teamLeaderNames.get(teamId);
+    UUID currentLeader = team.getLeaderId();
+    UUID previousLeader = teamLeaderIds.get(teamId);
     if (previousLeader != null
-        && (currentLeader == null || !previousLeader.equalsIgnoreCase(currentLeader))) {
-      teamLeaderNames.remove(teamId, previousLeader);
-      clearLeaderDisplay(previousLeader);
+        && (currentLeader == null || !previousLeader.equals(currentLeader))) {
+      teamLeaderIds.remove(teamId, previousLeader);
+      clearLeaderDisplay(resolvePlayerName(previousLeader));
     }
     Long deadlineAt = deadlines.get(teamId);
     if (deadlineAt == null) {
@@ -339,9 +340,9 @@ public class DeadlineScheduler {
     Component message = TeamMessageUtils.deadlineRemainingMessage(minutesLeft, secondsLeft, excess);
     notifyLeader(team, message);
     if (getDisplayMode() == DeadlineDisplayMode.SCOREBOARD) {
-      String leaderName = team.getLeader();
-      if (leaderName != null && !leaderName.isBlank()) {
-        Player leader = plugin.getServer().getPlayer(leaderName);
+      UUID leaderId = team.getLeaderId();
+      if (leaderId != null) {
+        Player leader = plugin.getServer().getPlayer(leaderId);
         if (leader != null) {
           TeamMessageUtils.sendTeamMessage(leader, message);
         }
@@ -376,9 +377,9 @@ public class DeadlineScheduler {
       long deadlineAt = entry.getValue();
       Team team = storage.getTeams().get(teamId);
       if (team == null) {
-        String leaderName = teamLeaderNames.remove(teamId);
-        if (leaderName != null) {
-          clearLeaderDisplay(leaderName);
+        UUID leaderId = teamLeaderIds.remove(teamId);
+        if (leaderId != null) {
+          clearLeaderDisplay(resolvePlayerName(leaderId));
         }
         deadlinesToRemove.add(teamId);
         changed = true;
@@ -433,8 +434,9 @@ public class DeadlineScheduler {
     if (!deadlinesToRemove.isEmpty()) {
       deadlines.keySet().removeAll(deadlinesToRemove);
       deadlinesToRemove.stream()
-          .map(teamLeaderNames::remove)
+          .map(teamLeaderIds::remove)
           .filter(Objects::nonNull)
+          .map(this::resolvePlayerName)
           .forEach(this::clearLeaderDisplay);
     }
     if (changed) {
@@ -447,7 +449,7 @@ public class DeadlineScheduler {
     int removedCount = 0;
     RemovalPolicy policy = pluginConfig.getExcessPlayerRemovalPolicy();
     while (team.getMembers().size() > max) {
-      String removed = selectMemberToRemove(team, policy);
+      UUID removed = selectMemberToRemove(team, policy);
       if (removed == null) {
         break;
       }
@@ -469,14 +471,14 @@ public class DeadlineScheduler {
     return removedCount;
   }
 
-  private String selectMemberToRemove(@NotNull Team team, @NotNull RemovalPolicy policy) {
-    List<String> members = team.getMembers();
+  private UUID selectMemberToRemove(@NotNull Team team, @NotNull RemovalPolicy policy) {
+    List<UUID> members = team.getMembers();
     if (members.isEmpty()) {
       return null;
     }
-    String leader = team.getLeader();
+    UUID leader = team.getLeaderId();
     if (policy == RemovalPolicy.OFFLINE_FIRST) {
-      String offlineCandidate = findOfflineCandidate(members, leader);
+      UUID offlineCandidate = findOfflineCandidate(members, leader);
       if (offlineCandidate != null) {
         return offlineCandidate;
       }
@@ -484,9 +486,9 @@ public class DeadlineScheduler {
     return findLastJoinedCandidate(members, leader);
   }
 
-  private String findOfflineCandidate(@NotNull List<String> members, String leader) {
+  private UUID findOfflineCandidate(@NotNull List<UUID> members, UUID leader) {
     for (int i = members.size() - 1; i >= 0; i--) {
-      String candidate = members.get(i);
+      UUID candidate = members.get(i);
       if (isLeader(candidate, leader)) {
         continue;
       }
@@ -498,9 +500,9 @@ public class DeadlineScheduler {
     return null;
   }
 
-  private String findLastJoinedCandidate(@NotNull List<String> members, String leader) {
+  private UUID findLastJoinedCandidate(@NotNull List<UUID> members, UUID leader) {
     for (int i = members.size() - 1; i >= 0; i--) {
-      String candidate = members.get(i);
+      UUID candidate = members.get(i);
       if (!isLeader(candidate, leader)) {
         return candidate;
       }
@@ -508,8 +510,8 @@ public class DeadlineScheduler {
     return members.get(members.size() - 1);
   }
 
-  private boolean isLeader(String candidate, String leader) {
-    return leader != null && leader.equalsIgnoreCase(candidate);
+  private boolean isLeader(UUID candidate, UUID leader) {
+    return leader != null && leader.equals(candidate);
   }
 
   /**
@@ -554,15 +556,15 @@ public class DeadlineScheduler {
     // Полностью очищаем кеш, чтобы при перезапуске/отключении не осталось привязок к
     // временным табло лидеров и их именам.
     leaderOriginalScoreboards.clear();
-    teamLeaderNames.clear();
+    teamLeaderIds.clear();
   }
 
   private void clearLeaderDisplay(@NotNull Team team) {
-    String notifiedLeader = teamLeaderNames.remove(team.getId());
+    UUID notifiedLeader = teamLeaderIds.remove(team.getId());
     if (notifiedLeader != null) {
-      clearLeaderDisplay(notifiedLeader);
+      clearLeaderDisplay(resolvePlayerName(notifiedLeader));
     } else {
-      clearLeaderDisplay(team.getLeader());
+      clearLeaderDisplay(resolvePlayerName(team.getLeaderId()));
     }
   }
 
@@ -589,25 +591,34 @@ public class DeadlineScheduler {
     }
   }
 
+  private String resolvePlayerName(UUID playerId) {
+    if (playerId == null) {
+      return null;
+    }
+    OfflinePlayer offlinePlayer = plugin.getServer().getOfflinePlayer(playerId);
+    return offlinePlayer != null ? offlinePlayer.getName() : null;
+  }
+
   private void notifyLeader(@NotNull Team team, @NotNull Component message) {
-    String leaderName = team.getLeader();
+    UUID leaderId = team.getLeaderId();
+    String leaderName = resolvePlayerName(leaderId);
     if (leaderName == null || leaderName.isBlank()) {
       return;
     }
-    Player leader = plugin.getServer().getPlayer(leaderName);
+    Player leader = plugin.getServer().getPlayer(leaderId);
     if (leader == null) {
       return;
     }
     DeadlineDisplayMode mode = getDisplayMode();
     if (mode == DeadlineDisplayMode.SCOREBOARD) {
-      String previousLeader = teamLeaderNames.put(team.getId(), leaderName);
-      if (previousLeader != null && !previousLeader.equalsIgnoreCase(leaderName)) {
-        clearLeaderDisplay(previousLeader);
+      UUID previousLeader = teamLeaderIds.put(team.getId(), leaderId);
+      if (previousLeader != null && !previousLeader.equals(leaderId)) {
+        clearLeaderDisplay(resolvePlayerName(previousLeader));
       }
     } else {
-      String previousLeader = teamLeaderNames.remove(team.getId());
+      UUID previousLeader = teamLeaderIds.remove(team.getId());
       if (previousLeader != null) {
-        clearLeaderDisplay(previousLeader);
+        clearLeaderDisplay(resolvePlayerName(previousLeader));
       }
     }
     switch (mode) {
@@ -618,11 +629,12 @@ public class DeadlineScheduler {
   }
 
   private void notifyLeaderWithoutScoreboard(@NotNull Team team, @NotNull Component message) {
-    String leaderName = team.getLeader();
+    UUID leaderId = team.getLeaderId();
+    String leaderName = resolvePlayerName(leaderId);
     if (leaderName == null || leaderName.isBlank()) {
       return;
     }
-    Player leader = plugin.getServer().getPlayer(leaderName);
+    Player leader = plugin.getServer().getPlayer(leaderId);
     if (leader == null) {
       return;
     }

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -3,6 +3,7 @@ package org.example.service;
 import java.util.*;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.example.config.PluginConfig;
@@ -51,10 +52,10 @@ public class MembershipService {
       return;
     }
     // Создаём запись команды и связываем лидера с новой структурой.
-    Team team = new Team(teamName, leader.getName(), prefix, color);
+    Team team = new Team(teamName, leader.getUniqueId(), prefix, color);
     storage.addTeam(team);
     updateTeamMembersPrefixes(team);
-    storage.getPlayerTeams().put(leader.getName(), team.getId());
+    storage.getPlayerTeams().put(leader.getUniqueId(), team.getId());
     TeamMessageUtils.sendTeamMessage(
         leader, Component.text("✅ Команда создана", NamedTextColor.GREEN));
     scheduler.enforceTeamSizes(false);
@@ -81,8 +82,8 @@ public class MembershipService {
       return;
     }
     // Добавляем игрока и фиксируем изменения в хранилище.
-    team.addMember(player.getName());
-    storage.getPlayerTeams().put(player.getName(), team.getId());
+    team.addMember(player.getUniqueId());
+    storage.getPlayerTeams().put(player.getUniqueId(), team.getId());
     storage.markTeamDirty(team);
     TeamMessageUtils.sendTeamMessage(
         player, Component.text("✅ Вы вступили в команду", NamedTextColor.GREEN));
@@ -94,13 +95,14 @@ public class MembershipService {
     Team team = storage.getTeamByName(teamName);
     // Проводим проверки существования команды и членства игрока.
     if (team == null) return;
-    if (!team.hasMember(player.getName()) && !team.isLeader(player.getName())) return;
+    UUID playerId = player.getUniqueId();
+    if (!team.hasMember(playerId) && !team.isLeader(playerId)) return;
     // Удаляем игрока и очищаем обратные ссылки.
-    team.removeMember(player.getName());
-    storage.getPlayerTeams().remove(player.getName());
+    team.removeMember(playerId);
+    storage.getPlayerTeams().remove(playerId);
     boolean removedTeam = false;
     // Если ушедший игрок был лидером, либо закрываем команду, либо назначаем нового.
-    if (team.isLeader(player.getName())) {
+    if (team.isLeader(playerId)) {
       if (team.getMembers().isEmpty()) {
         scheduler.cancelDeadline(team);
         storage.removeTeam(team);
@@ -125,18 +127,21 @@ public class MembershipService {
       String teamName, @NotNull Player leader, @NotNull String targetName) {
     Team team = storage.getTeamByName(teamName);
     // Проверяем право лидера на это действие и наличие цели в команде.
-    if (team == null || !team.isLeader(leader.getName())) return;
-    if (!team.hasMember(targetName)) return;
-    if (team.isLeader(targetName)) {
+    if (team == null || !team.isLeader(leader.getUniqueId())) return;
+    UUID targetId = findMemberIdByName(team, targetName);
+    if (targetId == null) {
+      return;
+    }
+    if (team.isLeader(targetId)) {
       removePlayerFromTeam(teamName, leader);
       return;
     }
     // Удаляем участника и фиксируем изменения.
-    team.removeMember(targetName);
-    storage.getPlayerTeams().remove(targetName);
+    team.removeMember(targetId);
+    storage.getPlayerTeams().remove(targetId);
     storage.markTeamDirty(team);
     scheduler.enforceTeamSizes(false);
-    notifyPrefixUpdate(targetName, null);
+    notifyPrefixUpdate(targetId, null);
     updateTeamMembersPrefixes(team);
   }
 
@@ -144,10 +149,10 @@ public class MembershipService {
       String teamName, @NotNull Player leader, @NotNull Player newLeader) {
     Team team = storage.getTeamByName(teamName);
     // Убеждаемся, что изменение лидерства инициирует действующий лидер.
-    if (team == null || !team.isLeader(leader.getName())) return;
+    if (team == null || !team.isLeader(leader.getUniqueId())) return;
     // Назначать лидером можно только участника команды.
-    if (!team.hasMember(newLeader.getName())) return;
-    team.setLeader(newLeader.getName());
+    if (!team.hasMember(newLeader.getUniqueId())) return;
+    team.setLeader(newLeader.getUniqueId());
     storage.markTeamDirty(team);
     scheduler.handleLeaderTransfer(team);
     scheduler.enforceTeamSizes(false);
@@ -156,18 +161,18 @@ public class MembershipService {
   public void disbandTeam(String teamName, @NotNull Player leader) {
     Team team = storage.getTeamByName(teamName);
     // Разрешаем роспуск только лидеру существующей команды.
-    if (team == null || !team.isLeader(leader.getName())) return;
+    if (team == null || !team.isLeader(leader.getUniqueId())) return;
     // Сохраняем список участников до удаления, чтобы очистить их отображаемые префиксы.
-    List<String> members = team.getMembers();
+    List<UUID> members = team.getMembers();
     scheduler.cancelDeadline(team);
     // Удаляем команду и уведомляем игроков о сбросе префикса.
     storage.removeTeam(team);
-    for (String memberName : members) {
-      notifyPrefixUpdate(memberName, null);
+    for (UUID memberId : members) {
+      notifyPrefixUpdate(memberId, null);
     }
     // После уведомления очищаем соответствия игроков и команд.
-    for (String memberName : members) {
-      storage.getPlayerTeams().remove(memberName);
+    for (UUID memberId : members) {
+      storage.getPlayerTeams().remove(memberId);
     }
     scheduler.enforceTeamSizes(false);
   }
@@ -175,7 +180,7 @@ public class MembershipService {
   public void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader) {
     Team team = storage.getTeamByName(oldTeamName);
     // Проверяем полномочия и уникальность нового имени.
-    if (team == null || !team.isLeader(leader.getName())) return;
+    if (team == null || !team.isLeader(leader.getUniqueId())) return;
     if (storage.getTeamByName(newTeamName) != null) return;
     storage.updateTeamName(team, newTeamName);
   }
@@ -183,7 +188,7 @@ public class MembershipService {
   public void setTeamPrefix(String teamName, String newPrefix, @NotNull Player leader) {
     Team team = storage.getTeamByName(teamName);
     // Изменение префикса доступно только лидеру, при этом валидируем значение.
-    if (team == null || !team.isLeader(leader.getName())) return;
+    if (team == null || !team.isLeader(leader.getUniqueId())) return;
     if (TeamUtils.isPrefixLengthInvalid(newPrefix, pluginConfig, leader)) return;
     team.setPrefix(newPrefix);
     storage.markTeamDirty(team);
@@ -193,7 +198,7 @@ public class MembershipService {
   public void setTeamColor(String teamName, String newColor, @NotNull Player leader) {
     Team team = storage.getTeamByName(teamName);
     // Проверяем права и корректность цвета перед сохранением.
-    if (team == null || !team.isLeader(leader.getName())) return;
+    if (team == null || !team.isLeader(leader.getUniqueId())) return;
     NamedTextColor teamColor = NamedTextColor.NAMES.value(newColor.toLowerCase(Locale.ROOT));
     if (teamColor == null) {
       TeamMessageUtils.sendTeamMessage(
@@ -214,7 +219,7 @@ public class MembershipService {
 
   public void updateTeamMembersPrefixes(@NotNull Team team) {
     Component prefixComponent = team.getPrefixComponent();
-    for (String member : team.getMembers()) {
+    for (UUID member : team.getMembers()) {
       notifyPrefixUpdate(member, prefixComponent);
     }
   }
@@ -226,10 +231,23 @@ public class MembershipService {
         .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefix));
   }
 
-  private void notifyPrefixUpdate(@NotNull String playerName, @Nullable Component prefix) {
-    Player onlinePlayer = plugin.getServer().getPlayer(playerName);
+  private void notifyPrefixUpdate(@NotNull UUID playerId, @Nullable Component prefix) {
+    Player onlinePlayer = plugin.getServer().getPlayer(playerId);
     if (onlinePlayer != null) {
       notifyPrefixUpdate(onlinePlayer, prefix);
     }
+  }
+
+  private UUID findMemberIdByName(@NotNull Team team, @NotNull String targetName) {
+    for (UUID memberId : team.getMembers()) {
+      OfflinePlayer offlinePlayer = plugin.getServer().getOfflinePlayer(memberId);
+      if (offlinePlayer != null) {
+        String currentName = offlinePlayer.getName();
+        if (currentName != null && currentName.equalsIgnoreCase(targetName)) {
+          return memberId;
+        }
+      }
+    }
+    return null;
   }
 }

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -99,7 +99,7 @@ public class TeamManager implements TeamService {
   }
 
   @Override
-  public @NotNull List<String> getTeamMembers(String teamName) {
+  public @NotNull List<UUID> getTeamMembers(String teamName) {
     return storage.getTeamMembers(teamName);
   }
 
@@ -119,8 +119,8 @@ public class TeamManager implements TeamService {
   }
 
   @Override
-  public String getTeamLeader(String teamName) {
-    return storage.getTeamLeader(teamName);
+  public UUID getTeamLeaderId(String teamName) {
+    return storage.getTeamLeaderId(teamName);
   }
 
   @Override

--- a/src/main/java/org/example/service/TeamService.java
+++ b/src/main/java/org/example/service/TeamService.java
@@ -112,7 +112,7 @@ public interface TeamService {
    * @return Список участников команды
    */
   @NotNull
-  List<String> getTeamMembers(String teamName);
+  List<UUID> getTeamMembers(String teamName);
 
   /**
    * Получает список названий всех команд.
@@ -145,7 +145,7 @@ public interface TeamService {
    * @param teamName Название команды
    * @return Имя лидера команды или null, если команда не существует
    */
-  String getTeamLeader(String teamName);
+  UUID getTeamLeaderId(String teamName);
 
   /**
    * Получает экземпляр плагина.

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
@@ -23,7 +24,7 @@ public class TeamStorage {
 
   private final Map<UUID, Team> teams = new ConcurrentHashMap<>();
   private final Map<String, UUID> teamIdsByName = new ConcurrentHashMap<>();
-  private final Map<String, UUID> playerTeams = new ConcurrentHashMap<>();
+  private final Map<UUID, UUID> playerTeams = new ConcurrentHashMap<>();
 
   private FileConfiguration teamsConfig;
   private File teamsFile;
@@ -58,6 +59,7 @@ public class TeamStorage {
     playerTeams.clear();
     deadlines.clear();
     var section = teamsConfig.getConfigurationSection("teams");
+    boolean legacyDataUpdated = false;
     if (section != null) {
       for (String teamIdStr : section.getKeys(false)) {
         UUID teamId;
@@ -77,8 +79,14 @@ public class TeamStorage {
                   "Skipping team entry " + teamId + " because it does not define a name.");
           continue;
         }
-        String leader = teamsConfig.getString("teams." + teamIdStr + ".leader", "");
-        if (leader == null || leader.isBlank()) {
+        String leaderRaw = teamsConfig.getString("teams." + teamIdStr + ".leader", "");
+        UUID leaderId = parseUuid(leaderRaw);
+        boolean leaderFromName = false;
+        if (leaderId == null) {
+          leaderId = resolvePlayerUuid(leaderRaw);
+          leaderFromName = leaderId != null;
+        }
+        if (leaderId == null) {
           plugin
               .getLogger()
               .warning(
@@ -88,20 +96,64 @@ public class TeamStorage {
         String prefix = teamsConfig.getString("teams." + teamIdStr + ".prefix", "");
         String color =
             normalizeColorKey(teamsConfig.getString("teams." + teamIdStr + ".color", "WHITE"));
-        Team team = new Team(teamId, name, leader, prefix, color);
-        team.setMembers(teamsConfig.getStringList("teams." + teamIdStr + ".members"));
+        List<String> rawMembers = teamsConfig.getStringList("teams." + teamIdStr + ".members");
+        List<UUID> memberIds = new ArrayList<>();
+        boolean convertedMembers = false;
+        for (String rawMember : rawMembers) {
+          UUID memberId = parseUuid(rawMember);
+          boolean convertedFromName = false;
+          if (memberId == null) {
+            memberId = resolvePlayerUuid(rawMember);
+            convertedFromName = memberId != null;
+          }
+          if (memberId == null) {
+            plugin
+                .getLogger()
+                .warning(
+                    "Skipping member entry '"
+                        + rawMember
+                        + "' for team "
+                        + teamId
+                        + " because it could not be converted to UUID.");
+            continue;
+          }
+          if (!memberIds.contains(memberId)) {
+            memberIds.add(memberId);
+          }
+          if (convertedFromName) {
+            convertedMembers = true;
+          }
+        }
+        if (!memberIds.contains(leaderId)) {
+          memberIds.add(0, leaderId);
+          convertedMembers = true;
+        } else if (!memberIds.isEmpty() && !leaderId.equals(memberIds.get(0))) {
+          memberIds.remove(leaderId);
+          memberIds.add(0, leaderId);
+          convertedMembers = true;
+        }
+        if (memberIds.isEmpty()) {
+          memberIds.add(leaderId);
+          convertedMembers = true;
+        }
+        Team team = new Team(teamId, name, leaderId, prefix, color);
+        team.setMembers(memberIds);
         long deadline = teamsConfig.getLong("teams." + teamIdStr + ".deadline", 0L);
         if (deadline > 0L) {
           deadlines.put(team.getId(), deadline);
         }
         addTeamInternal(team, false);
-        for (String member : team.getMembers()) {
+        for (UUID member : team.getMembers()) {
           playerTeams.put(member, team.getId());
         }
+        legacyDataUpdated = legacyDataUpdated || leaderFromName || convertedMembers;
       }
     }
     dirtyTeams.clear();
     deadlinesDirty = false;
+    if (legacyDataUpdated) {
+      saveTeams(deadlines);
+    }
   }
 
   /** Saves teams and deadlines back to teams.yml. */
@@ -113,8 +165,10 @@ public class TeamStorage {
       Team team = entry.getValue();
       String path = "teams." + teamId;
       teamsConfig.set(path + ".name", team.getName());
-      teamsConfig.set(path + ".leader", team.getLeader());
-      teamsConfig.set(path + ".members", team.getMembers());
+      teamsConfig.set(path + ".leader", team.getLeaderId().toString());
+      teamsConfig.set(
+          path + ".members",
+          team.getMembers().stream().map(UUID::toString).collect(Collectors.toList()));
       teamsConfig.set(path + ".prefix", team.getPrefix());
       teamsConfig.set(path + ".color", colorKeyFor(team.getColor()));
       Long deadline = deadlines.get(teamId);
@@ -180,7 +234,7 @@ public class TeamStorage {
     markTeamDirty(team);
   }
 
-  public Map<String, UUID> getPlayerTeams() {
+  public Map<UUID, UUID> getPlayerTeams() {
     return playerTeams;
   }
 
@@ -199,13 +253,13 @@ public class TeamStorage {
   }
 
   public String getPlayerTeam(@NotNull Player player) {
-    UUID id = playerTeams.get(player.getName());
+    UUID id = playerTeams.get(player.getUniqueId());
     Team team = id != null ? teams.get(id) : null;
     return team != null ? team.getName() : null;
   }
 
   @NotNull
-  public List<String> getTeamMembers(String teamName) {
+  public List<UUID> getTeamMembers(String teamName) {
     Team team = getTeamByName(teamName);
     return team != null ? new ArrayList<>(team.getMembers()) : List.of();
   }
@@ -226,9 +280,9 @@ public class TeamStorage {
     return team != null ? team.getColor() : NamedTextColor.WHITE;
   }
 
-  public String getTeamLeader(String teamName) {
+  public UUID getTeamLeaderId(String teamName) {
     Team team = getTeamByName(teamName);
-    return team != null ? team.getLeader() : null;
+    return team != null ? team.getLeaderId() : null;
   }
 
   public void markTeamDirty(@NotNull Team team) {
@@ -336,5 +390,24 @@ public class TeamStorage {
 
   private static String normalizeTeamKey(String name) {
     return name != null ? name.toLowerCase(Locale.ROOT) : null;
+  }
+
+  private UUID parseUuid(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    try {
+      return UUID.fromString(value.trim());
+    } catch (IllegalArgumentException ex) {
+      return null;
+    }
+  }
+
+  private UUID resolvePlayerUuid(String value) {
+    if (value == null || value.isBlank()) {
+      return null;
+    }
+    OfflinePlayer offlinePlayer = plugin.getServer().getOfflinePlayer(value.trim());
+    return offlinePlayer != null ? offlinePlayer.getUniqueId() : null;
   }
 }

--- a/src/main/java/org/example/util/TeamUtils.java
+++ b/src/main/java/org/example/util/TeamUtils.java
@@ -1,6 +1,7 @@
 package org.example.util;
 
 import java.util.Set;
+import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -30,12 +31,12 @@ public class TeamUtils {
    * @param excludedPlayers Игроки, которых нужно исключить из уведомления (может быть null)
    */
   public static void notifyTeamMembers(
-      String teamName, TeamService teamManager, Component message, Set<String> excludedPlayers) {
-    for (String memberName : teamManager.getTeamMembers(teamName)) {
-      if (excludedPlayers != null && excludedPlayers.contains(memberName)) {
+      String teamName, TeamService teamManager, Component message, Set<UUID> excludedPlayers) {
+    for (UUID memberId : teamManager.getTeamMembers(teamName)) {
+      if (excludedPlayers != null && excludedPlayers.contains(memberId)) {
         continue; // Пропускаем исключённых игроков
       }
-      Player member = teamManager.getPlugin().getServer().getPlayer(memberName);
+      Player member = teamManager.getPlugin().getServer().getPlayer(memberId);
       if (member != null) {
         TeamMessageUtils.sendTeamMessage(member, message);
       }

--- a/src/main/java/org/example/util/TeamValidator.java
+++ b/src/main/java/org/example/util/TeamValidator.java
@@ -1,5 +1,6 @@
 package org.example.util;
 
+import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
@@ -24,8 +25,8 @@ public class TeamValidator {
       TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.teamDoesNotExistMessage(teamName));
       return true;
     }
-    String currentLeader = teamService.getTeamLeader(teamName);
-    if (!leader.getName().equals(currentLeader)) {
+    UUID currentLeader = teamService.getTeamLeaderId(teamName);
+    if (!leader.getUniqueId().equals(currentLeader)) {
       Component prefix =
           TeamUtils.createPrefixComponent(
               teamService.getTeamPrefix(teamName), teamService.getTeamColor(teamName));

--- a/src/test/java/org/example/service/DeadlineSchedulerTest.java
+++ b/src/test/java/org/example/service/DeadlineSchedulerTest.java
@@ -43,11 +43,15 @@ class DeadlineSchedulerTest {
     TeamStorage storage = new TeamStorage(plugin, config);
     DeadlineScheduler scheduler = new DeadlineScheduler(plugin, config, storage);
 
-    Team team = new Team(UUID.randomUUID(), "Alpha", "Leader", "", "WHITE");
-    team.setMembers(List.of("Leader", "MemberOne", "MemberTwo"));
-    storage.getTeams().put(team.getId(), team);
-
     PlayerMock leader = server.addPlayer("Leader");
+    PlayerMock memberOne = server.addPlayer("MemberOne");
+    PlayerMock memberTwo = server.addPlayer("MemberTwo");
+
+    Team team =
+        new Team(UUID.randomUUID(), "Alpha", leader.getUniqueId(), "", "WHITE");
+    team.setMembers(
+        List.of(leader.getUniqueId(), memberOne.getUniqueId(), memberTwo.getUniqueId()));
+    storage.getTeams().put(team.getId(), team);
     Scoreboard original = leader.getScoreboard();
 
     scheduler.enforceTeamSizes(false);
@@ -56,7 +60,7 @@ class DeadlineSchedulerTest {
     scheduler.getDeadlines().clear();
     assertNotNull(leader.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
 
-    team.setMembers(List.of("Leader", "MemberOne"));
+    team.setMembers(List.of(leader.getUniqueId(), memberOne.getUniqueId()));
     scheduler.enforceTeamSizes(true);
 
     assertNull(leader.getScoreboard().getObjective(DisplaySlot.SIDEBAR));

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -44,15 +44,17 @@ class MembershipServiceTest {
     DeadlineScheduler scheduler = new DeadlineScheduler(plugin, config, storage);
     MembershipService membershipService = new MembershipService(plugin, config, storage, scheduler);
 
-    Team team = new Team(UUID.randomUUID(), "Alpha", "Captain", "AA", "WHITE");
-    team.setMembers(List.of("Captain", "Successor", "Reserve"));
-    storage.getTeams().put(team.getId(), team);
-    storage.getPlayerTeams().put("Captain", team.getId());
-    storage.getPlayerTeams().put("Successor", team.getId());
-    storage.getPlayerTeams().put("Reserve", team.getId());
-
     PlayerMock captain = server.addPlayer("Captain");
     PlayerMock successor = server.addPlayer("Successor");
+    PlayerMock reserve = server.addPlayer("Reserve");
+
+    Team team =
+        new Team(UUID.randomUUID(), "Alpha", captain.getUniqueId(), "AA", "WHITE");
+    team.setMembers(List.of(captain.getUniqueId(), successor.getUniqueId(), reserve.getUniqueId()));
+    storage.getTeams().put(team.getId(), team);
+    storage.getPlayerTeams().put(captain.getUniqueId(), team.getId());
+    storage.getPlayerTeams().put(successor.getUniqueId(), team.getId());
+    storage.getPlayerTeams().put(reserve.getUniqueId(), team.getId());
     Scoreboard captainOriginal = captain.getScoreboard();
     Scoreboard successorOriginal = successor.getScoreboard();
 
@@ -79,15 +81,17 @@ class MembershipServiceTest {
     DeadlineScheduler scheduler = new DeadlineScheduler(plugin, config, storage);
     MembershipService membershipService = new MembershipService(plugin, config, storage, scheduler);
 
-    Team team = new Team(UUID.randomUUID(), "Alpha", "Captain", "AA", "WHITE");
-    team.setMembers(List.of("Captain", "Successor", "Reserve"));
-    storage.getTeams().put(team.getId(), team);
-    storage.getPlayerTeams().put("Captain", team.getId());
-    storage.getPlayerTeams().put("Successor", team.getId());
-    storage.getPlayerTeams().put("Reserve", team.getId());
-
     PlayerMock captain = server.addPlayer("Captain");
     PlayerMock successor = server.addPlayer("Successor");
+    PlayerMock reserve = server.addPlayer("Reserve");
+
+    Team team =
+        new Team(UUID.randomUUID(), "Alpha", captain.getUniqueId(), "AA", "WHITE");
+    team.setMembers(List.of(captain.getUniqueId(), successor.getUniqueId(), reserve.getUniqueId()));
+    storage.getTeams().put(team.getId(), team);
+    storage.getPlayerTeams().put(captain.getUniqueId(), team.getId());
+    storage.getPlayerTeams().put(successor.getUniqueId(), team.getId());
+    storage.getPlayerTeams().put(reserve.getUniqueId(), team.getId());
     Scoreboard captainOriginal = captain.getScoreboard();
     Scoreboard successorOriginal = successor.getScoreboard();
 
@@ -101,7 +105,7 @@ class MembershipServiceTest {
     assertSame(captainOriginal, captain.getScoreboard());
     assertNull(captain.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
 
-    assertEquals("Successor", team.getLeader());
+    assertEquals(successor.getUniqueId(), team.getLeaderId());
     assertNotSame(successorOriginal, successor.getScoreboard());
     assertNotNull(successor.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
   }
@@ -114,14 +118,17 @@ class MembershipServiceTest {
     DeadlineScheduler scheduler = new DeadlineScheduler(plugin, config, storage);
     MembershipService membershipService = new MembershipService(plugin, config, storage, scheduler);
 
-    Team team = new Team(UUID.randomUUID(), "Alpha", "Captain", "AA", "WHITE");
-    team.setMembers(List.of("Captain", "MemberOne", "MemberTwo"));
-    storage.getTeams().put(team.getId(), team);
-    storage.getPlayerTeams().put("Captain", team.getId());
-    storage.getPlayerTeams().put("MemberOne", team.getId());
-    storage.getPlayerTeams().put("MemberTwo", team.getId());
-
     PlayerMock captain = server.addPlayer("Captain");
+    PlayerMock memberOne = server.addPlayer("MemberOne");
+    PlayerMock memberTwo = server.addPlayer("MemberTwo");
+
+    Team team =
+        new Team(UUID.randomUUID(), "Alpha", captain.getUniqueId(), "AA", "WHITE");
+    team.setMembers(List.of(captain.getUniqueId(), memberOne.getUniqueId(), memberTwo.getUniqueId()));
+    storage.getTeams().put(team.getId(), team);
+    storage.getPlayerTeams().put(captain.getUniqueId(), team.getId());
+    storage.getPlayerTeams().put(memberOne.getUniqueId(), team.getId());
+    storage.getPlayerTeams().put(memberTwo.getUniqueId(), team.getId());
     Scoreboard captainOriginal = captain.getScoreboard();
 
     scheduler.enforceTeamSizes(false);

--- a/src/test/java/org/example/service/TeamManagerTest.java
+++ b/src/test/java/org/example/service/TeamManagerTest.java
@@ -79,7 +79,7 @@ class TeamManagerTest {
 
     teamManager.createTeam("Alpha", "AA", "white", leader);
     assertEquals("Alpha", teamManager.getPlayerTeam(leader));
-    assertTrue(teamManager.getTeamMembers("Alpha").contains(leader.getName()));
+    assertTrue(teamManager.getTeamMembers("Alpha").contains(leader.getUniqueId()));
 
     teamManager.addPlayerToTeam("Alpha", member);
     assertEquals("Alpha", teamManager.getPlayerTeam(member));
@@ -126,11 +126,11 @@ class TeamManagerTest {
     teamManager.createTeam(teamName, "VG", "white", leader);
 
     assertEquals(teamName, teamManager.getPlayerTeam(leader));
-    assertTrue(teamManager.getTeamMembers(teamName).contains(leader.getName()));
+    assertTrue(teamManager.getTeamMembers(teamName).contains(leader.getUniqueId()));
 
     teamManager.addPlayerToTeam(teamName, member);
     assertEquals(teamName, teamManager.getPlayerTeam(member));
-    assertTrue(teamManager.getTeamMembers(teamName).contains(member.getName()));
+    assertTrue(teamManager.getTeamMembers(teamName).contains(member.getUniqueId()));
   }
 
   @Test
@@ -200,8 +200,8 @@ class TeamManagerTest {
 
     assertNull(teamManager.getPlayerTeam(leader));
     assertEquals(teamName, teamManager.getPlayerTeam(successor));
-    assertEquals(successor.getName(), teamManager.getTeamLeader(teamName));
-    assertFalse(teamManager.getTeamMembers(teamName).contains(leader.getName()));
+    assertEquals(successor.getUniqueId(), teamManager.getTeamLeaderId(teamName));
+    assertFalse(teamManager.getTeamMembers(teamName).contains(leader.getUniqueId()));
   }
 
   @Test

--- a/src/test/java/org/example/service/TeamStorageTest.java
+++ b/src/test/java/org/example/service/TeamStorageTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,7 +43,8 @@ class TeamStorageTest {
     Map<UUID, Long> deadlines = new HashMap<>();
     storage.loadTeams(deadlines);
 
-    Team team = new Team(UUID.randomUUID(), "TestTeam", "Leader", "[T]", "red");
+    PlayerMock leader = server.addPlayer("Leader");
+    Team team = new Team(UUID.randomUUID(), "TestTeam", leader.getUniqueId(), "[T]", "red");
     storage.addTeam(team);
     storage.saveTeams(deadlines);
 
@@ -71,8 +73,10 @@ class TeamStorageTest {
     storage.loadTeams(deadlines);
 
     UUID teamId = UUID.randomUUID();
-    Team team = new Team(teamId, "DeadlineTeam", "Leader", "[D]", "blue");
-    team.setMembers(new ArrayList<>(List.of("Leader", "Member")));
+    PlayerMock leader = server.addPlayer("Leader");
+    PlayerMock member = server.addPlayer("Member");
+    Team team = new Team(teamId, "DeadlineTeam", leader.getUniqueId(), "[D]", "blue");
+    team.setMembers(new ArrayList<>(List.of(leader.getUniqueId(), member.getUniqueId())));
     storage.addTeam(team);
 
     long deadline = System.currentTimeMillis() + 60000L;
@@ -100,7 +104,8 @@ class TeamStorageTest {
 
     UUID validId = UUID.randomUUID();
     config.set("teams." + validId + ".name", "ValidTeam");
-    config.set("teams." + validId + ".leader", "Leader");
+    PlayerMock leader = server.addPlayer("ValidLeader");
+    config.set("teams." + validId + ".leader", leader.getUniqueId().toString());
     config.save(teamsFile);
 
     TeamStorage reloaded = new TeamStorage(plugin, null);


### PR DESCRIPTION
## Summary
- store team leaders and members as UUIDs in Team and TeamStorage, migrating legacy name entries on load and writing UUID lists when saving
- switch membership logic, deadline handling, and command utilities to operate with UUIDs while resolving names only when messaging players
- update tab completion, notifications, and related tests to account for UUID-based membership data

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ced310f048832ea4f0f9780e24bff5