### PR TITLE
Normalize team membership lookups

### DIFF
--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -1,12 +1,15 @@
 package org.example.model;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.example.util.TeamUtils;
+import org.jetbrains.annotations.Nullable;
 
 /** Представляет команду с уникальным идентификатором и изменяемыми данными. */
 public class Team {
@@ -14,6 +17,7 @@ public class Team {
   private String name; // Название команды, теперь изменяемое
   private String leader;
   private final List<String> members;
+  private final Set<String> memberNamesLower;
   private String prefix;
   private NamedTextColor color;
 
@@ -25,7 +29,9 @@ public class Team {
     this.id = id;
     this.name = name;
     this.leader = leader;
-    this.members = new ArrayList<>(List.of(leader));
+    this.members = new ArrayList<>();
+    this.memberNamesLower = new HashSet<>();
+    addMember(leader);
     this.prefix = prefix;
     this.color = NamedTextColor.NAMES.valueOr(color.toLowerCase(Locale.ROOT), NamedTextColor.WHITE);
   }
@@ -78,18 +84,31 @@ public class Team {
 
   // Методы управления участниками
   public void addMember(String member) {
-    if (!members.contains(member)) {
+    String normalized = normalize(member);
+    if (memberNamesLower.add(normalized)) {
       members.add(member);
     }
   }
 
   public void removeMember(String member) {
-    members.remove(member);
+    String normalized = normalize(member);
+    if (memberNamesLower.remove(normalized)) {
+      members.removeIf(existing -> existing.equalsIgnoreCase(member));
+    }
   }
 
   public void setMembers(List<String> newMembers) {
     members.clear();
-    members.addAll(newMembers);
+    memberNamesLower.clear();
+    for (String newMember : newMembers) {
+      if (newMember == null) {
+        continue;
+      }
+      String normalized = normalize(newMember);
+      if (memberNamesLower.add(normalized)) {
+        members.add(newMember);
+      }
+    }
   }
 
   // Утилитный метод для префикса
@@ -99,11 +118,26 @@ public class Team {
 
   // Проверка, является ли игрок участником
   public boolean hasMember(String playerName) {
-    return members.contains(playerName);
+    return memberNamesLower.contains(normalize(playerName));
   }
 
   // Проверка, является ли игрок лидером
   public boolean isLeader(String playerName) {
-    return leader.equals(playerName);
+    return leader.equalsIgnoreCase(playerName);
+  }
+
+  @Nullable
+  public String findMember(String playerName) {
+    String normalized = normalize(playerName);
+    for (String member : members) {
+      if (normalize(member).equals(normalized)) {
+        return member;
+      }
+    }
+    return null;
+  }
+
+  private String normalize(String playerName) {
+    return playerName.toLowerCase(Locale.ROOT);
   }
 }

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -126,17 +126,22 @@ public class MembershipService {
     Team team = storage.getTeamByName(teamName);
     // Проверяем право лидера на это действие и наличие цели в команде.
     if (team == null || !team.isLeader(leader.getName())) return;
-    if (!team.hasMember(targetName)) return;
-    if (team.isLeader(targetName)) {
+    String normalizedTarget = targetName.toLowerCase(Locale.ROOT);
+    if (!team.hasMember(normalizedTarget)) return;
+    if (team.isLeader(normalizedTarget)) {
       removePlayerFromTeam(teamName, leader);
       return;
     }
+    String actualTargetName = team.findMember(normalizedTarget);
+    if (actualTargetName == null) {
+      return;
+    }
     // Удаляем участника и фиксируем изменения.
-    team.removeMember(targetName);
-    storage.getPlayerTeams().remove(targetName);
+    team.removeMember(actualTargetName);
+    storage.getPlayerTeams().remove(actualTargetName);
     storage.markTeamDirty(team);
     scheduler.enforceTeamSizes(false);
-    notifyPrefixUpdate(targetName, null);
+    notifyPrefixUpdate(actualTargetName, null);
     updateTeamMembersPrefixes(team);
   }
 

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -322,6 +322,51 @@ class TeamCommandTest {
   }
 
   @Test
+  void adminKickCommandMatchesMemberIgnoringCase() {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("KickBoss");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    leader.addAttachment(plugin, "mypurpurplugin.teamadmin", true);
+
+    assertTrue(commandMap.dispatch(leader, "team create Delta DD WHITE"));
+    assertEquals("Delta", teamManager.getPlayerTeam(leader));
+
+    PlayerMock member = server.addPlayer("KickTarget");
+    teamManager.addPlayerToTeam("Delta", member);
+    assertEquals("Delta", teamManager.getPlayerTeam(member));
+
+    while (leader.nextComponentMessage() != null) {}
+
+    assertTrue(commandMap.dispatch(leader, "teamadmin kick kicktarget"));
+
+    assertFalse(teamManager.getTeamMembers("Delta").contains("KickTarget"));
+    assertNull(teamManager.getPlayerTeam(member));
+  }
+
+  @Test
+  void adminTransferCommandMatchesMemberIgnoringCase() {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("TransferChief");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    leader.addAttachment(plugin, "mypurpurplugin.teamadmin", true);
+
+    assertTrue(commandMap.dispatch(leader, "team create Sigma SG WHITE"));
+    assertEquals("Sigma", teamManager.getPlayerTeam(leader));
+
+    PlayerMock successor = server.addPlayer("TransferHeir");
+    teamManager.addPlayerToTeam("Sigma", successor);
+    assertEquals("Sigma", teamManager.getPlayerTeam(successor));
+
+    while (leader.nextComponentMessage() != null) {}
+
+    assertTrue(commandMap.dispatch(leader, "teamadmin transfer transferheir"));
+
+    assertEquals("TransferHeir", teamManager.getTeamLeader("Sigma"));
+  }
+
+  @Test
   void asyncChatEventAddsTeamPrefix() {
     CommandMap commandMap = server.getCommandMap();
     PlayerMock leader = server.addPlayer("Leader");


### PR DESCRIPTION
## Summary
- track team members in a lowercase set so membership operations ignore casing
- normalise target names during kick operations to keep storage in sync
- cover `/teamadmin kick` and `/teamadmin transfer` with case-insensitive integration tests

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ced3393ac8832e9a256609d91ece42