### PR TITLE
Optimize deadline recalculation for targeted team updates

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -24,6 +24,7 @@ import org.example.listener.TeamChatListener;
 import org.example.model.Team;
 import org.example.util.TeamMessageUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * Планировщик, который следит за размерами команд и временем, отведённым на их уменьшение до
@@ -188,45 +189,144 @@ public class DeadlineScheduler {
       resetAllLeaderDisplays();
     }
 
-    for (Map.Entry<UUID, Team> entry : storage.getTeams().entrySet()) {
-      Team team = entry.getValue();
-      int size = team.getMembers().size();
-      UUID teamId = entry.getKey();
-      if (size <= max) {
-        if (deadlines.remove(teamId) != null) {
-          changed = true;
-        }
-        clearLeaderDisplay(team);
-        continue;
-      }
+    long now = System.currentTimeMillis();
+    for (Team team : storage.getTeams().values()) {
+      changed |=
+          evaluateTeamState(team, max, enforcementEnabled, graceEnabled, now);
+    }
+    if (changed) {
+      storage.markDeadlinesDirty();
+    }
+  }
 
-      int excess = size - max;
+  /**
+   * Переоценивает состояние конкретной команды и при необходимости обновляет дедлайн или проводит
+   * удаление лишних участников без полного обхода всех команд.
+   */
+  public void evaluateTeam(@Nullable Team team) {
+    evaluateTeam(team, false);
+  }
+
+  /**
+   * Переоценивает состояние конкретной команды с учётом источника вызова.
+   *
+   * @param team команда, для которой следует обновить дедлайн
+   * @param triggeredByReload {@code true}, если проверка вызвана перезагрузкой плагина или сервера
+   */
+  public void evaluateTeam(@Nullable Team team, boolean triggeredByReload) {
+    if (team == null) {
+      return;
+    }
+    int max = pluginConfig.getMaxMembers();
+    boolean enforcementEnabled = !triggeredByReload || pluginConfig.isEnforceMaxMembersOnReload();
+    boolean graceEnabled =
+        pluginConfig.isGracePeriodEnabled() && pluginConfig.getGracePeriodMinutes() > 0;
+    long now = System.currentTimeMillis();
+    long startedAt = System.nanoTime();
+    boolean changed = evaluateTeamState(team, max, enforcementEnabled, graceEnabled, now);
+    if (changed) {
+      storage.markDeadlinesDirty();
+    }
+    if (pluginConfig.isDebugModeEnabled()) {
+      long elapsedMicros = TimeUnit.NANOSECONDS.toMicros(System.nanoTime() - startedAt);
       plugin
           .getLogger()
-          .warning("Команда " + team.getName() + " превышает лимит: " + size + " из " + max + ".");
+          .info(
+              "Пересчёт команды "
+                  + team.getName()
+                  + " занял "
+                  + elapsedMicros
+                  + " мкс (reload="
+                  + triggeredByReload
+                  + ")");
+    }
+  }
 
-      if (!enforcementEnabled) {
-        Component leaderMessage = buildEnforcementDisabledMessage(max, excess);
-        DeadlineDisplayMode mode = getDisplayMode();
-        if (mode == DeadlineDisplayMode.SCOREBOARD) {
-          notifyLeaderWithoutScoreboard(team, leaderMessage);
-          clearLeaderDisplay(team);
-        } else {
-          notifyLeader(team, leaderMessage);
-        }
+  private boolean evaluateTeamState(
+      @NotNull Team team,
+      int max,
+      boolean enforcementEnabled,
+      boolean graceEnabled,
+      long now) {
+    boolean changed = false;
+    UUID teamId = team.getId();
+
+    if (max <= 0) {
+      if (deadlines.remove(teamId) != null) {
+        changed = true;
+      }
+      clearLeaderDisplay(team);
+      return changed;
+    }
+
+    int size = team.getMembers().size();
+    if (size <= max) {
+      if (deadlines.remove(teamId) != null) {
+        changed = true;
+      }
+      clearLeaderDisplay(team);
+      return changed;
+    }
+
+    int excess = size - max;
+    plugin
+        .getLogger()
+        .warning("Команда " + team.getName() + " превышает лимит: " + size + " из " + max + ".");
+
+    if (!enforcementEnabled) {
+      Component leaderMessage = buildEnforcementDisabledMessage(max, excess);
+      DeadlineDisplayMode mode = getDisplayMode();
+      if (mode == DeadlineDisplayMode.SCOREBOARD) {
+        notifyLeaderWithoutScoreboard(team, leaderMessage);
+        clearLeaderDisplay(team);
+      } else {
+        notifyLeader(team, leaderMessage);
+      }
+      notifyAdmins(
+          adminBaseMessage(team, size, max)
+              .append(Component.space())
+              .append(
+                  Component.text("Автоматическое сокращение отключено.", NamedTextColor.GOLD)));
+      if (deadlines.remove(teamId) != null) {
+        changed = true;
+      }
+      return changed;
+    }
+
+    if (!graceEnabled) {
+      if (deadlines.remove(teamId) != null) {
+        changed = true;
+      }
+      clearLeaderDisplay(team);
+      int removed = removeExtraPlayers(team, max);
+      if (removed > 0) {
+        Component leaderMessage = TeamMessageUtils.forcedRemovalMessage(removed);
+        notifyLeader(team, leaderMessage);
         notifyAdmins(
             adminBaseMessage(team, size, max)
                 .append(Component.space())
                 .append(
-                    Component.text("Автоматическое сокращение отключено.", NamedTextColor.GOLD)));
-        continue;
+                    Component.text(
+                        "Удалено " + removed + " участника(ов) без льготного периода.",
+                        NamedTextColor.RED)));
+        plugin
+            .getLogger()
+            .info(
+                "Команда "
+                    + team.getName()
+                    + ": удалено "
+                    + removed
+                    + " участника(ов) без льготного периода.");
       }
+      return changed;
+    }
 
