### PR TITLE
Normalize cfgdefault command registration

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -42,7 +42,7 @@ public class MyPurpurPlugin extends JavaPlugin {
     registerCommand("getteamsuuidlist", new AdminCommands(teamManager));
     registerCommand("getteamuuid", new AdminCommands(teamManager));
     registerCommand("teamreload", new TeamReloadCommand(this, teamManager, pluginConfig));
-    registerCommand("cfgDefault", new CfgDefaultCommand(this, pluginConfig, teamManager));
+    registerCommand("cfgdefault", new CfgDefaultCommand(this, pluginConfig, teamManager));
     registerCommand("menu", new MenuCommand(this, pluginConfig));
     registerCommand("debugtoggle", new DebugToggleCommand(this));
 

--- a/src/main/java/org/example/command/CfgDefaultCommand.java
+++ b/src/main/java/org/example/command/CfgDefaultCommand.java
@@ -11,7 +11,7 @@ import org.example.config.PluginConfig;
 import org.example.service.TeamService;
 import org.jetbrains.annotations.NotNull;
 
-/** Обработчик команды /cfgDefault для сброса конфигурации плагина до дефолтных настроек. */
+/** Обработчик команды /cfgdefault для сброса конфигурации плагина до дефолтных настроек. */
 public class CfgDefaultCommand implements CommandExecutor {
 
   private final MyPurpurPlugin plugin;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -38,9 +38,9 @@ commands:
     permission: mypurpurplugin.teamreload
     permission-message: "❌ У вас нет прав для использования этой команды!"
 
-  cfgDefault:
+  cfgdefault:
     description: Сбросить конфигурацию плагина до дефолтных настроек (только для консоли)
-    usage: /cfgDefault
+    usage: /cfgdefault
     permission: mypurpurplugin.cfgdefault
     permission-message: "❌ У вас нет прав для использования этой команды!"
 
@@ -68,7 +68,7 @@ permissions:
     description: Доступ к команде /teamreload (только для консоли)
     default: op
   mypurpurplugin.cfgdefault:
-    description: Доступ к команде /cfgDefault (только для консоли)
+    description: Доступ к команде /cfgdefault (только для консоли)
     default: op
   mypurpurplugin.debugtoggle:
     description: Доступ к команде /debugtoggle (только для консоли)


### PR DESCRIPTION
## Summary
- rename the cfgdefault command entry in plugin.yml to use the lowercase command key and adjust its usage/permission description
- update the plugin startup to register the new lowercase command name and refresh documentation on the handler

## Testing
- ./gradlew build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d1892d61ec832ea1ba3c95644052d7