### PR TITLE
Add Gradle CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,20 +2,42 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: [ main ]
   pull_request:
-    branches: ["main"]
+    branches: [ main ]
 
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up JDK 21
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '21'
-          cache: 'gradle'
-      - name: Build with Gradle
-        run: ./gradlew test build -PenableRealServerTests=false
+          distribution: temurin
+          java-version: "21"
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for Gradle wrapper
+        run: chmod +x gradlew
+
+      - name: Run Spotless check
+        run: ./gradlew spotlessCheck
+
+      - name: Run tests
+        run: ./gradlew test
+
+      - name: Build project
+        run: ./gradlew build


### PR DESCRIPTION
## Summary
- add a CI workflow that checks out the code, configures Java 21, caches Gradle directories, and runs the Gradle spotlessCheck, test, and build tasks

## Testing
- `./gradlew spotlessCheck test build` *(fails: spotlessJavaCheck reports existing formatting violations)*

------
https://chatgpt.com/codex/tasks/task_e_68cf9202f430832e8925ffc7c4223ef5