### PR TITLE
Adjust leader display resets for untouched scoreboards

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -627,8 +627,21 @@ public class DeadlineScheduler {
     UUID notifiedLeader = teamLeaderIds.remove(team.getId());
     if (notifiedLeader != null) {
       clearLeaderDisplay(notifiedLeader);
-    } else {
-      clearLeaderDisplay(team.getLeaderId());
+      return;
+    }
+    UUID leaderId = team.getLeaderId();
+    if (leaderId == null) {
+      return;
+    }
+    DeadlineDisplayMode mode = getDisplayMode();
+    if (mode == DeadlineDisplayMode.SCOREBOARD) {
+      if (leaderOriginalScoreboards.containsKey(leaderId)) {
+        clearLeaderDisplay(leaderId);
+      }
+      return;
+    }
+    if (mode == DeadlineDisplayMode.ACTION_BAR) {
+      clearLeaderDisplay(leaderId);
     }
   }
 
@@ -636,16 +649,19 @@ public class DeadlineScheduler {
     if (leaderId == null) {
       return;
     }
-    Scoreboard original = leaderOriginalScoreboards.remove(leaderId);
+    boolean hadOriginalScoreboard = leaderOriginalScoreboards.containsKey(leaderId);
+    Scoreboard original = hadOriginalScoreboard ? leaderOriginalScoreboards.remove(leaderId) : null;
     Player leader = plugin.getServer().getPlayer(leaderId);
     DeadlineDisplayMode mode = getDisplayMode();
     if (leader != null) {
-      if (original != null) {
-        leader.setScoreboard(original);
-      } else if (mode == DeadlineDisplayMode.SCOREBOARD) {
-        ScoreboardManager manager = plugin.getServer().getScoreboardManager();
-        if (manager != null) {
-          leader.setScoreboard(manager.getMainScoreboard());
+      if (hadOriginalScoreboard) {
+        if (original != null) {
+          leader.setScoreboard(original);
+        } else if (mode == DeadlineDisplayMode.SCOREBOARD) {
+          ScoreboardManager manager = plugin.getServer().getScoreboardManager();
+          if (manager != null) {
+            leader.setScoreboard(manager.getMainScoreboard());
+          }
         }
       }
       if (mode == DeadlineDisplayMode.ACTION_BAR) {

--- a/src/test/java/org/example/service/DeadlineSchedulerTest.java
+++ b/src/test/java/org/example/service/DeadlineSchedulerTest.java
@@ -67,6 +67,27 @@ class DeadlineSchedulerTest {
     assertSame(original, leader.getScoreboard());
   }
 
+  @Test
+  void resetLeaderDisplaysKeepsCustomScoreboardWithoutDeadline() throws IOException {
+    prepareConfig();
+    PluginConfig config = new PluginConfig(plugin);
+    TeamStorage storage = new TeamStorage(plugin, config);
+    DeadlineScheduler scheduler = new DeadlineScheduler(plugin, config, storage);
+
+    PlayerMock leader = server.addPlayer("Leader");
+    Team team =
+        new Team(UUID.randomUUID(), "Alpha", leader.getUniqueId(), "", "WHITE");
+    team.setMembers(List.of(leader.getUniqueId()));
+    storage.getTeams().put(team.getId(), team);
+
+    Scoreboard custom = server.getScoreboardManager().getNewScoreboard();
+    leader.setScoreboard(custom);
+
+    scheduler.resetLeaderDisplays();
+
+    assertSame(custom, leader.getScoreboard());
+  }
+
   private void prepareConfig() throws IOException {
     File dataFolder = plugin.getDataFolder();
     if (!dataFolder.exists() && !dataFolder.mkdirs()) {


### PR DESCRIPTION
## Summary
- avoid resetting leader scoreboards when no original scoreboard was cached
- stop clearing team leader displays when no scoreboard warning was ever issued
- add a MockBukkit regression test ensuring resetLeaderDisplays preserves untouched scoreboards

## Testing
- ./gradlew test --console=plain --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68d079328b48832e90ba945c4bc1018c