### PR TITLE
Use cached prefixes during async chat rendering

### DIFF
--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -7,6 +7,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
@@ -64,30 +65,26 @@ public class TeamChatListener implements Listener {
   @EventHandler
   public void onPlayerChat(@NotNull AsyncChatEvent event) {
     Player player = event.getPlayer();
-    String teamName = teamManager.getPlayerTeam(player);
     ((MyPurpurPlugin) teamManager.getPlugin())
-        .debugTeamAction("Обработка сообщения от игрока", player.getName(), teamName);
+        .debugTeamAction("Обработка сообщения от игрока", player.getName(), null);
 
     boolean forceWhiteChat = teamManager.getPluginConfig().isForceWhiteChat();
+    UUID playerId = player.getUniqueId();
+    Component prefixComponent = lastPlayerPrefixes.get(playerId);
 
-    if (teamName != null) {
-      String prefix = teamManager.getTeamPrefix(teamName);
-      NamedTextColor teamColor = teamManager.getTeamColor(teamName);
-      Component prefixComponent = TeamUtils.createPrefixComponent(prefix, teamColor);
-
-      event.renderer(
-          (source, sourceDisplayName, message, viewer) ->
-              prefixComponent
-                  .append(sourceDisplayName)
-                  .append(Component.text(": "))
-                  .append(forceWhiteChat ? message.color(NamedTextColor.WHITE) : message));
-    } else {
-      event.renderer(
-          (source, sourceDisplayName, message, viewer) ->
-              sourceDisplayName
-                  .append(Component.text(": "))
-                  .append(forceWhiteChat ? message.color(NamedTextColor.WHITE) : message));
+    if (prefixComponent == null) {
+      Bukkit.getScheduler().runTask(teamManager.getPlugin(), () -> updatePlayerPrefix(player));
     }
+
+    event.renderer(
+        (source, sourceDisplayName, message, viewer) -> {
+          Component base = Component.empty();
+          if (prefixComponent != null) {
+            base = base.append(prefixComponent);
+          }
+          Component formattedMessage = forceWhiteChat ? message.color(NamedTextColor.WHITE) : message;
+          return base.append(sourceDisplayName).append(Component.text(": ")).append(formattedMessage);
+        });
   }
 
   @EventHandler

--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -14,14 +14,14 @@ import org.jetbrains.annotations.Nullable;
 /** Представляет команду с уникальным идентификатором и изменяемыми данными. */
 public class Team {
   private final UUID id; // Уникальный неизменяемый идентификатор
-  private String name; // Название команды, теперь изменяемое
+  private volatile String name; // Название команды, теперь изменяемое
 
   private UUID leader;
   private final List<UUID> members;
   private final Set<UUID> memberLookup;
 
-  private String prefix;
-  private NamedTextColor color;
+  private volatile String prefix;
+  private volatile NamedTextColor color;
 
   public Team(String name, UUID leader, String prefix, String color) {
     this(UUID.randomUUID(), name, leader, prefix, color);

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -68,6 +68,11 @@ class TeamChatListenerTest extends MockBukkitTestBase {
     PlayerMock player = server.addPlayer("Chatter");
     teamService.createTeam("Beta", player, "B", NamedTextColor.BLUE);
 
+    Component prefixComponent = Component.text("[B] ", NamedTextColor.BLUE);
+    server
+        .getPluginManager()
+        .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefixComponent));
+
     Component message = Component.text("Привет", NamedTextColor.GREEN);
     Set<Audience> viewers = new HashSet<>();
     ChatRenderer initialRenderer = ChatRenderer.defaultRenderer();
@@ -122,6 +127,33 @@ class TeamChatListenerTest extends MockBukkitTestBase {
     server.getPluginManager().callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefix));
 
     assertEquals("[O] Quitter", PlainTextComponentSerializer.plainText().serialize(player.playerListName()));
+  }
+
+  @Test
+  void chatEventUsesLatestCachedPrefixImmediately() {
+    PlayerMock player = server.addPlayer("Immediate");
+    teamService.assignPlayer(player, "Delta", "D", NamedTextColor.DARK_GREEN);
+
+    Component prefix = Component.text("[NEW] ", NamedTextColor.DARK_GREEN);
+    server
+        .getPluginManager()
+        .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefix));
+
+    Component message = Component.text("Test", NamedTextColor.YELLOW);
+    Set<Audience> viewers = new HashSet<>();
+    ChatRenderer initialRenderer = ChatRenderer.defaultRenderer();
+    SignedMessage signedMessage = SignedMessage.system("Test", message);
+    AsyncChatEvent event =
+        new AsyncChatEvent(
+            false, player, viewers, initialRenderer, message, message, signedMessage);
+
+    assertDoesNotThrow(() -> server.getPluginManager().callEvent(event));
+
+    Component rendered =
+        event.renderer()
+            .render(player, Component.text(player.getName()), event.message(), Audience.empty());
+    assertEquals(
+        "[NEW] Immediate: Test", PlainTextComponentSerializer.plainText().serialize(rendered));
   }
 
   private static class StubTeamService implements TeamService {


### PR DESCRIPTION
## Summary
- read chat prefixes from the cached values in `TeamChatListener` and schedule sync refreshes when absent
- mark mutable team fields as volatile to protect cross-thread reads
- extend MockBukkit tests to verify chat rendering after prefix updates

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cf99b3f70c832e9147e3f4a1e92606