### PR TITLE
Cache original tab list names before applying prefixes

### DIFF
--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -30,12 +30,17 @@ public class TeamChatListener implements Listener {
 
   public TeamChatListener(@NotNull TeamService teamManager) {
     this.teamManager = teamManager;
-    Bukkit.getOnlinePlayers().forEach(this::updatePlayerPrefix);
+    Bukkit.getOnlinePlayers().forEach(
+        player -> {
+          cacheOriginalPlayerListName(player);
+          updatePlayerPrefix(player);
+        });
   }
 
   @EventHandler
   public void onPlayerJoin(@NotNull PlayerJoinEvent event) {
     Player player = event.getPlayer();
+    cacheOriginalPlayerListName(player);
     updatePlayerPrefix(player);
     String teamName = teamManager.getPlayerTeam(player);
     if (teamName != null && teamManager.getTeamIdByName(teamName) != null) {
@@ -109,7 +114,7 @@ public class TeamChatListener implements Listener {
       }
       ((MyPurpurPlugin) teamManager.getPlugin())
           .debug("Устанавливаем префикс для игрока " + player.getName() + ": " + prefix);
-      Component originalName = getOrStoreOriginalPlayerListName(player, prefix);
+      Component originalName = cacheOriginalPlayerListName(player, prefix);
       Component originalDisplayName = getOrStoreOriginalPlayerDisplayName(player, prefix);
       lastPlayerPrefixes.put(playerId, prefix);
       player.playerListName(prefix.append(originalName));
@@ -155,7 +160,7 @@ public class TeamChatListener implements Listener {
       NamedTextColor teamColor = teamManager.getTeamColor(teamName);
       Component prefixComponent = TeamUtils.createPrefixComponent(prefix, teamColor);
       Component cachedPrefix = lastPlayerPrefixes.get(playerId);
-      Component originalName = getOrStoreOriginalPlayerListName(player, prefixComponent);
+      Component originalName = cacheOriginalPlayerListName(player, prefixComponent);
       Component originalDisplayName = getOrStoreOriginalPlayerDisplayName(player, prefixComponent);
       lastPlayerPrefixes.put(playerId, prefixComponent);
       player.playerListName(prefixComponent.append(originalName));
@@ -167,7 +172,7 @@ public class TeamChatListener implements Listener {
     }
   }
 
-  private @NotNull Component getOrStoreOriginalPlayerListName(
+  private @NotNull Component cacheOriginalPlayerListName(
       @NotNull Player player, Component applyingPrefix) {
     UUID playerId = player.getUniqueId();
     Component existing = originalPlayerListNames.get(playerId);
@@ -180,6 +185,10 @@ public class TeamChatListener implements Listener {
     Component toStore = sanitized != null ? sanitized : current;
     originalPlayerListNames.put(playerId, toStore);
     return toStore;
+  }
+
+  private @NotNull Component cacheOriginalPlayerListName(@NotNull Player player) {
+    return cacheOriginalPlayerListName(player, null);
   }
 
   private @NotNull Component getCurrentPlayerListName(@NotNull Player player) {

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -279,6 +279,31 @@ class TeamChatListenerTest extends MockBukkitTestBase {
         "[R] Reloaded: Hi", PlainTextComponentSerializer.plainText().serialize(rendered));
   }
 
+  @Test
+  void warmCachePreservesExistingCustomTabNames() {
+    HandlerList.unregisterAll(listener);
+    listener.clearCachedPrefixes();
+
+    PlayerMock player = server.addPlayer("Styled");
+    Component customTabName =
+        Component.text("Fancy ", NamedTextColor.GOLD)
+            .append(Component.text("Styled", NamedTextColor.DARK_GREEN));
+    player.playerListName(customTabName);
+    teamService.assignPlayer(player, "Stylists", "S", NamedTextColor.DARK_GREEN);
+
+    listener = new TeamChatListener(teamService);
+    server.getPluginManager().registerEvents(listener, plugin);
+
+    Component prefix = Component.text("[S] ", NamedTextColor.DARK_GREEN);
+    assertEquals(prefix.append(customTabName), player.playerListName());
+
+    server
+        .getPluginManager()
+        .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, null));
+
+    assertEquals(customTabName, player.playerListName());
+  }
+
   private static class StubTeamService implements TeamService {
     private final org.bukkit.plugin.java.JavaPlugin plugin;
     private final PluginConfig config;

--- a/src/test/java/org/example/service/TeamManagerShutdownIntegrationTest.java
+++ b/src/test/java/org/example/service/TeamManagerShutdownIntegrationTest.java
@@ -16,16 +16,25 @@ class TeamManagerShutdownIntegrationTest extends MockBukkitTestBase {
     PlayerMock alice = server.addPlayer("Alice");
     PlayerMock bob = server.addPlayer("Bob");
 
+    Component aliceOriginal =
+        Component.text("Leader ", NamedTextColor.GOLD)
+            .append(Component.text("Alice", NamedTextColor.RED));
+    Component bobOriginal =
+        Component.text("Member ", NamedTextColor.BLUE)
+            .append(Component.text("Bob", NamedTextColor.WHITE));
+    alice.playerListName(aliceOriginal);
+    bob.playerListName(bobOriginal);
+
     Component prefix = Component.text("[A] ", NamedTextColor.RED);
     server.getPluginManager().callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(alice, prefix));
     server.getPluginManager().callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(bob, prefix));
 
-    assertEquals(prefix.append(Component.text("Alice")), alice.playerListName());
-    assertEquals(prefix.append(Component.text("Bob")), bob.playerListName());
+    assertEquals(prefix.append(aliceOriginal), alice.playerListName());
+    assertEquals(prefix.append(bobOriginal), bob.playerListName());
 
     plugin.getTeamManager().shutdown();
 
-    assertEquals(Component.text("Alice"), alice.playerListName());
-    assertEquals(Component.text("Bob"), bob.playerListName());
+    assertEquals(aliceOriginal, alice.playerListName());
+    assertEquals(bobOriginal, bob.playerListName());
   }
 }


### PR DESCRIPTION
## Summary
- cache each player's tab list component before applying prefixes so they can be restored accurately
- seed the cache for players who are already online when the listener is constructed
- add regression coverage for preserving custom tab names during warm-cache startup and plugin shutdown

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d107b7d664832e86e9d7169a6a5432