### PR TITLE
Reset player prefixes on shutdown

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -24,6 +24,8 @@ public class MyPurpurPlugin extends JavaPlugin {
   @SuppressWarnings("FieldCanBeLocal")
   private PluginConfig pluginConfig;
 
+  private TeamChatListener teamChatListener;
+
   private boolean debugMode = true;
 
   @Override
@@ -45,7 +47,8 @@ public class MyPurpurPlugin extends JavaPlugin {
     registerCommand("debugtoggle", new DebugToggleCommand(this));
 
     // Регистрация слушателя чата
-    getServer().getPluginManager().registerEvents(new TeamChatListener(teamManager), this);
+    teamChatListener = new TeamChatListener(teamManager);
+    getServer().getPluginManager().registerEvents(teamChatListener, this);
 
     getLogger().info("Плагин MyPurpurPlugin успешно загружен!");
   }
@@ -133,10 +136,21 @@ public class MyPurpurPlugin extends JavaPlugin {
     getLogger().info("Режим отладки " + (debugMode ? "включён" : "отключён") + "!");
   }
 
+  public TeamService getTeamManager() {
+    return teamManager;
+  }
+
+  public TeamChatListener getTeamChatListener() {
+    return teamChatListener;
+  }
+
   @Override
   public void onDisable() {
     if (teamManager != null) {
       teamManager.shutdown();
+    }
+    if (teamChatListener != null) {
+      teamChatListener.clearCachedPrefixes();
     }
   }
 }

--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -112,6 +112,11 @@ public class TeamChatListener implements Listener {
     }
   }
 
+  /** Clears cached prefix information for all tracked players. */
+  public void clearCachedPrefixes() {
+    lastPlayerPrefixes.clear();
+  }
+
   private void updatePlayerPrefix(@NotNull Player player) {
     String teamName = teamManager.getPlayerTeam(player);
     UUID playerId = player.getUniqueId();

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -6,6 +6,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.example.config.PluginConfig;
+import org.example.listener.TeamChatListener;
 import org.jetbrains.annotations.NotNull;
 
 /** Facade over team related services. Delegates work to specialised classes. */
@@ -169,6 +170,15 @@ public class TeamManager implements TeamService {
 
   @Override
   public void shutdown() {
+    plugin
+        .getServer()
+        .getOnlinePlayers()
+        .forEach(
+            player ->
+                plugin
+                    .getServer()
+                    .getPluginManager()
+                    .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, null)));
     storage.stopAutoSave();
     scheduler.resetLeaderDisplays();
     scheduler.stop();

--- a/src/test/java/org/example/service/TeamManagerShutdownIntegrationTest.java
+++ b/src/test/java/org/example/service/TeamManagerShutdownIntegrationTest.java
@@ -1,0 +1,32 @@
+package org.example.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.example.MockBukkitTestBase;
+import org.example.listener.TeamChatListener;
+import org.junit.jupiter.api.Test;
+
+class TeamManagerShutdownIntegrationTest extends MockBukkitTestBase {
+
+  @Test
+  void shutdownResetsPlayerListNames() {
+    PlayerMock alice = server.addPlayer("Alice");
+    PlayerMock bob = server.addPlayer("Bob");
+
+    Component prefix = Component.text("[A] ", NamedTextColor.RED);
+    server.getPluginManager().callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(alice, prefix));
+    server.getPluginManager().callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(bob, prefix));
+
+    assertEquals(
+        prefix.append(Component.text("Alice", NamedTextColor.WHITE)), alice.playerListName());
+    assertEquals(prefix.append(Component.text("Bob", NamedTextColor.WHITE)), bob.playerListName());
+
+    plugin.getTeamManager().shutdown();
+
+    assertEquals(Component.text("Alice", NamedTextColor.WHITE), alice.playerListName());
+    assertEquals(Component.text("Bob", NamedTextColor.WHITE), bob.playerListName());
+  }
+}


### PR DESCRIPTION
## Summary
- fire `PlayerPrefixUpdateEvent` for every online player when `TeamManager.shutdown()` runs to reset tab prefixes
- retain a `TeamChatListener` instance for cache cleanup and expose accessors for tests
- add a MockBukkit integration test ensuring shutdown restores plain white player list names

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cfe8d14770832ead00e170647541f5