### PR TITLE
Add regression test for teamadmin kick prefix reset

### DIFF
--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -345,6 +345,31 @@ class TeamCommandTest {
   }
 
   @Test
+  void adminKickCommandClearsMembershipAndTabPrefix() {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("KickCaptain");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    leader.addAttachment(plugin, "mypurpurplugin.teamadmin", true);
+
+    PlayerMock member = server.addPlayer("KickRecruit");
+
+    assertTrue(commandMap.dispatch(leader, "team create Gamma GM WHITE"));
+    teamManager.addPlayerToTeam("Gamma", member);
+
+    Component expectedPrefix =
+        Component.text("[GM] ", NamedTextColor.WHITE)
+            .append(Component.text(member.getName(), NamedTextColor.WHITE));
+    assertEquals(expectedPrefix, member.playerListName());
+
+    assertTrue(commandMap.dispatch(leader, "teamadmin kick KickRecruit"));
+
+    assertNull(teamManager.getPlayerTeam(member));
+    Component reset = Component.text(member.getName(), NamedTextColor.WHITE);
+    assertEquals(reset, member.playerListName());
+  }
+
+  @Test
   void adminTransferCommandMatchesMemberIgnoringCase() {
     CommandMap commandMap = server.getCommandMap();
 


### PR DESCRIPTION
## Summary
- add a MockBukkit regression test to /teamadmin kick that ensures the kicked player loses their team assignment and tab prefix

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf051c1e64832eaec4598438750794