### PR TITLE
Restore original player list names when clearing prefixes

### DIFF
--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -118,8 +118,15 @@ public class TeamChatListener implements Listener {
     }
   }
 
-  /** Clears cached prefix information for all tracked players. */
+  /** Clears cached prefix information for all tracked players and restores their original names. */
   public void clearCachedPrefixes() {
+    originalPlayerListNames.forEach(
+        (playerId, originalName) -> {
+          Player player = Bukkit.getPlayer(playerId);
+          if (player != null) {
+            player.playerListName(originalName);
+          }
+        });
     lastPlayerPrefixes.clear();
     originalPlayerListNames.clear();
   }

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -181,6 +181,26 @@ class TeamChatListenerTest extends MockBukkitTestBase {
   }
 
   @Test
+  void clearCachedPrefixesRestoresOriginalCustomListName() {
+    PlayerMock player = server.addPlayer("Shutdown");
+    Component customName =
+        Component.text("Fancy ", NamedTextColor.GOLD)
+            .append(Component.text("List", NamedTextColor.DARK_GREEN));
+    player.playerListName(customName);
+    teamService.assignPlayer(player, "Shutdowners", "S", NamedTextColor.GREEN);
+
+    Component prefix = Component.text("[S] ", NamedTextColor.GREEN);
+    server
+        .getPluginManager()
+        .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefix));
+    assertEquals(prefix.append(customName), player.playerListName());
+
+    listener.clearCachedPrefixes();
+
+    assertEquals(customName, player.playerListName());
+  }
+
+  @Test
   void chatEventUsesLatestCachedPrefixImmediately() {
     PlayerMock player = server.addPlayer("Immediate");
     teamService.assignPlayer(player, "Delta", "D", NamedTextColor.DARK_GREEN);


### PR DESCRIPTION
## Summary
- restore each tracked player's saved player list name before clearing cached prefixes
- add a regression test covering custom list names surviving prefix application and cache clearing

## Testing
- ./gradlew clean test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d04333ad74832ea7f3a651feb83748