-      if (!graceEnabled) {
-        if (deadlines.remove(teamId) != null) {
-          changed = true;
-          clearLeaderDisplay(team);
-        }
+    Long existingDeadline = deadlines.get(teamId);
+    if (existingDeadline != null) {
+      if (existingDeadline <= now) {
+        changed = true;
+        deadlines.remove(teamId);
+        clearLeaderDisplay(team);
         int removed = removeExtraPlayers(team, max);
         if (removed > 0) {
           Component leaderMessage = TeamMessageUtils.forcedRemovalMessage(removed);
@@ -236,76 +336,42 @@ public class DeadlineScheduler {
                   .append(Component.space())
                   .append(
                       Component.text(
-                          "Удалено " + removed + " участника(ов) без льготного периода.",
+                          "Льготный период истёк, удалено " + removed + " участника(ов).",
                           NamedTextColor.RED)));
           plugin
               .getLogger()
               .info(
-                  "Команда "
+                  "Льготный период команды "
                       + team.getName()
-                      + ": удалено "
+                      + " истёк, удалено "
                       + removed
-                      + " участника(ов) без льготного периода.");
+                      + " игрок(ов).");
         }
-        continue;
+        return changed;
       }
+      return changed;
+    }
 
-      Long existingDeadline = deadlines.get(teamId);
-      long now = System.currentTimeMillis();
-      if (existingDeadline != null) {
-        if (existingDeadline <= now) {
-          changed = true;
-          deadlines.remove(teamId);
-          clearLeaderDisplay(team);
-          int removed = removeExtraPlayers(team, max);
-          if (removed > 0) {
-            Component leaderMessage = TeamMessageUtils.forcedRemovalMessage(removed);
-            notifyLeader(team, leaderMessage);
-            notifyAdmins(
-                adminBaseMessage(team, size, max)
-                    .append(Component.space())
-                    .append(
-                        Component.text(
-                            "Льготный период истёк, удалено " + removed + " участника(ов).",
-                            NamedTextColor.RED)));
-            plugin
-                .getLogger()
-                .info(
-                    "Льготный период команды "
-                        + team.getName()
-                        + " истёк, удалено "
-                        + removed
-                        + " игрок(ов).");
-          }
-          continue;
-        }
-        continue;
-      }
-      long deadlineAt = now + pluginConfig.getGracePeriodMinutes() * 60L * 1000L;
-      Long previous = deadlines.put(teamId, deadlineAt);
-      boolean deadlineUpdated = !Objects.equals(previous, deadlineAt);
-      if (deadlineUpdated) {
-        changed = true;
-      }
-      if (deadlineUpdated) {
-        Component leaderMessage =
-            TeamMessageUtils.deadlineWarningMessage(
-                max, pluginConfig.getGracePeriodMinutes(), excess);
-        notifyLeader(team, leaderMessage);
-        notifyAdmins(
-            adminBaseMessage(team, size, max)
-                .append(Component.space())
-                .append(
-                    Component.text(
-                        "Лидеру дано "
-                            + pluginConfig.getGracePeriodMinutes()
-                            + " мин. на сокращение.",
-                        NamedTextColor.GOLD)));
-      }
+    long deadlineAt = now + pluginConfig.getGracePeriodMinutes() * 60L * 1000L;
+    Long previous = deadlines.put(teamId, deadlineAt);
+    boolean deadlineUpdated = !Objects.equals(previous, deadlineAt);
+    if (deadlineUpdated) {
+      changed = true;
+      Component leaderMessage =
+          TeamMessageUtils.deadlineWarningMessage(
+              max, pluginConfig.getGracePeriodMinutes(), excess);
+      notifyLeader(team, leaderMessage);
+      notifyAdmins(
+          adminBaseMessage(team, size, max)
+              .append(Component.space())
+              .append(
+                  Component.text(
+                      "Лидеру дано "
+                          + pluginConfig.getGracePeriodMinutes()
+                          + " мин. на сокращение.",
+                      NamedTextColor.GOLD)));
     }
