### PR TITLE
Refactor team membership to use UUID identifiers

### DIFF
--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -16,9 +16,9 @@ public class Team {
   private final UUID id; // Уникальный неизменяемый идентификатор
   private String name; // Название команды, теперь изменяемое
 
-  private String leader;
-  private final List<String> members;
-  private final Set<String> memberNamesLower;
+  private UUID leader;
+  private final List<UUID> members;
+  private final Set<UUID> memberLookup;
 
   private String prefix;
   private NamedTextColor color;
@@ -32,10 +32,11 @@ public class Team {
     this.name = name;
     this.leader = leader;
     this.members = new ArrayList<>();
-    this.memberNamesLower = new HashSet<>();
+    this.memberLookup = new HashSet<>();
     addMember(leader);
     this.prefix = prefix;
-    this.color = NamedTextColor.NAMES.valueOr(color.toLowerCase(Locale.ROOT), NamedTextColor.WHITE);
+    this.color =
+        NamedTextColor.NAMES.valueOr(color.toLowerCase(Locale.ROOT), NamedTextColor.WHITE);
   }
 
   // Геттеры
@@ -74,6 +75,7 @@ public class Team {
 
   public void setLeader(UUID leader) {
     this.leader = leader;
+    addMember(leader);
   }
 
   public void setPrefix(String prefix) {
@@ -81,37 +83,41 @@ public class Team {
   }
 
   public void setColor(String color) {
-    this.color = NamedTextColor.NAMES.valueOr(color.toLowerCase(Locale.ROOT), NamedTextColor.WHITE);
+    this.color =
+        NamedTextColor.NAMES.valueOr(color.toLowerCase(Locale.ROOT), NamedTextColor.WHITE);
   }
 
   // Методы управления участниками
 
-  public void addMember(String member) {
-    String normalized = normalize(member);
-    if (memberNamesLower.add(normalized)) {
-
+  public void addMember(UUID member) {
+    if (member == null) {
+      return;
+    }
+    if (memberLookup.add(member)) {
       members.add(member);
     }
   }
 
-
-  public void removeMember(String member) {
-    String normalized = normalize(member);
-    if (memberNamesLower.remove(normalized)) {
-      members.removeIf(existing -> existing.equalsIgnoreCase(member));
+  public void removeMember(UUID member) {
+    if (member == null) {
+      return;
     }
-
+    if (memberLookup.remove(member)) {
+      members.removeIf(existing -> existing.equals(member));
+    }
   }
 
   public void setMembers(List<UUID> newMembers) {
     members.clear();
-    memberNamesLower.clear();
-    for (String newMember : newMembers) {
+    memberLookup.clear();
+    if (newMembers == null) {
+      return;
+    }
+    for (UUID newMember : newMembers) {
       if (newMember == null) {
         continue;
       }
-      String normalized = normalize(newMember);
-      if (memberNamesLower.add(normalized)) {
+      if (memberLookup.add(newMember)) {
         members.add(newMember);
       }
     }
@@ -124,28 +130,25 @@ public class Team {
 
   // Проверка, является ли игрок участником
 
-  public boolean hasMember(String playerName) {
-    return memberNamesLower.contains(normalize(playerName));
+  public boolean hasMember(UUID playerId) {
+    return playerId != null && memberLookup.contains(playerId);
   }
 
   // Проверка, является ли игрок лидером
-  public boolean isLeader(String playerName) {
-    return leader.equalsIgnoreCase(playerName);
+  public boolean isLeader(UUID playerId) {
+    return playerId != null && playerId.equals(leader);
   }
 
   @Nullable
-  public String findMember(String playerName) {
-    String normalized = normalize(playerName);
-    for (String member : members) {
-      if (normalize(member).equals(normalized)) {
+  public UUID findMember(UUID playerId) {
+    if (playerId == null) {
+      return null;
+    }
+    for (UUID member : members) {
+      if (member.equals(playerId)) {
         return member;
       }
     }
     return null;
-  }
-
-  private String normalize(String playerName) {
-    return playerName.toLowerCase(Locale.ROOT);
-
   }
 }

--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -8,7 +8,6 @@ import java.util.concurrent.TimeUnit;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
@@ -36,7 +35,7 @@ public class DeadlineScheduler {
   private final PluginConfig pluginConfig;
   private final TeamStorage storage;
   private final Map<UUID, Long> deadlines = new ConcurrentHashMap<>();
-  private final Map<String, Scoreboard> leaderOriginalScoreboards = new ConcurrentHashMap<>();
+  private final Map<UUID, Scoreboard> leaderOriginalScoreboards = new ConcurrentHashMap<>();
   private final Map<UUID, UUID> teamLeaderIds = new ConcurrentHashMap<>();
   private BukkitTask task;
 
@@ -116,7 +115,7 @@ public class DeadlineScheduler {
     boolean removed = deadlines.remove(teamId) != null;
     UUID leaderId = teamLeaderIds.remove(teamId);
     if (leaderId != null) {
-      clearLeaderDisplay(resolvePlayerName(leaderId));
+      clearLeaderDisplay(leaderId);
     } else {
       clearLeaderDisplay(team);
     }
@@ -319,7 +318,7 @@ public class DeadlineScheduler {
     if (previousLeader != null
         && (currentLeader == null || !previousLeader.equals(currentLeader))) {
       teamLeaderIds.remove(teamId, previousLeader);
-      clearLeaderDisplay(resolvePlayerName(previousLeader));
+      clearLeaderDisplay(previousLeader);
     }
     Long deadlineAt = deadlines.get(teamId);
     if (deadlineAt == null) {
@@ -379,7 +378,7 @@ public class DeadlineScheduler {
       if (team == null) {
         UUID leaderId = teamLeaderIds.remove(teamId);
         if (leaderId != null) {
-          clearLeaderDisplay(resolvePlayerName(leaderId));
+          clearLeaderDisplay(leaderId);
         }
         deadlinesToRemove.add(teamId);
         changed = true;
@@ -436,7 +435,6 @@ public class DeadlineScheduler {
       deadlinesToRemove.stream()
           .map(teamLeaderIds::remove)
           .filter(Objects::nonNull)
-          .map(this::resolvePlayerName)
           .forEach(this::clearLeaderDisplay);
     }
     if (changed) {
@@ -562,19 +560,18 @@ public class DeadlineScheduler {
   private void clearLeaderDisplay(@NotNull Team team) {
     UUID notifiedLeader = teamLeaderIds.remove(team.getId());
     if (notifiedLeader != null) {
-      clearLeaderDisplay(resolvePlayerName(notifiedLeader));
+      clearLeaderDisplay(notifiedLeader);
     } else {
-      clearLeaderDisplay(resolvePlayerName(team.getLeaderId()));
+      clearLeaderDisplay(team.getLeaderId());
     }
   }
 
-  private void clearLeaderDisplay(String leaderName) {
-    if (leaderName == null || leaderName.isBlank()) {
+  private void clearLeaderDisplay(UUID leaderId) {
+    if (leaderId == null) {
       return;
     }
-    String key = leaderName.toLowerCase(Locale.ROOT);
-    Scoreboard original = leaderOriginalScoreboards.remove(key);
-    Player leader = plugin.getServer().getPlayer(leaderName);
+    Scoreboard original = leaderOriginalScoreboards.remove(leaderId);
+    Player leader = plugin.getServer().getPlayer(leaderId);
     DeadlineDisplayMode mode = getDisplayMode();
     if (leader != null) {
       if (original != null) {
@@ -591,18 +588,9 @@ public class DeadlineScheduler {
     }
   }
 
-  private String resolvePlayerName(UUID playerId) {
-    if (playerId == null) {
-      return null;
-    }
-    OfflinePlayer offlinePlayer = plugin.getServer().getOfflinePlayer(playerId);
-    return offlinePlayer != null ? offlinePlayer.getName() : null;
-  }
-
   private void notifyLeader(@NotNull Team team, @NotNull Component message) {
     UUID leaderId = team.getLeaderId();
-    String leaderName = resolvePlayerName(leaderId);
-    if (leaderName == null || leaderName.isBlank()) {
+    if (leaderId == null) {
       return;
     }
     Player leader = plugin.getServer().getPlayer(leaderId);
@@ -613,12 +601,12 @@ public class DeadlineScheduler {
     if (mode == DeadlineDisplayMode.SCOREBOARD) {
       UUID previousLeader = teamLeaderIds.put(team.getId(), leaderId);
       if (previousLeader != null && !previousLeader.equals(leaderId)) {
-        clearLeaderDisplay(resolvePlayerName(previousLeader));
+        clearLeaderDisplay(previousLeader);
       }
     } else {
       UUID previousLeader = teamLeaderIds.remove(team.getId());
       if (previousLeader != null) {
-        clearLeaderDisplay(resolvePlayerName(previousLeader));
+        clearLeaderDisplay(previousLeader);
       }
     }
     switch (mode) {
@@ -630,8 +618,7 @@ public class DeadlineScheduler {
 
   private void notifyLeaderWithoutScoreboard(@NotNull Team team, @NotNull Component message) {
     UUID leaderId = team.getLeaderId();
-    String leaderName = resolvePlayerName(leaderId);
-    if (leaderName == null || leaderName.isBlank()) {
+    if (leaderId == null) {
       return;
     }
     Player leader = plugin.getServer().getPlayer(leaderId);
@@ -656,8 +643,8 @@ public class DeadlineScheduler {
       TeamMessageUtils.sendTeamMessage(player, message);
       return;
     }
-    String key = player.getName().toLowerCase(Locale.ROOT);
-    leaderOriginalScoreboards.computeIfAbsent(key, k -> player.getScoreboard());
+    UUID playerId = player.getUniqueId();
+    leaderOriginalScoreboards.putIfAbsent(playerId, player.getScoreboard());
     Scoreboard scoreboard = manager.getNewScoreboard();
     Objective objective =
         scoreboard.registerNewObjective(

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -128,25 +128,22 @@ public class MembershipService {
     Team team = storage.getTeamByName(teamName);
     // Проверяем право лидера на это действие и наличие цели в команде.
 
-    if (team == null || !team.isLeader(leader.getName())) return;
-    String normalizedTarget = targetName.toLowerCase(Locale.ROOT);
-    if (!team.hasMember(normalizedTarget)) return;
-    if (team.isLeader(normalizedTarget)) {
-
-      removePlayerFromTeam(teamName, leader);
+    if (team == null || !team.isLeader(leader.getUniqueId())) return;
+    UUID targetId = findMemberIdByName(team, targetName);
+    if (targetId == null) {
       return;
     }
-    String actualTargetName = team.findMember(normalizedTarget);
-    if (actualTargetName == null) {
+    if (team.isLeader(targetId)) {
+      removePlayerFromTeam(teamName, leader);
       return;
     }
     // Удаляем участника и фиксируем изменения.
 
-    team.removeMember(actualTargetName);
-    storage.getPlayerTeams().remove(actualTargetName);
+    team.removeMember(targetId);
+    storage.getPlayerTeams().remove(targetId);
     storage.markTeamDirty(team);
     scheduler.enforceTeamSizes(false);
-    notifyPrefixUpdate(actualTargetName, null);
+    notifyPrefixUpdate(targetId, null);
 
     updateTeamMembersPrefixes(team);
   }

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -165,7 +165,8 @@ public class TeamStorage {
       Team team = entry.getValue();
       String path = "teams." + teamId;
       teamsConfig.set(path + ".name", team.getName());
-      teamsConfig.set(path + ".leader", team.getLeaderId().toString());
+      UUID leaderId = team.getLeaderId();
+      teamsConfig.set(path + ".leader", leaderId != null ? leaderId.toString() : null);
       teamsConfig.set(
           path + ".members",
           team.getMembers().stream().map(UUID::toString).collect(Collectors.toList()));

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -340,7 +340,7 @@ class TeamCommandTest {
 
     assertTrue(commandMap.dispatch(leader, "teamadmin kick kicktarget"));
 
-    assertFalse(teamManager.getTeamMembers("Delta").contains("KickTarget"));
+    assertFalse(teamManager.getTeamMembers("Delta").contains(member.getUniqueId()));
     assertNull(teamManager.getPlayerTeam(member));
   }
 
@@ -363,7 +363,7 @@ class TeamCommandTest {
 
     assertTrue(commandMap.dispatch(leader, "teamadmin transfer transferheir"));
 
-    assertEquals("TransferHeir", teamManager.getTeamLeader("Sigma"));
+    assertEquals(successor.getUniqueId(), teamManager.getTeamLeaderId("Sigma"));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Switch the Team model to store leaders and members as UUIDs and update member management helpers.
- Update membership flows, deadline scheduling, and storage serialization to operate on UUIDs and persist them.
- Refresh admin command tests to assert against UUID-based leader and member tracking.

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cef72bb9a0832e98e1742b1127835c