### PR TITLE
Avoid blocking UUID lookups for uncached team members

### DIFF
--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -416,7 +416,17 @@ public class TeamStorage {
     if (value == null || value.isBlank()) {
       return null;
     }
-    OfflinePlayer offlinePlayer = plugin.getServer().getOfflinePlayer(value.trim());
-    return offlinePlayer != null ? offlinePlayer.getUniqueId() : null;
+    String trimmed = value.trim();
+    OfflinePlayer offlinePlayer = plugin.getServer().getOfflinePlayerIfCached(trimmed);
+    if (offlinePlayer == null) {
+      plugin
+          .getLogger()
+          .warning(
+              "Cannot resolve player name '"
+                  + trimmed
+                  + "' because no cached profile is available.");
+      return null;
+    }
+    return offlinePlayer.getUniqueId();
   }
 }

--- a/src/test/java/org/example/service/TeamStorageTest.java
+++ b/src/test/java/org/example/service/TeamStorageTest.java
@@ -8,6 +8,7 @@ import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -145,5 +146,39 @@ class TeamStorageTest {
 
     YamlConfiguration afterShutdown = YamlConfiguration.loadConfiguration(teamsFile);
     assertNull(afterShutdown.getString("teams." + team.getId() + ".name"));
+  }
+
+  @Test
+  void loadTeamsSkipsUncachedPlayerNames() throws IOException {
+    TeamStorage storage = new TeamStorage(plugin, null);
+    Map<UUID, Long> deadlines = new HashMap<>();
+    storage.loadTeams(deadlines);
+
+    File teamsFile = new File(plugin.getDataFolder(), "teams.yml");
+    YamlConfiguration config = YamlConfiguration.loadConfiguration(teamsFile);
+
+    UUID teamId = UUID.randomUUID();
+    PlayerMock leader = server.addPlayer("KnownLeader");
+    config.set("teams." + teamId + ".name", "LegacyTeam");
+    config.set("teams." + teamId + ".leader", leader.getUniqueId().toString());
+    config.set("teams." + teamId + ".members", List.of("UncachedMember"));
+    config.save(teamsFile);
+
+    TeamStorage reloaded = new TeamStorage(plugin, null);
+    Map<UUID, Long> reloadedDeadlines = new HashMap<>();
+    reloaded.loadTeams(reloadedDeadlines);
+
+    Team loadedTeam = reloaded.getTeams().get(teamId);
+    assertNotNull(loadedTeam, "Team should load even with unresolved member names");
+    assertEquals(
+        List.of(leader.getUniqueId()),
+        loadedTeam.getMembers(),
+        "Only cached members should remain after loading");
+
+    long uncachedEntries =
+        Arrays.stream(server.getOfflinePlayers())
+            .filter(player -> "UncachedMember".equalsIgnoreCase(player.getName()))
+            .count();
+    assertEquals(0L, uncachedEntries, "No offline profile should be created for uncached names");
   }
 }


### PR DESCRIPTION
## Summary
- prefer cached offline player lookups when resolving legacy team data and warn when no profile is available
- add regression coverage for teams containing uncached member names to ensure no fake UUIDs are produced

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d06c18e4d0832eafb24abb70a2dbbc