### PR TITLE
Normalize team input whitespace

### DIFF
--- a/src/main/java/org/example/command/TeamAdminCommand.java
+++ b/src/main/java/org/example/command/TeamAdminCommand.java
@@ -95,7 +95,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
               "❌ Вы не состоите в команде и не можете передать лидерство!", NamedTextColor.RED));
       return true;
     }
-    String newLeaderName = args[1];
+    String newLeaderName = args[1].trim();
     Player newLeader = teamManager.getPlugin().getServer().getPlayerExact(newLeaderName);
     if (newLeader == null || !newLeader.isOnline()) {
       TeamMessageUtils.sendTeamMessage(
@@ -123,7 +123,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
               "❌ Вы не состоите в команде и не можете исключать игроков!", NamedTextColor.RED));
       return true;
     }
-    String targetName = args[1];
+    String targetName = args[1].trim();
     if (targetName.equalsIgnoreCase(player.getName())) {
       TeamMessageUtils.sendTeamMessage(
           player, Component.text("❌ Вы не можете исключить себя из команды!", NamedTextColor.RED));
@@ -162,7 +162,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
               "❌ Вы не состоите в команде и не можете её переименовать!", NamedTextColor.RED));
       return true;
     }
-    String newTeamName = args[1];
+    String newTeamName = args[1].trim();
     if (TeamUtils.isTeamNameLengthInvalid(newTeamName, pluginConfig, player)) {
       return true;
     }
@@ -186,7 +186,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
               "❌ Вы не состоите в команде и не можете изменить её префикс!", NamedTextColor.RED));
       return true;
     }
-    String newPrefix = args[1];
+    String newPrefix = args[1].trim();
     teamManager.setTeamPrefix(teamName, newPrefix, player);
     return true;
   }
@@ -206,7 +206,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
               "❌ Вы не состоите в команде и не можете изменить её цвет!", NamedTextColor.RED));
       return true;
     }
-    String newColor = args[1];
+    String newColor = args[1].trim();
     teamManager.setTeamColor(teamName, newColor, player);
     return true;
   }

--- a/src/main/java/org/example/command/sub/CreateSubCommand.java
+++ b/src/main/java/org/example/command/sub/CreateSubCommand.java
@@ -28,7 +28,10 @@ public class CreateSubCommand implements SubCommand {
               NamedTextColor.RED));
       return true;
     }
-    teamService.createTeam(args[1], args[2], args[3], player);
+    String teamName = args[1].trim();
+    String prefix = args[2].trim();
+    String color = args[3].trim();
+    teamService.createTeam(teamName, prefix, color, player);
     return true;
   }
 

--- a/src/main/java/org/example/command/sub/JoinSubCommand.java
+++ b/src/main/java/org/example/command/sub/JoinSubCommand.java
@@ -27,7 +27,8 @@ public class JoinSubCommand implements SubCommand {
           Component.text("❌ Использование: /team join <название>", NamedTextColor.RED));
       return true;
     }
-    teamService.addPlayerToTeam(args[1], player);
+    String teamName = args[1].trim();
+    teamService.addPlayerToTeam(teamName, player);
     return true;
   }
 