-    if (changed) {
-      storage.markDeadlinesDirty();
-    }
+    return changed;
   }
 
   public void handleLeaderTransfer(@NotNull Team team) {

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -64,7 +64,7 @@ public class MembershipService {
     storage.getPlayerTeams().put(leader.getUniqueId(), team.getId());
     TeamMessageUtils.sendTeamMessage(
         leader, Component.text("✅ Команда создана", NamedTextColor.GREEN));
-    scheduler.enforceTeamSizes(false);
+    scheduler.evaluateTeam(team);
   }
 
   public void addPlayerToTeam(String teamName, @NotNull Player player) {
@@ -95,7 +95,7 @@ public class MembershipService {
     storage.markTeamDirty(team);
     TeamMessageUtils.sendTeamMessage(
         player, Component.text("✅ Вы вступили в команду", NamedTextColor.GREEN));
-    scheduler.enforceTeamSizes(false);
+    scheduler.evaluateTeam(team);
     updateTeamMembersPrefixes(team);
   }
 
@@ -124,7 +124,9 @@ public class MembershipService {
     if (!removedTeam) {
       storage.markTeamDirty(team);
     }
-    scheduler.enforceTeamSizes(false);
+    if (!removedTeam) {
+      scheduler.evaluateTeam(team);
+    }
     notifyPrefixUpdate(player, null);
     if (!removedTeam) {
       updateTeamMembersPrefixes(team);
@@ -150,7 +152,7 @@ public class MembershipService {
     team.removeMember(targetId);
     storage.getPlayerTeams().remove(targetId);
     storage.markTeamDirty(team);
-    scheduler.enforceTeamSizes(false);
+    scheduler.evaluateTeam(team);
     notifyPrefixUpdate(targetId, null);
 
     updateTeamMembersPrefixes(team);
@@ -166,7 +168,7 @@ public class MembershipService {
     team.setLeader(newLeader.getUniqueId());
     storage.markTeamDirty(team);
     scheduler.handleLeaderTransfer(team);
-    scheduler.enforceTeamSizes(false);
+    scheduler.evaluateTeam(team);
   }
 
   public void disbandTeam(String teamName, @NotNull Player leader) {
@@ -185,7 +187,6 @@ public class MembershipService {
     for (UUID memberId : members) {
       storage.getPlayerTeams().remove(memberId);
     }
-    scheduler.enforceTeamSizes(false);
   }
 
   public void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader) {

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -47,7 +47,7 @@ class MembershipServiceTest extends MockBukkitTestBase {
     assertEquals(leader.getUniqueId(), team.getLeaderId(), "Лидер сохраняется");
     assertEquals("A", team.getPrefix(), "Префикс сохраняется");
     assertEquals("Alpha", storage.getPlayerTeam(leader), "Игрок связан с командой");
-    assertEquals(1, scheduler.enforceCalls, "После создания вызывается проверка лимитов");
+    assertEquals(1, scheduler.evaluateCalls, "После создания вызывается проверка лимитов");
   }
 
   @Test
@@ -70,7 +70,7 @@ class MembershipServiceTest extends MockBukkitTestBase {
     assertFalse(
         storage.getPlayerTeams().containsKey(secondMember.getUniqueId()),
         "Игрок не должен иметь записи о команде");
-    assertEquals(2, scheduler.enforceCalls, "Проверка лимитов вызывается при успешном добавлении");
+    assertEquals(2, scheduler.evaluateCalls, "Проверка лимитов вызывается при успешном добавлении");
   }
 
   @Test
@@ -127,6 +127,7 @@ class MembershipServiceTest extends MockBukkitTestBase {
 
   private static class TestDeadlineScheduler extends DeadlineScheduler {
     int enforceCalls;
+    int evaluateCalls;
     final Set<String> cancelledTeams = new HashSet<>();
     final Set<String> leaderTransfers = new HashSet<>();
 
@@ -142,6 +143,11 @@ class MembershipServiceTest extends MockBukkitTestBase {
     @Override
     public void enforceTeamSizes() {
       enforceCalls++;
+    }
+
+    @Override
+    public void evaluateTeam(Team team) {
+      evaluateCalls++;
     }
 
     @Override


### PR DESCRIPTION
## Summary
- add a DeadlineScheduler#evaluateTeam API to update deadlines for a single team and log its execution time when debug logging is enabled
- replace broad enforcement calls in MembershipService with the targeted evaluation workflow and keep reload logic untouched
- update scheduler-related tests to assert the new behaviour

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cffc4be818832e9b2767b4d8257d45