### PR TITLE
Preserve player list name formatting when team prefixes change

### DIFF
--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -107,7 +107,7 @@ public class TeamChatListener implements Listener {
       }
       ((MyPurpurPlugin) teamManager.getPlugin())
           .debug("Устанавливаем префикс для игрока " + player.getName() + ": " + prefix);
-      Component originalName = getOrStoreOriginalPlayerListName(player, cachedPrefix, prefix);
+      Component originalName = getOrStoreOriginalPlayerListName(player, prefix);
       lastPlayerPrefixes.put(playerId, prefix);
       player.playerListName(prefix.append(originalName));
     } else {
@@ -135,8 +135,7 @@ public class TeamChatListener implements Listener {
       NamedTextColor teamColor = teamManager.getTeamColor(teamName);
       Component prefixComponent = TeamUtils.createPrefixComponent(prefix, teamColor);
       Component cachedPrefix = lastPlayerPrefixes.get(playerId);
-      Component originalName =
-          getOrStoreOriginalPlayerListName(player, cachedPrefix, prefixComponent);
+      Component originalName = getOrStoreOriginalPlayerListName(player, prefixComponent);
       lastPlayerPrefixes.put(playerId, prefixComponent);
       player.playerListName(prefixComponent.append(originalName));
     } else {
@@ -146,25 +145,15 @@ public class TeamChatListener implements Listener {
   }
 
   private @NotNull Component getOrStoreOriginalPlayerListName(
-      @NotNull Player player, Component activePrefix, Component applyingPrefix) {
+      @NotNull Player player, Component applyingPrefix) {
     UUID playerId = player.getUniqueId();
-    Component current = getCurrentPlayerListName(player);
     Component existing = originalPlayerListNames.get(playerId);
     if (existing != null) {
-      if (activePrefix == null) {
-        Component sanitized = stripPrefixIfPresent(current, applyingPrefix);
-        if (sanitized != null) {
-          current = sanitized;
-        }
-        if (!Objects.equals(existing, current)) {
-          originalPlayerListNames.put(playerId, current);
-          existing = current;
-        }
-      }
       return existing;
     }
 
-    Component sanitized = stripKnownPrefix(current, activePrefix, applyingPrefix);
+    Component current = getCurrentPlayerListName(player);
+    Component sanitized = stripKnownPrefix(current, lastPlayerPrefixes.get(playerId), applyingPrefix);
     Component toStore = sanitized != null ? sanitized : current;
     originalPlayerListNames.put(playerId, toStore);
     return toStore;
@@ -172,10 +161,16 @@ public class TeamChatListener implements Listener {
 
   private @NotNull Component getCurrentPlayerListName(@NotNull Player player) {
     Component current = player.playerListName();
-    if (current == null) {
-      current = Component.text(player.getName(), NamedTextColor.WHITE);
+    if (current != null) {
+      return current;
     }
-    return current;
+
+    Component displayName = player.displayName();
+    if (displayName != null) {
+      return displayName;
+    }
+
+    return Component.text(player.getName(), NamedTextColor.WHITE);
   }
 
   private Component stripKnownPrefix(

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -153,6 +153,34 @@ class TeamChatListenerTest extends MockBukkitTestBase {
   }
 
   @Test
+  void customListNameRestoredAfterMultiplePrefixUpdates() {
+    PlayerMock player = server.addPlayer("Formatter");
+    Component customName =
+        Component.text("Rainbow ", NamedTextColor.LIGHT_PURPLE)
+            .append(Component.text("Player", NamedTextColor.GREEN));
+    player.playerListName(customName);
+    teamService.assignPlayer(player, "Palette", "P", NamedTextColor.DARK_AQUA);
+
+    Component firstPrefix = Component.text("[P] ", NamedTextColor.DARK_AQUA);
+    Component secondPrefix = Component.text("{P} ", NamedTextColor.DARK_PURPLE);
+
+    server
+        .getPluginManager()
+        .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, firstPrefix));
+    assertEquals(firstPrefix.append(customName), player.playerListName());
+
+    server
+        .getPluginManager()
+        .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, secondPrefix));
+    assertEquals(secondPrefix.append(customName), player.playerListName());
+
+    server
+        .getPluginManager()
+        .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, null));
+    assertEquals(customName, player.playerListName());
+  }
+
+  @Test
   void chatEventUsesLatestCachedPrefixImmediately() {
     PlayerMock player = server.addPlayer("Immediate");
     teamService.assignPlayer(player, "Delta", "D", NamedTextColor.DARK_GREEN);


### PR DESCRIPTION
## Summary
- track each player's original list name component before applying team prefixes and reuse it for updates
- base prefixed list names on stored components (falling back to display names when needed) and restore them when prefixes clear
- add regression coverage for restoring custom player list names after multiple prefix updates

## Testing
- ./gradlew cleanTest test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d013ae457c832e90ef2c9515eabc5e