### PR TITLE
Warm team chat prefixes on reload

### DIFF
--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -27,6 +27,7 @@ public class TeamChatListener implements Listener {
 
   public TeamChatListener(@NotNull TeamService teamManager) {
     this.teamManager = teamManager;
+    Bukkit.getOnlinePlayers().forEach(this::updatePlayerPrefix);
   }
 
   @EventHandler
@@ -78,9 +79,10 @@ public class TeamChatListener implements Listener {
 
     event.renderer(
         (source, sourceDisplayName, message, viewer) -> {
+          Component latestPrefixComponent = lastPlayerPrefixes.get(playerId);
           Component base = Component.empty();
-          if (prefixComponent != null) {
-            base = base.append(prefixComponent);
+          if (latestPrefixComponent != null) {
+            base = base.append(latestPrefixComponent);
           }
           Component formattedMessage = forceWhiteChat ? message.color(NamedTextColor.WHITE) : message;
           return base.append(sourceDisplayName).append(Component.text(": ")).append(formattedMessage);

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -156,6 +156,32 @@ class TeamChatListenerTest extends MockBukkitTestBase {
         "[NEW] Immediate: Test", PlainTextComponentSerializer.plainText().serialize(rendered));
   }
 
+  @Test
+  void warmCacheAppliesPrefixForOnlinePlayersOnPluginEnable() {
+    HandlerList.unregisterAll(listener);
+    listener.clearCachedPrefixes();
+
+    PlayerMock player = server.addPlayer("Reloaded");
+    teamService.assignPlayer(player, "Reload", "R", NamedTextColor.DARK_AQUA);
+
+    listener = new TeamChatListener(teamService);
+    server.getPluginManager().registerEvents(listener, plugin);
+
+    Component message = Component.text("Hi", NamedTextColor.WHITE);
+    Set<Audience> viewers = new HashSet<>();
+    ChatRenderer initialRenderer = ChatRenderer.defaultRenderer();
+    SignedMessage signedMessage = SignedMessage.system("Hi", message);
+    AsyncChatEvent event =
+        new AsyncChatEvent(false, player, viewers, initialRenderer, message, message, signedMessage);
+
+    server.getPluginManager().callEvent(event);
+
+    Component rendered =
+        event.renderer().render(player, Component.text(player.getName()), event.message(), Audience.empty());
+    assertEquals(
+        "[R] Reloaded: Hi", PlainTextComponentSerializer.plainText().serialize(rendered));
+  }
+
   private static class StubTeamService implements TeamService {
     private final org.bukkit.plugin.java.JavaPlugin plugin;
     private final PluginConfig config;


### PR DESCRIPTION
## Summary
- refresh chat rendering to fetch the latest cached prefix when formatting messages
- warm cached prefixes for already online players when the team chat listener is constructed
- add a unit test proving prefixes are applied immediately after plugin enable

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cfed0521b0832e9fb2772a682c5479