### PR TITLE
Remove redundant null guard in removal policy config

### DIFF
--- a/src/main/java/org/example/config/PluginConfig.java
+++ b/src/main/java/org/example/config/PluginConfig.java
@@ -207,9 +207,6 @@ public class PluginConfig {
    */
   public @NotNull RemovalPolicy getExcessPlayerRemovalPolicy() {
     String rawValue = config.getString("team.deadline-removal-policy", "last-joined");
-    if (rawValue == null) {
-      return RemovalPolicy.LAST_JOINED;
-    }
     String normalized = rawValue.trim().replace('-', '_').toUpperCase(Locale.ROOT);
     try {
       return RemovalPolicy.valueOf(normalized);


### PR DESCRIPTION
## Summary
- rely on ConfigurationSection default when retrieving excess player removal policy
- preserve normalization and fallback logging to LAST_JOINED for invalid values

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d159db7534832e8e5c13760629982c