--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -29,12 +29,12 @@ public class Team {
 
   public Team(UUID id, String name, UUID leader, String prefix, String color) {
     this.id = id;
-    this.name = name;
+    this.name = normalizeName(name);
     this.leader = leader;
     this.members = new ArrayList<>();
     this.memberLookup = new HashSet<>();
     addMember(leader);
-    this.prefix = prefix;
+    this.prefix = normalizePrefix(prefix);
     this.color =
         NamedTextColor.NAMES.valueOr(color.toLowerCase(Locale.ROOT), NamedTextColor.WHITE);
   }
@@ -70,7 +70,7 @@ public class Team {
 
   // Сеттеры
   public void setName(String name) {
-    this.name = name;
+    this.name = normalizeName(name);
   }
 
   public void setLeader(UUID leader) {
@@ -79,7 +79,7 @@ public class Team {
   }
 
   public void setPrefix(String prefix) {
-    this.prefix = prefix;
+    this.prefix = normalizePrefix(prefix);
   }
 
   public void setColor(String color) {
@@ -150,5 +150,13 @@ public class Team {
       }
     }
     return null;
+  }
+
+  private static String normalizeName(String name) {
+    return name == null ? "" : name.trim();
+  }
+
+  private static String normalizePrefix(String prefix) {
+    return prefix == null ? "" : prefix.trim();
   }
 }

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -34,25 +34,31 @@ public class MembershipService {
   }
 
   public void createTeam(String teamName, String prefix, String color, @NotNull Player leader) {
+    String normalizedTeamName = teamName == null ? "" : teamName.trim();
+    String normalizedPrefix = prefix == null ? "" : prefix.trim();
+    String normalizedColor = color == null ? "" : color.trim();
     // Убеждаемся, что имя и лидер свободны, чтобы не создавать дубликатов команд.
-    if (storage.getPlayerTeam(leader) != null || storage.getTeamByName(teamName) != null) {
-      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.teamAlreadyExistsMessage(teamName));
+    if (storage.getPlayerTeam(leader) != null
+        || storage.getTeamByName(normalizedTeamName) != null) {
+      TeamMessageUtils.sendTeamMessage(
+          leader, TeamMessageUtils.teamAlreadyExistsMessage(normalizedTeamName));
       return;
     }
     // Проверяем, что игрок выбрал поддерживаемый цвет для корректного отображения.
-    NamedTextColor teamColor = NamedTextColor.NAMES.value(color.toLowerCase(Locale.ROOT));
+    NamedTextColor teamColor =
+        NamedTextColor.NAMES.value(normalizedColor.toLowerCase(Locale.ROOT));
     if (teamColor == null) {
       TeamMessageUtils.sendTeamMessage(
           leader, Component.text("❌ Неверный цвет команды", NamedTextColor.RED));
       return;
     }
     // Валидируем длину имени и префикса согласно настройкам плагина.
-    if (TeamUtils.isTeamNameLengthInvalid(teamName, pluginConfig, leader)
-        || TeamUtils.isPrefixLengthInvalid(prefix, pluginConfig, leader)) {
+    if (TeamUtils.isTeamNameLengthInvalid(normalizedTeamName, pluginConfig, leader)
+        || TeamUtils.isPrefixLengthInvalid(normalizedPrefix, pluginConfig, leader)) {
       return;
     }
     // Создаём запись команды и связываем лидера с новой структурой.
-    Team team = new Team(teamName, leader.getUniqueId(), prefix, color);
+    Team team = new Team(normalizedTeamName, leader.getUniqueId(), normalizedPrefix, normalizedColor);
     storage.addTeam(team);
     updateTeamMembersPrefixes(team);
     storage.getPlayerTeams().put(leader.getUniqueId(), team.getId());
@@ -62,10 +68,12 @@ public class MembershipService {
   }
 
   public void addPlayerToTeam(String teamName, @NotNull Player player) {
-    Team team = storage.getTeamByName(teamName);
+    String normalizedTeamName = teamName == null ? "" : teamName.trim();
+    Team team = storage.getTeamByName(normalizedTeamName);
     // Если команда не найдена — сообщаем игроку и прекращаем обработку.
     if (team == null) {
-      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.teamDoesNotExistMessage(teamName));
+      TeamMessageUtils.sendTeamMessage(
+          player, TeamMessageUtils.teamDoesNotExistMessage(normalizedTeamName));
       return;
     }
     // Не допускаем вступления игроков, у которых уже есть команда.
@@ -184,16 +192,18 @@ public class MembershipService {
     Team team = storage.getTeamByName(oldTeamName);
     // Проверяем полномочия и уникальность нового имени.
     if (team == null || !team.isLeader(leader.getUniqueId())) return;
-    if (storage.getTeamByName(newTeamName) != null) return;
-    storage.updateTeamName(team, newTeamName);
+    String normalizedNewName = newTeamName == null ? "" : newTeamName.trim();
+    if (storage.getTeamByName(normalizedNewName) != null) return;
+    storage.updateTeamName(team, normalizedNewName);
   }
 
   public void setTeamPrefix(String teamName, String newPrefix, @NotNull Player leader) {
     Team team = storage.getTeamByName(teamName);
     // Изменение префикса доступно только лидеру, при этом валидируем значение.
     if (team == null || !team.isLeader(leader.getUniqueId())) return;
-    if (TeamUtils.isPrefixLengthInvalid(newPrefix, pluginConfig, leader)) return;
-    team.setPrefix(newPrefix);
+    String normalizedPrefix = newPrefix == null ? "" : newPrefix.trim();
+    if (TeamUtils.isPrefixLengthInvalid(normalizedPrefix, pluginConfig, leader)) return;
+    team.setPrefix(normalizedPrefix);
     storage.markTeamDirty(team);
     updateTeamMembersPrefixes(team);
   }
@@ -202,13 +212,15 @@ public class MembershipService {
     Team team = storage.getTeamByName(teamName);
     // Проверяем права и корректность цвета перед сохранением.
     if (team == null || !team.isLeader(leader.getUniqueId())) return;
-    NamedTextColor teamColor = NamedTextColor.NAMES.value(newColor.toLowerCase(Locale.ROOT));
+    String normalizedColor = newColor == null ? "" : newColor.trim();
+    NamedTextColor teamColor =
+        NamedTextColor.NAMES.value(normalizedColor.toLowerCase(Locale.ROOT));
     if (teamColor == null) {
       TeamMessageUtils.sendTeamMessage(
           leader, Component.text("❌ Неверный цвет команды", NamedTextColor.RED));
       return;
     }
-    team.setColor(newColor);
+    team.setColor(normalizedColor);
     storage.markTeamDirty(team);
     updateTeamMembersPrefixes(team);
   }

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -136,7 +136,7 @@ public class TeamStorage {
           memberIds.add(leaderId);
           convertedMembers = true;
         }
-        Team team = new Team(teamId, name, leaderId, prefix, color);
+        Team team = new Team(teamId, name != null ? name.trim() : null, leaderId, prefix, color);
         team.setMembers(memberIds);
         long deadline = teamsConfig.getLong("teams." + teamIdStr + ".deadline", 0L);
         if (deadline > 0L) {
@@ -213,11 +213,12 @@ public class TeamStorage {
   }
 
   public void updateTeamName(@NotNull Team team, @NotNull String newName) {
+    String normalizedNewNameValue = newName.trim();
     String currentName = team.getName();
-    if (Objects.equals(currentName, newName)) {
+    if (Objects.equals(currentName, normalizedNewNameValue)) {
       return;
     }
-    String normalizedNewName = normalizeTeamKey(newName);
+    String normalizedNewName = normalizeTeamKey(normalizedNewNameValue);
     if (normalizedNewName != null) {
       UUID existingId = teamIdsByName.get(normalizedNewName);
       if (existingId != null && !existingId.equals(team.getId())) {
@@ -228,7 +229,7 @@ public class TeamStorage {
     if (normalizedCurrentName != null) {
       teamIdsByName.remove(normalizedCurrentName);
     }
-    team.setName(newName);
+    team.setName(normalizedNewNameValue);
     if (normalizedNewName != null) {
       teamIdsByName.put(normalizedNewName, team.getId());
     }
@@ -390,7 +391,7 @@ public class TeamStorage {
   }
 
   private static String normalizeTeamKey(String name) {
-    return name != null ? name.toLowerCase(Locale.ROOT) : null;
+    return name != null ? name.trim().toLowerCase(Locale.ROOT) : null;
   }
 
   private UUID parseUuid(String value) {

--- a/src/main/java/org/example/util/TeamUtils.java
+++ b/src/main/java/org/example/util/TeamUtils.java
@@ -53,21 +53,35 @@ public class TeamUtils {
    */
   public static boolean isPrefixLengthInvalid(
       String prefix, PluginConfig pluginConfig, Player player) {
+    String normalizedPrefix = prefix == null ? "" : prefix.trim();
     int minPrefixLength = pluginConfig.getMinPrefixLength();
     int maxPrefixLength = pluginConfig.getMaxPrefixLength();
-    if (prefix.length() < minPrefixLength) {
+    int actualLength = normalizedPrefix.length();
+    if (actualLength < minPrefixLength) {
       TeamMessageUtils.sendTeamMessage(
           player,
           Component.text(
-              "❌ Префикс слишком короткий!\nМинимальная длина — " + minPrefixLength + " символов.",
+              "❌ Префикс слишком короткий! (значение: \""
+                  + normalizedPrefix
+                  + "\", длина: "
+                  + actualLength
+                  + ")\nМинимальная длина — "
+                  + minPrefixLength
+                  + " символов.",
               NamedTextColor.RED));
       return true;
     }
-    if (prefix.length() > maxPrefixLength) {
+    if (actualLength > maxPrefixLength) {
       TeamMessageUtils.sendTeamMessage(
           player,
           Component.text(
-              "❌ Префикс слишком длинный!\nМаксимальная длина — " + maxPrefixLength + " символов.",
+              "❌ Префикс слишком длинный! (значение: \""
+                  + normalizedPrefix
+                  + "\", длина: "
+                  + actualLength
+                  + ")\nМаксимальная длина — "
+                  + maxPrefixLength
+                  + " символов.",
               NamedTextColor.RED));
       return true;
     }
@@ -84,23 +98,33 @@ public class TeamUtils {
    */
   public static boolean isTeamNameLengthInvalid(
       String teamName, PluginConfig pluginConfig, Player player) {
+    String normalizedName = teamName == null ? "" : teamName.trim();
     int minTeamNameLength = pluginConfig.getMinTeamNameLength();
     int maxTeamNameLength = pluginConfig.getMaxTeamNameLength();
-    if (teamName.length() < minTeamNameLength) {
+    int actualLength = normalizedName.length();
+    if (actualLength < minTeamNameLength) {
       TeamMessageUtils.sendTeamMessage(
           player,
           Component.text(
-              "❌ Название команды слишком короткое!\nМинимальная длина — "
+              "❌ Название команды слишком короткое! (значение: \""
+                  + normalizedName
+                  + "\", длина: "
+                  + actualLength
+                  + ")\nМинимальная длина — "
                   + minTeamNameLength
                   + " символов.",
               NamedTextColor.RED));
       return true;
     }
-    if (teamName.length() > maxTeamNameLength) {
+    if (actualLength > maxTeamNameLength) {
       TeamMessageUtils.sendTeamMessage(
           player,
           Component.text(
-              "❌ Название команды слишком длинное!\nМаксимальная длина — "
+              "❌ Название команды слишком длинное! (значение: \""
+                  + normalizedName
+                  + "\", длина: "
+                  + actualLength
+                  + ")\nМаксимальная длина — "
                   + maxTeamNameLength
                   + " символов.",
               NamedTextColor.RED));

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -184,6 +184,22 @@ class TeamCommandTest {
   }
 
   @Test
+  void joinCommandMatchesNameWhenTeamCreatedWithTrailingWhitespace() {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock leader = server.addPlayer("WhitespaceLeader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    teamManager.createTeam("Omega ", "OO", "WHITE", leader);
+    assertEquals("Omega", teamManager.getPlayerTeam(leader));
+
+    PlayerMock recruit = server.addPlayer("WhitespaceRecruit");
+    recruit.addAttachment(plugin, "mypurpurplugin.team", true);
+
+    assertTrue(commandMap.dispatch(recruit, "team join Omega"));
+    assertEquals("Omega", teamManager.getPlayerTeam(recruit));
+  }
+
+  @Test
   void deniesCommandWithoutPermission() {
     CommandMap commandMap = server.getCommandMap();
     PlayerMock player = server.addPlayer("Player");


### PR DESCRIPTION
## Summary
- trim team and prefix arguments across admin and player commands before validation and service calls
- normalize stored team names/prefixes and update validation messages to reflect trimmed values
- cover joining a team created with trailing whitespace via integration test

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cf96c8e18c832eb55b80c541ffba85