### PR TITLE
Support loading members from string lists

### DIFF
--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -105,7 +105,26 @@ public class Team {
     }
   }
 
-  public void setMembers(List<UUID> newMembers) {
+  public void setMembers(List<String> newMembers) {
+    if (newMembers == null) {
+      setMembersByUuid(null);
+      return;
+    }
+    List<UUID> parsedMembers = new ArrayList<>(newMembers.size());
+    for (String newMember : newMembers) {
+      if (newMember == null || newMember.isBlank()) {
+        continue;
+      }
+      try {
+        parsedMembers.add(UUID.fromString(newMember.trim()));
+      } catch (IllegalArgumentException ignored) {
+        // Skip entries that are not valid UUID representations.
+      }
+    }
+    setMembersByUuid(parsedMembers);
+  }
+
+  public void setMembersByUuid(List<UUID> newMembers) {
     members.clear();
     memberLookup.clear();
     if (newMembers == null) {

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -432,7 +432,8 @@ public class TeamStorage {
       long deadline,
       Map<UUID, Long> deadlines) {
     Team team = new Team(teamId, name != null ? name.trim() : null, leaderId, prefix, color);
-    List<UUID> memberIds = new ArrayList<>();
+    team.setMembers(rawMembers);
+    List<UUID> memberIds = new ArrayList<>(team.getMembers());
     boolean convertedMembers = false;
     for (String rawMember : rawMembers) {
       UUID memberId = parseUuid(rawMember);
@@ -476,7 +477,7 @@ public class TeamStorage {
       memberIds.add(leaderId);
       convertedMembers = true;
     }
-    team.setMembers(memberIds);
+    team.setMembersByUuid(memberIds);
     if (deadline > 0L) {
       deadlines.put(team.getId(), deadline);
     }
@@ -630,7 +631,7 @@ public class TeamStorage {
       List<UUID> members = new ArrayList<>(team.getMembers());
       if (!members.contains(resolvedUuid)) {
         members.add(resolvedUuid);
-        team.setMembers(members);
+        team.setMembersByUuid(members);
         playerTeams.put(resolvedUuid, team.getId());
         teamsConfig.set(
             "teams." + team.getId() + ".members",

--- a/src/test/java/org/example/service/DeadlineSchedulerTest.java
+++ b/src/test/java/org/example/service/DeadlineSchedulerTest.java
@@ -48,7 +48,7 @@ class DeadlineSchedulerTest {
     PlayerMock memberTwo = server.addPlayer("MemberTwo");
 
     Team team = new Team(UUID.randomUUID(), "Alpha", leader.getUniqueId(), "", "WHITE");
-    team.setMembers(
+    team.setMembersByUuid(
         List.of(leader.getUniqueId(), memberOne.getUniqueId(), memberTwo.getUniqueId()));
     storage.getTeams().put(team.getId(), team);
     Scoreboard original = leader.getScoreboard();
@@ -59,7 +59,7 @@ class DeadlineSchedulerTest {
     scheduler.getDeadlines().clear();
     assertNotNull(leader.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
 
-    team.setMembers(List.of(leader.getUniqueId(), memberOne.getUniqueId()));
+    team.setMembersByUuid(List.of(leader.getUniqueId(), memberOne.getUniqueId()));
     scheduler.enforceTeamSizes(true);
 
     assertNull(leader.getScoreboard().getObjective(DisplaySlot.SIDEBAR));
@@ -75,7 +75,7 @@ class DeadlineSchedulerTest {
 
     PlayerMock leader = server.addPlayer("Leader");
     Team team = new Team(UUID.randomUUID(), "Alpha", leader.getUniqueId(), "", "WHITE");
-    team.setMembers(List.of(leader.getUniqueId()));
+    team.setMembersByUuid(List.of(leader.getUniqueId()));
     storage.getTeams().put(team.getId(), team);
 
     Scoreboard custom = server.getScoreboardManager().getNewScoreboard();

--- a/src/test/java/org/example/service/TeamStorageTest.java
+++ b/src/test/java/org/example/service/TeamStorageTest.java
@@ -77,7 +77,7 @@ class TeamStorageTest {
     PlayerMock leader = server.addPlayer("Leader");
     PlayerMock member = server.addPlayer("Member");
     Team team = new Team(teamId, "DeadlineTeam", leader.getUniqueId(), "[D]", "blue");
-    team.setMembers(new ArrayList<>(List.of(leader.getUniqueId(), member.getUniqueId())));
+    team.setMembersByUuid(new ArrayList<>(List.of(leader.getUniqueId(), member.getUniqueId())));
     storage.addTeam(team);
 
     long deadline = System.currentTimeMillis() + 60000L;
@@ -89,6 +89,32 @@ class TeamStorageTest {
     reloaded.loadTeams(reloadedDeadlines);
 
     assertEquals(deadline, reloadedDeadlines.get(teamId));
+  }
+
+  @Test
+  void saveAndReloadPreservesMembers() throws IOException {
+    TeamStorage storage = new TeamStorage(plugin, null);
+    Map<UUID, Long> deadlines = new HashMap<>();
+    storage.loadTeams(deadlines);
+
+    PlayerMock leader = server.addPlayer("LeaderMember");
+    PlayerMock member = server.addPlayer("SecondMember");
+    Team team =
+        new Team(UUID.randomUUID(), "MembersTeam", leader.getUniqueId(), "[M]", "yellow");
+    team.setMembersByUuid(List.of(leader.getUniqueId(), member.getUniqueId()));
+    storage.addTeam(team);
+    storage.saveTeams(deadlines);
+
+    TeamStorage reloaded = new TeamStorage(plugin, null);
+    Map<UUID, Long> reloadedDeadlines = new HashMap<>();
+    reloaded.loadTeams(reloadedDeadlines);
+
+    Team loadedTeam = reloaded.getTeams().get(team.getId());
+    assertNotNull(loadedTeam, "Team should exist after reload");
+    assertEquals(
+        List.of(leader.getUniqueId(), member.getUniqueId()),
+        loadedTeam.getMembers(),
+        "Team members should be preserved after reload");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add a string-based Team#setMembers helper that converts to UUIDs and delegates to a renamed setMembersByUuid
- ensure TeamStorage records YAML member lists via the new method while continuing to normalize the resolved UUIDs
- update tests and add coverage to confirm members persist across reloads

## Testing
- ./gradlew test --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68d19a0c8b30832eb1686247ee894685