### PR TITLE
Preserve config comments on reload

### DIFF
--- a/src/main/java/org/example/config/PluginConfig.java
+++ b/src/main/java/org/example/config/PluginConfig.java
@@ -40,39 +40,50 @@ public class PluginConfig {
     }
 
     config = YamlConfiguration.loadConfiguration(configFile);
-    setDefaults();
+    setDefaults(true);
   }
 
   /** Устанавливает значения по умолчанию для конфигурации. */
-  private void setDefaults() {
+  private void setDefaults(boolean persistChanges) {
+    boolean newKeysAdded = false;
+
     // Глобальные настройки
-    config.addDefault("debug-mode", true);
-    config.addDefault("force-white-chat", false);
+    newKeysAdded |= addDefaultIfMissing("debug-mode", true);
+    newKeysAdded |= addDefaultIfMissing("force-white-chat", false);
 
     // Основные настройки
-    config.addDefault("team.requires-op", false);
-    config.addDefault("team.notify-admins", true);
-    config.addDefault("team.max-members", 0);
-    config.addDefault("team.min-prefix-length", 1);
-    config.addDefault("team.max-prefix-length", 16);
-    config.addDefault("team.min-team-name-length", 3);
-    config.addDefault("team.max-team-name-length", 32);
-    config.addDefault("team.enforce-max-members-on-reload", true);
-    config.addDefault("team.grace-period-enabled", true);
-    config.addDefault("team.grace-period-minutes", 10);
-    config.addDefault("team.deadline-notify-period-seconds", 300L);
-    config.addDefault("team.save-interval-seconds", 60L);
-    config.addDefault("team.deadline-display-mode", "CHAT");
-    config.addDefault("team.deadline-removal-policy", "last-joined");
+    newKeysAdded |= addDefaultIfMissing("team.requires-op", false);
+    newKeysAdded |= addDefaultIfMissing("team.notify-admins", true);
+    newKeysAdded |= addDefaultIfMissing("team.max-members", 0);
+    newKeysAdded |= addDefaultIfMissing("team.min-prefix-length", 1);
+    newKeysAdded |= addDefaultIfMissing("team.max-prefix-length", 16);
+    newKeysAdded |= addDefaultIfMissing("team.min-team-name-length", 3);
+    newKeysAdded |= addDefaultIfMissing("team.max-team-name-length", 32);
+    newKeysAdded |= addDefaultIfMissing("team.enforce-max-members-on-reload", true);
+    newKeysAdded |= addDefaultIfMissing("team.grace-period-enabled", true);
+    newKeysAdded |= addDefaultIfMissing("team.grace-period-minutes", 10);
+    newKeysAdded |= addDefaultIfMissing("team.deadline-notify-period-seconds", 300L);
+    newKeysAdded |= addDefaultIfMissing("team.save-interval-seconds", 60L);
+    newKeysAdded |= addDefaultIfMissing("team.deadline-display-mode", "CHAT");
+    newKeysAdded |= addDefaultIfMissing("team.deadline-removal-policy", "last-joined");
 
     // Настройки меню
-    config.addDefault("menu.open-sound", "BLOCK_NOTE_BLOCK_PLING");
-    config.addDefault("menu.particle-effect", "FIREWORK");
-    config.addDefault("menu.sound-volume", 1.0);
-    config.addDefault("menu.sound-pitch", 1.0);
+    newKeysAdded |= addDefaultIfMissing("menu.open-sound", "BLOCK_NOTE_BLOCK_PLING");
+    newKeysAdded |= addDefaultIfMissing("menu.particle-effect", "FIREWORK");
+    newKeysAdded |= addDefaultIfMissing("menu.sound-volume", 1.0);
+    newKeysAdded |= addDefaultIfMissing("menu.sound-pitch", 1.0);
 
     config.options().copyDefaults(true);
-    saveConfig();
+
+    if (persistChanges && newKeysAdded) {
+      saveConfig();
+    }
+  }
+
+  private boolean addDefaultIfMissing(@NotNull String path, Object value) {
+    boolean missing = !config.contains(path);
+    config.addDefault(path, value);
+    return missing;
   }
 
   /** Сохраняет файл конфигурации. */
@@ -87,7 +98,7 @@ public class PluginConfig {
   /** Перезагружает конфигурацию из файла. */
   public void reloadConfig() {
     config = YamlConfiguration.loadConfiguration(configFile);
-    setDefaults();
+    setDefaults(false);
   }
 
   /**

--- a/src/test/java/org/example/config/PluginConfigTest.java
+++ b/src/test/java/org/example/config/PluginConfigTest.java
@@ -8,6 +8,9 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import be.seeseemelk.mockbukkit.plugin.PluginManagerMock;
 import java.io.File;
 import java.lang.reflect.Field;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
 import org.bukkit.command.CommandMap;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -120,9 +123,6 @@ class PluginConfigTest {
     FileConfiguration configuration = (FileConfiguration) configField.get(pluginConfig);
 
     assertEquals("BLOCK_NOTE_BLOCK_PLING", configuration.getString("menu.open-sound"));
-
-    YamlConfiguration reloaded = YamlConfiguration.loadConfiguration(configFile);
-    assertEquals("BLOCK_NOTE_BLOCK_PLING", reloaded.getString("menu.open-sound"));
   }
 
   @Test
@@ -147,8 +147,51 @@ class PluginConfigTest {
     CommandMap commandMap = server.getCommandMap();
     assertTrue(commandMap.dispatch(console, "teamreload"));
 
-    YamlConfiguration reloaded = YamlConfiguration.loadConfiguration(configFile);
-    assertEquals("FIREWORK", reloaded.getString("menu.particle-effect"));
-    assertEquals(7, reloaded.getInt("team.max-members"));
+    Field configField = PluginConfig.class.getDeclaredField("config");
+    configField.setAccessible(true);
+    FileConfiguration configuration = (FileConfiguration) configField.get(pluginConfig);
+
+    assertEquals("FIREWORK", configuration.getString("menu.particle-effect"));
+    assertEquals(7, configuration.getInt("team.max-members"));
+  }
+
+  @Test
+  void reloadConfigKeepsFileHashAndComments() throws Exception {
+    server = MockBukkit.mock();
+    MyPurpurPlugin plugin = MockBukkit.load(MyPurpurPlugin.class);
+
+    Field cfgField = MyPurpurPlugin.class.getDeclaredField("pluginConfig");
+    cfgField.setAccessible(true);
+    PluginConfig pluginConfig = (PluginConfig) cfgField.get(plugin);
+
+    Field fileField = PluginConfig.class.getDeclaredField("configFile");
+    fileField.setAccessible(true);
+    File configFile = (File) fileField.get(pluginConfig);
+
+    String customComment = "# admin-note: keep this comment";
+    Files.writeString(
+        configFile.toPath(),
+        System.lineSeparator() + customComment + System.lineSeparator(),
+        StandardOpenOption.APPEND);
+
+    byte[] initialContent = Files.readAllBytes(configFile.toPath());
+    byte[] initialHash = MessageDigest.getInstance("SHA-256").digest(initialContent);
+
+    pluginConfig.reloadConfig();
+
+    byte[] afterFirstReload = Files.readAllBytes(configFile.toPath());
+    byte[] firstReloadHash = MessageDigest.getInstance("SHA-256").digest(afterFirstReload);
+
+    assertArrayEquals(initialHash, firstReloadHash, "Hashes should match after first reload");
+    assertTrue(new String(afterFirstReload).contains(customComment));
+
+    pluginConfig.reloadConfig();
+
+    byte[] afterSecondReload = Files.readAllBytes(configFile.toPath());
+    byte[] secondReloadHash = MessageDigest.getInstance("SHA-256").digest(afterSecondReload);
+
+    assertArrayEquals(
+        initialHash, secondReloadHash, "Hashes should remain stable after repeated reloads");
+    assertTrue(new String(afterSecondReload).contains(customComment));
   }
 }


### PR DESCRIPTION
## Summary
- track whether PluginConfig defaults add new keys and persist them only when necessary
- stop rewriting config files during reloads while still copying defaults into memory
- update PluginConfig tests and add a regression test that guards comment preservation

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68ced33b479c832e93402fbcefbac1ec