### PR TITLE
Refactor configuration paths and reuse plugin config

### DIFF
--- a/src/main/java/org/example/config/PluginConfig.java
+++ b/src/main/java/org/example/config/PluginConfig.java
@@ -11,6 +11,91 @@ import org.jetbrains.annotations.NotNull;
 /** Класс для управления конфигурацией плагина. */
 public class PluginConfig {
 
+  /** Пути до ключей конфигурации. */
+  public static final class Keys {
+    private Keys() {}
+
+    public static final String DEBUG_MODE = "debug.mode";
+    public static final String CHAT_FORCE_WHITE = "chat.force-white";
+
+    public static final class Team {
+      private Team() {}
+
+      public static final class Commands {
+        private Commands() {}
+
+        public static final String REQUIRES_OP = "team.commands.requires-op";
+      }
+
+      public static final class Notifications {
+        private Notifications() {}
+
+        public static final String NOTIFY_ADMINS = "team.notifications.notify-admins";
+      }
+
+      public static final class Naming {
+        private Naming() {}
+
+        public static final class Prefix {
+          private Prefix() {}
+
+          public static final String MIN_LENGTH = "team.naming.prefix.min-length";
+          public static final String MAX_LENGTH = "team.naming.prefix.max-length";
+        }
+
+        public static final class TeamName {
+          private TeamName() {}
+
+          public static final String MIN_LENGTH = "team.naming.team.min-length";
+          public static final String MAX_LENGTH = "team.naming.team.max-length";
+        }
+      }
+
+      public static final class Membership {
+        private Membership() {}
+
+        public static final String MAX_MEMBERS = "team.membership.max-members";
+        public static final String ENFORCE_MAX_ON_RELOAD =
+            "team.membership.enforce-max-members-on-reload";
+
+        public static final class GracePeriod {
+          private GracePeriod() {}
+
+          public static final String ENABLED = "team.membership.grace-period.enabled";
+          public static final String MINUTES = "team.membership.grace-period.minutes";
+        }
+      }
+
+      public static final class Deadlines {
+        private Deadlines() {}
+
+        public static final String NOTIFY_PERIOD_SECONDS = "team.deadlines.notify-period-seconds";
+        public static final String DISPLAY_MODE = "team.deadlines.display-mode";
+        public static final String REMOVAL_POLICY = "team.deadlines.removal-policy";
+      }
+
+      public static final class Storage {
+        private Storage() {}
+
+        public static final String SAVE_INTERVAL_SECONDS = "team.storage.save-interval-seconds";
+      }
+    }
+
+    public static final class Menu {
+      private Menu() {}
+
+      public static final class Sound {
+        private Sound() {}
+
+        public static final String OPEN = "menu.sound.open";
+        public static final String VOLUME = "menu.sound.volume";
+        public static final String PITCH = "menu.sound.pitch";
+      }
+
+      public static final String PARTICLE_EFFECT = "menu.particle-effect";
+    }
+  }
+
   private final JavaPlugin plugin;
   private FileConfiguration config;
   private File configFile;
@@ -47,31 +132,67 @@ public class PluginConfig {
   private void setDefaults(boolean persistChanges) {
     boolean newKeysAdded = false;
 
+    // Миграция старых ключей
+    newKeysAdded |= migrateLegacyKey("debug-mode", Keys.DEBUG_MODE);
+    newKeysAdded |= migrateLegacyKey("force-white-chat", Keys.CHAT_FORCE_WHITE);
+    newKeysAdded |= migrateLegacyKey("team.requires-op", Keys.Team.Commands.REQUIRES_OP);
+    newKeysAdded |= migrateLegacyKey("team.notify-admins", Keys.Team.Notifications.NOTIFY_ADMINS);
+    newKeysAdded |=
+        migrateLegacyKey("team.max-members", Keys.Team.Membership.MAX_MEMBERS);
+    newKeysAdded |=
+        migrateLegacyKey(
+            "team.enforce-max-members-on-reload",
+            Keys.Team.Membership.ENFORCE_MAX_ON_RELOAD);
+    newKeysAdded |=
+        migrateLegacyKey("team.grace-period-enabled", Keys.Team.Membership.GracePeriod.ENABLED);
+    newKeysAdded |=
+        migrateLegacyKey("team.grace-period-minutes", Keys.Team.Membership.GracePeriod.MINUTES);
+    newKeysAdded |=
+        migrateLegacyKey("team.min-prefix-length", Keys.Team.Naming.Prefix.MIN_LENGTH);
+    newKeysAdded |=
+        migrateLegacyKey("team.max-prefix-length", Keys.Team.Naming.Prefix.MAX_LENGTH);
+    newKeysAdded |=
+        migrateLegacyKey("team.min-team-name-length", Keys.Team.Naming.TeamName.MIN_LENGTH);
+    newKeysAdded |=
+        migrateLegacyKey("team.max-team-name-length", Keys.Team.Naming.TeamName.MAX_LENGTH);
+    newKeysAdded |=
+        migrateLegacyKey(
+            "team.deadline-notify-period-seconds", Keys.Team.Deadlines.NOTIFY_PERIOD_SECONDS);
+    newKeysAdded |=
+        migrateLegacyKey("team.deadline-display-mode", Keys.Team.Deadlines.DISPLAY_MODE);
+    newKeysAdded |=
+        migrateLegacyKey("team.deadline-removal-policy", Keys.Team.Deadlines.REMOVAL_POLICY);
+    newKeysAdded |=
+        migrateLegacyKey("team.save-interval-seconds", Keys.Team.Storage.SAVE_INTERVAL_SECONDS);
+    newKeysAdded |= migrateLegacyKey("menu.open-sound", Keys.Menu.Sound.OPEN);
+    newKeysAdded |= migrateLegacyKey("menu.sound-volume", Keys.Menu.Sound.VOLUME);
+    newKeysAdded |= migrateLegacyKey("menu.sound-pitch", Keys.Menu.Sound.PITCH);
+
     // Глобальные настройки
-    newKeysAdded |= addDefaultIfMissing("debug-mode", true);
-    newKeysAdded |= addDefaultIfMissing("force-white-chat", false);
+    newKeysAdded |= addDefaultIfMissing(Keys.DEBUG_MODE, true);
+    newKeysAdded |= addDefaultIfMissing(Keys.CHAT_FORCE_WHITE, false);
 
     // Основные настройки
-    newKeysAdded |= addDefaultIfMissing("team.requires-op", false);
-    newKeysAdded |= addDefaultIfMissing("team.notify-admins", true);
-    newKeysAdded |= addDefaultIfMissing("team.max-members", 0);
-    newKeysAdded |= addDefaultIfMissing("team.min-prefix-length", 1);
-    newKeysAdded |= addDefaultIfMissing("team.max-prefix-length", 16);
-    newKeysAdded |= addDefaultIfMissing("team.min-team-name-length", 3);
-    newKeysAdded |= addDefaultIfMissing("team.max-team-name-length", 32);
-    newKeysAdded |= addDefaultIfMissing("team.enforce-max-members-on-reload", true);
-    newKeysAdded |= addDefaultIfMissing("team.grace-period-enabled", true);
-    newKeysAdded |= addDefaultIfMissing("team.grace-period-minutes", 10);
-    newKeysAdded |= addDefaultIfMissing("team.deadline-notify-period-seconds", 300L);
-    newKeysAdded |= addDefaultIfMissing("team.save-interval-seconds", 60L);
-    newKeysAdded |= addDefaultIfMissing("team.deadline-display-mode", "CHAT");
-    newKeysAdded |= addDefaultIfMissing("team.deadline-removal-policy", "last-joined");
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Commands.REQUIRES_OP, false);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Notifications.NOTIFY_ADMINS, true);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Membership.MAX_MEMBERS, 0);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Naming.Prefix.MIN_LENGTH, 1);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Naming.Prefix.MAX_LENGTH, 16);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Naming.TeamName.MIN_LENGTH, 3);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Naming.TeamName.MAX_LENGTH, 32);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Membership.ENFORCE_MAX_ON_RELOAD, true);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Membership.GracePeriod.ENABLED, true);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Membership.GracePeriod.MINUTES, 10);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Deadlines.NOTIFY_PERIOD_SECONDS, 300L);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Storage.SAVE_INTERVAL_SECONDS, 60L);
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Deadlines.DISPLAY_MODE, "CHAT");
+    newKeysAdded |= addDefaultIfMissing(Keys.Team.Deadlines.REMOVAL_POLICY, "last-joined");
 
     // Настройки меню
-    newKeysAdded |= addDefaultIfMissing("menu.open-sound", "BLOCK_NOTE_BLOCK_PLING");
-    newKeysAdded |= addDefaultIfMissing("menu.particle-effect", "FIREWORK");
-    newKeysAdded |= addDefaultIfMissing("menu.sound-volume", 1.0);
-    newKeysAdded |= addDefaultIfMissing("menu.sound-pitch", 1.0);
+    newKeysAdded |= addDefaultIfMissing(Keys.Menu.Sound.OPEN, "BLOCK_NOTE_BLOCK_PLING");
+    newKeysAdded |= addDefaultIfMissing(Keys.Menu.PARTICLE_EFFECT, "FIREWORK");
+    newKeysAdded |= addDefaultIfMissing(Keys.Menu.Sound.VOLUME, 1.0);
+    newKeysAdded |= addDefaultIfMissing(Keys.Menu.Sound.PITCH, 1.0);
 
     config.options().copyDefaults(true);
 
@@ -84,6 +205,81 @@ public class PluginConfig {
     boolean missing = !config.contains(path);
     config.addDefault(path, value);
     return missing;
+  }
+
+  private boolean migrateLegacyKey(@NotNull String legacyPath, @NotNull String newPath) {
+    if (config.contains(legacyPath) && !config.contains(newPath)) {
+      Object value = config.get(legacyPath);
+      config.set(newPath, value);
+      config.set(legacyPath, null);
+      return true;
+    }
+    return false;
+  }
+
+  private boolean getBooleanWithLegacyFallback(
+      @NotNull String path, boolean defaultValue, String... legacyPaths) {
+    if (config.contains(path)) {
+      return config.getBoolean(path, defaultValue);
+    }
+    for (String legacyPath : legacyPaths) {
+      if (config.contains(legacyPath)) {
+        return config.getBoolean(legacyPath, defaultValue);
+      }
+    }
+    return defaultValue;
+  }
+
+  private int getIntWithLegacyFallback(@NotNull String path, int defaultValue, String... legacyPaths) {
+    if (config.contains(path)) {
+      return config.getInt(path, defaultValue);
+    }
+    for (String legacyPath : legacyPaths) {
+      if (config.contains(legacyPath)) {
+        return config.getInt(legacyPath, defaultValue);
+      }
+    }
+    return defaultValue;
+  }
+
+  private long getLongWithLegacyFallback(
+      @NotNull String path, long defaultValue, String... legacyPaths) {
+    if (config.contains(path)) {
+      return config.getLong(path, defaultValue);
+    }
+    for (String legacyPath : legacyPaths) {
+      if (config.contains(legacyPath)) {
+        return config.getLong(legacyPath, defaultValue);
+      }
+    }
+    return defaultValue;
+  }
+
+  private double getDoubleWithLegacyFallback(
+      @NotNull String path, double defaultValue, String... legacyPaths) {
+    if (config.contains(path)) {
+      return config.getDouble(path, defaultValue);
+    }
+    for (String legacyPath : legacyPaths) {
+      if (config.contains(legacyPath)) {
+        return config.getDouble(legacyPath, defaultValue);
+      }
+    }
+    return defaultValue;
+  }
+
+  private String getStringWithLegacyFallback(
+      @NotNull String path, String defaultValue, String... legacyPaths) {
+    if (config.contains(path)) {
+      return config.getString(path, defaultValue);
+    }
+    for (String legacyPath : legacyPaths) {
+      if (config.contains(legacyPath)) {
+        String value = config.getString(legacyPath, defaultValue);
+        return value != null ? value : defaultValue;
+      }
+    }
+    return defaultValue;
   }
 
   /** Сохраняет файл конфигурации. */
@@ -107,7 +303,7 @@ public class PluginConfig {
    * @return true, если режим отладки активен, иначе false
    */
   public boolean isDebugModeEnabled() {
-    return config.getBoolean("debug-mode", true);
+    return getBooleanWithLegacyFallback(Keys.DEBUG_MODE, true, "debug-mode");
   }
 
   /**
@@ -116,7 +312,7 @@ public class PluginConfig {
    * @return true, если сообщения должны быть перекрашены в белый цвет
    */
   public boolean isForceWhiteChat() {
-    return config.getBoolean("force-white-chat", false);
+    return getBooleanWithLegacyFallback(Keys.CHAT_FORCE_WHITE, false, "force-white-chat");
   }
 
   /**
@@ -125,7 +321,8 @@ public class PluginConfig {
    * @return true, если требуется OP, иначе false
    */
   public boolean isTeamCommandRequiresOp() {
-    return config.getBoolean("team.requires-op", false);
+    return getBooleanWithLegacyFallback(
+        Keys.Team.Commands.REQUIRES_OP, false, "team.requires-op");
   }
 
   /**
@@ -134,7 +331,8 @@ public class PluginConfig {
    * @return true, если уведомления включены, иначе false
    */
   public boolean shouldNotifyAdmins() {
-    return config.getBoolean("team.notify-admins", true);
+    return getBooleanWithLegacyFallback(
+        Keys.Team.Notifications.NOTIFY_ADMINS, true, "team.notify-admins");
   }
 
   /**
@@ -143,7 +341,7 @@ public class PluginConfig {
    * @return Максимальное количество участников (0 — без ограничений)
    */
   public int getMaxMembers() {
-    return config.getInt("team.max-members", 0);
+    return getIntWithLegacyFallback(Keys.Team.Membership.MAX_MEMBERS, 0, "team.max-members");
   }
 
   /**
@@ -152,7 +350,10 @@ public class PluginConfig {
    * @return true, если ограничение должно применяться
    */
   public boolean isEnforceMaxMembersOnReload() {
-    return config.getBoolean("team.enforce-max-members-on-reload", true);
+    return getBooleanWithLegacyFallback(
+        Keys.Team.Membership.ENFORCE_MAX_ON_RELOAD,
+        true,
+        "team.enforce-max-members-on-reload");
   }
 
   /**
@@ -161,7 +362,8 @@ public class PluginConfig {
    * @return true, если льготный период активен
    */
   public boolean isGracePeriodEnabled() {
-    return config.getBoolean("team.grace-period-enabled", true);
+    return getBooleanWithLegacyFallback(
+        Keys.Team.Membership.GracePeriod.ENABLED, true, "team.grace-period-enabled");
   }
 
   /**
@@ -170,7 +372,8 @@ public class PluginConfig {
    * @return длительность периода в минутах
    */
   public int getGracePeriodMinutes() {
-    return config.getInt("team.grace-period-minutes", 10);
+    return getIntWithLegacyFallback(
+        Keys.Team.Membership.GracePeriod.MINUTES, 10, "team.grace-period-minutes");
   }
 
   /**
@@ -179,7 +382,10 @@ public class PluginConfig {
    * @return период проверки в секундах
    */
   public long getDeadlineNotifyPeriodSeconds() {
-    return config.getLong("team.deadline-notify-period-seconds", 300L);
+    return getLongWithLegacyFallback(
+        Keys.Team.Deadlines.NOTIFY_PERIOD_SECONDS,
+        300L,
+        "team.deadline-notify-period-seconds");
   }
 
   /**
@@ -188,7 +394,8 @@ public class PluginConfig {
    * @return интервал автосохранения
    */
   public long getSaveIntervalSeconds() {
-    return config.getLong("team.save-interval-seconds", 60L);
+    return getLongWithLegacyFallback(
+        Keys.Team.Storage.SAVE_INTERVAL_SECONDS, 60L, "team.save-interval-seconds");
   }
 
   /**
@@ -197,7 +404,8 @@ public class PluginConfig {
    * @return режим отображения
    */
   public String getDeadlineDisplayMode() {
-    return config.getString("team.deadline-display-mode", "CHAT");
+    return getStringWithLegacyFallback(
+        Keys.Team.Deadlines.DISPLAY_MODE, "CHAT", "team.deadline-display-mode");
   }
 
   /**
@@ -206,7 +414,9 @@ public class PluginConfig {
    * @return стратегия удаления игроков
    */
   public @NotNull RemovalPolicy getExcessPlayerRemovalPolicy() {
-    String rawValue = config.getString("team.deadline-removal-policy", "last-joined");
+    String rawValue =
+        getStringWithLegacyFallback(
+            Keys.Team.Deadlines.REMOVAL_POLICY, "last-joined", "team.deadline-removal-policy");
     String normalized = rawValue.trim().replace('-', '_').toUpperCase(Locale.ROOT);
     try {
       return RemovalPolicy.valueOf(normalized);
@@ -214,7 +424,9 @@ public class PluginConfig {
       plugin
           .getLogger()
           .warning(
-              "Некорректное значение team.deadline-removal-policy: "
+              "Некорректное значение "
+                  + Keys.Team.Deadlines.REMOVAL_POLICY
+                  + ": "
                   + rawValue
                   + ". Используем LAST_JOINED.");
       return RemovalPolicy.LAST_JOINED;
@@ -227,7 +439,8 @@ public class PluginConfig {
    * @return Минимальная длина префикса
    */
   public int getMinPrefixLength() {
-    return config.getInt("team.min-prefix-length", 1);
+    return getIntWithLegacyFallback(
+        Keys.Team.Naming.Prefix.MIN_LENGTH, 1, "team.min-prefix-length");
   }
 
   /**
@@ -236,7 +449,8 @@ public class PluginConfig {
    * @return Максимальная длина префикса
    */
   public int getMaxPrefixLength() {
-    return config.getInt("team.max-prefix-length", 16);
+    return getIntWithLegacyFallback(
+        Keys.Team.Naming.Prefix.MAX_LENGTH, 16, "team.max-prefix-length");
   }
 
   /**
@@ -245,7 +459,8 @@ public class PluginConfig {
    * @return Минимальная длина названия команды
    */
   public int getMinTeamNameLength() {
-    return config.getInt("team.min-team-name-length", 3);
+    return getIntWithLegacyFallback(
+        Keys.Team.Naming.TeamName.MIN_LENGTH, 3, "team.min-team-name-length");
   }
 
   /**
@@ -254,7 +469,8 @@ public class PluginConfig {
    * @return Максимальная длина названия команды
    */
   public int getMaxTeamNameLength() {
-    return config.getInt("team.max-team-name-length", 32);
+    return getIntWithLegacyFallback(
+        Keys.Team.Naming.TeamName.MAX_LENGTH, 32, "team.max-team-name-length");
   }
 
   /**
@@ -263,7 +479,8 @@ public class PluginConfig {
    * @return Название звука
    */
   public String getMenuOpenSound() {
-    return config.getString("menu.open-sound", "BLOCK_NOTE_BLOCK_PLING");
+    return getStringWithLegacyFallback(
+        Keys.Menu.Sound.OPEN, "BLOCK_NOTE_BLOCK_PLING", "menu.open-sound");
   }
 
   /**
@@ -272,7 +489,8 @@ public class PluginConfig {
    * @return Название эффекта частиц
    */
   public String getMenuParticleEffect() {
-    return config.getString("menu.particle-effect", "FIREWORK");
+    return getStringWithLegacyFallback(
+        Keys.Menu.PARTICLE_EFFECT, "FIREWORK", "menu.particle-effect");
   }
 
   /**
@@ -281,7 +499,7 @@ public class PluginConfig {
    * @return Громкость звука
    */
   public double getMenuSoundVolume() {
-    return config.getDouble("menu.sound-volume", 1.0);
+    return getDoubleWithLegacyFallback(Keys.Menu.Sound.VOLUME, 1.0, "menu.sound-volume");
   }
 
   /**
@@ -290,6 +508,6 @@ public class PluginConfig {
    * @return Высота звука
    */
   public double getMenuSoundPitch() {
-    return config.getDouble("menu.sound-pitch", 1.0);
+    return getDoubleWithLegacyFallback(Keys.Menu.Sound.PITCH, 1.0, "menu.sound-pitch");
   }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -6,32 +6,42 @@
 # Список всех частиц: https://jd.papermc.io/paper/1.21/org/bukkit/Particle.html
 
 # Общие настройки
-debug-mode: true # Включает подробное логирование действий плагина
-force-white-chat: false # Принудительно перекрашивать сообщения чата в белый цвет
+debug:
+  mode: true # Включает подробное логирование действий плагина
+chat:
+  force-white: false # Принудительно перекрашивать сообщения чата в белый цвет
 
 # Настройки команды /team
 team:
-  requires-op: false # Если true, команды /team доступны только OP; если false — всем игрокам
-  min-prefix-length: 1 # Минимальная длина префикса команды
-  max-prefix-length: 16 # Максимальная длина префикса команды
-  min-team-name-length: 3 # Минимальная длина названия команды
-  max-team-name-length: 32 # Максимальная длина названия команды
-  max-members: 0 # Максимальное количество участников в команде (0 — безлимит)
-  notify-admins: true # Уведомлять ли администраторов о создании/роспуске команд
-  enforce-max-members-on-reload: true # Применять ограничение при перезагрузке
-
-  grace-period-enabled: true # Давать время на удаление лишних участников
-  deadline-notify-period-seconds: 300 # Период проверки дедлайнов и оповещения (в секундах)
-  save-interval-seconds: 60 # Интервал автосохранения команд (в секундах, 0 — мгновенное сохранение)
-  deadline-display-mode: CHAT # CHAT, ACTION_BAR или SCOREBOARD
-  grace-period-minutes: 10 # Длительность периода (в минутах, 0 — отключено)
-  deadline-removal-policy: last-joined # Способ удаления лишних игроков: offline-first или last-joined
-
+  commands:
+    requires-op: false # Если true, команды /team доступны только OP; если false — всем игрокам
+  notifications:
+    notify-admins: true # Уведомлять ли администраторов о создании/роспуске команд
+  naming:
+    prefix:
+      min-length: 1 # Минимальная длина префикса команды
+      max-length: 16 # Максимальная длина префикса команды
+    team:
+      min-length: 3 # Минимальная длина названия команды
+      max-length: 32 # Максимальная длина названия команды
+  membership:
+    max-members: 0 # Максимальное количество участников в команде (0 — безлимит)
+    enforce-max-members-on-reload: true # Применять ограничение при перезагрузке
+    grace-period:
+      enabled: true # Давать время на удаление лишних участников
+      minutes: 10 # Длительность периода (в минутах, 0 — отключено)
+  deadlines:
+    notify-period-seconds: 300 # Период проверки дедлайнов и оповещения (в секундах)
+    display-mode: CHAT # CHAT, ACTION_BAR или SCOREBOARD
+    removal-policy: last-joined # Способ удаления лишних игроков: offline-first или last-joined
+  storage:
+    save-interval-seconds: 60 # Интервал автосохранения команд (в секундах, 0 — мгновенное сохранение)
 
 # Настройки меню
 menu:
-  open-sound: BLOCK_NOTE_BLOCK_PLING # Звуковой эффект при открытии меню
-  sound-volume: 1.0 # Громкость звука (0.0–1.0)
-  sound-pitch: 1.0 # Высота тона звука (0.5–2.0)
+  sound:
+    open: BLOCK_NOTE_BLOCK_PLING # Звуковой эффект при открытии меню
+    volume: 1.0 # Громкость звука (0.0–1.0)
+    pitch: 1.0 # Высота тона звука (0.5–2.0)
   particle-effect: FIREWORK # Эффект частиц при открытии меню (примеры: SMOKE, HEART, FIREWORK, EXPLOSION)
 

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -48,6 +48,16 @@ class TeamCommandTest {
   private FileConfiguration config;
   private DeadlineScheduler scheduler;
 
+  private static final String MAX_MEMBERS_PATH = PluginConfig.Keys.Team.Membership.MAX_MEMBERS;
+  private static final String ENFORCE_MAX_ON_RELOAD_PATH =
+      PluginConfig.Keys.Team.Membership.ENFORCE_MAX_ON_RELOAD;
+  private static final String GRACE_ENABLED_PATH =
+      PluginConfig.Keys.Team.Membership.GracePeriod.ENABLED;
+  private static final String GRACE_MINUTES_PATH =
+      PluginConfig.Keys.Team.Membership.GracePeriod.MINUTES;
+  private static final String DEADLINE_DISPLAY_MODE_PATH =
+      PluginConfig.Keys.Team.Deadlines.DISPLAY_MODE;
+
   @BeforeAll
   static void initServer() {
     server = MockBukkit.mock();
@@ -211,10 +221,10 @@ class TeamCommandTest {
 
   @Test
   void transfersLeadershipRestoresScoreboardForPreviousLeader() {
-    config.set("team.deadline-display-mode", "SCOREBOARD");
-    config.set("team.max-members", 0);
-    config.set("team.grace-period-enabled", true);
-    config.set("team.grace-period-minutes", 5);
+    config.set(DEADLINE_DISPLAY_MODE_PATH, "SCOREBOARD");
+    config.set(MAX_MEMBERS_PATH, 0);
+    config.set(GRACE_ENABLED_PATH, true);
+    config.set(GRACE_MINUTES_PATH, 5);
 
     PlayerMock oldLeader = server.addPlayer("OldLeader");
     PlayerMock newLeader = server.addPlayer("NewLeader");
@@ -225,7 +235,7 @@ class TeamCommandTest {
     Scoreboard oldLeaderOriginal = oldLeader.getScoreboard();
     Scoreboard newLeaderOriginal = newLeader.getScoreboard();
 
-    config.set("team.max-members", 1);
+    config.set(MAX_MEMBERS_PATH, 1);
     scheduler.enforceTeamSizes();
 
     Scoreboard warnedOldLeaderBoard = oldLeader.getScoreboard();
@@ -247,7 +257,7 @@ class TeamCommandTest {
 
   @Test
   void preventsJoinWhenTeamFull() {
-    config.set("team.max-members", 1);
+    config.set(MAX_MEMBERS_PATH, 1);
     CommandMap commandMap = server.getCommandMap();
 
     PlayerMock leader = server.addPlayer("Leader");
@@ -266,10 +276,10 @@ class TeamCommandTest {
 
   @Test
   void keepsBlockingJoinsAfterReloadWhenEnforcementDisabled() {
-    config.set("team.max-members", 0);
-    config.set("team.grace-period-enabled", true);
-    config.set("team.grace-period-minutes", 5);
-    config.set("team.enforce-max-members-on-reload", false);
+    config.set(MAX_MEMBERS_PATH, 0);
+    config.set(GRACE_ENABLED_PATH, true);
+    config.set(GRACE_MINUTES_PATH, 5);
+    config.set(ENFORCE_MAX_ON_RELOAD_PATH, false);
 
     PlayerMock leader = server.addPlayer("ReloadLeader");
     PlayerMock memberOne = server.addPlayer("ReloadMemberOne");
@@ -281,7 +291,7 @@ class TeamCommandTest {
 
     assertEquals(3, teamManager.getTeamMembers("Reloaded").size());
 
-    config.set("team.max-members", 1);
+    config.set(MAX_MEMBERS_PATH, 1);
 
     scheduler.enforceTeamSizes(true);
     assertTrue(scheduler.getDeadlines().isEmpty());
@@ -465,7 +475,7 @@ class TeamCommandTest {
   @Test
   void playerQuitRemovesDeadlineAfterLeaving() {
     // Allow two players initially
-    config.set("team.max-members", 2);
+    config.set(MAX_MEMBERS_PATH, 2);
     CommandMap commandMap = server.getCommandMap();
 
     PlayerMock leader = server.addPlayer("Leader");
@@ -477,7 +487,7 @@ class TeamCommandTest {
     commandMap.dispatch(member, "team join Beta");
 
     // Reduce max members and enforce deadlines
-    config.set("team.max-members", 1);
+    config.set(MAX_MEMBERS_PATH, 1);
     scheduler.enforceTeamSizes();
     assertNotNull(teamManager.getTeamDeadline("Beta"));
 
@@ -501,8 +511,8 @@ class TeamCommandTest {
     member.addAttachment(plugin, "mypurpurplugin.team", true);
     assertTrue(commandMap.dispatch(member, "team join Beta"));
 
-    config.set("team.max-members", 1);
-    config.set("team.grace-period-minutes", 5);
+    config.set(MAX_MEMBERS_PATH, 1);
+    config.set(GRACE_MINUTES_PATH, 5);
     assertEquals(2, teamManager.getTeamMembers("Beta").size());
     assertEquals(1, pluginConfig.getMaxMembers());
 
@@ -533,8 +543,8 @@ class TeamCommandTest {
     member.addAttachment(plugin, "mypurpurplugin.team", true);
     assertTrue(commandMap.dispatch(member, "team join Beta"));
 
-    config.set("team.max-members", 1);
-    config.set("team.grace-period-minutes", 5);
+    config.set(MAX_MEMBERS_PATH, 1);
+    config.set(GRACE_MINUTES_PATH, 5);
     assertEquals(2, teamManager.getTeamMembers("Beta").size());
     assertEquals(1, pluginConfig.getMaxMembers());
     config.save(new File(plugin.getDataFolder(), "config.yml"));
@@ -571,8 +581,8 @@ class TeamCommandTest {
     extra.addAttachment(plugin, "mypurpurplugin.team", true);
     assertTrue(commandMap.dispatch(extra, "team join Beta"));
 
-    config.set("team.max-members", 1);
-    config.set("team.grace-period-minutes", 5);
+    config.set(MAX_MEMBERS_PATH, 1);
+    config.set(GRACE_MINUTES_PATH, 5);
 
     while (leader.nextComponentMessage() != null) {}
 

--- a/src/test/java/org/example/config/PluginConfigTest.java
+++ b/src/test/java/org/example/config/PluginConfigTest.java
@@ -57,10 +57,10 @@ class PluginConfigTest {
     assertTrue(regenerated.exists(), "Config file should be regenerated on reload");
 
     YamlConfiguration yaml = YamlConfiguration.loadConfiguration(regenerated);
-    assertEquals(1, yaml.getInt("team.min-prefix-length"));
-    assertEquals(16, yaml.getInt("team.max-prefix-length"));
-    assertEquals(32, yaml.getInt("team.max-team-name-length"));
-    assertEquals(0, yaml.getInt("team.max-members"));
+    assertEquals(1, yaml.getInt(PluginConfig.Keys.Team.Naming.Prefix.MIN_LENGTH));
+    assertEquals(16, yaml.getInt(PluginConfig.Keys.Team.Naming.Prefix.MAX_LENGTH));
+    assertEquals(32, yaml.getInt(PluginConfig.Keys.Team.Naming.TeamName.MAX_LENGTH));
+    assertEquals(0, yaml.getInt(PluginConfig.Keys.Team.Membership.MAX_MEMBERS));
 
     PlayerMock leader = server.addPlayer("Leader");
     leader.addAttachment(plugin, "mypurpurplugin.team", true);
@@ -91,7 +91,7 @@ class PluginConfigTest {
     fileField.setAccessible(true);
     File configFile = (File) fileField.get(pluginConfig);
 
-    configuration.set("team.max-team-name-length", null);
+    configuration.set(PluginConfig.Keys.Team.Naming.TeamName.MAX_LENGTH, null);
     configuration.save(configFile);
 
     pluginConfig.reloadConfig();
@@ -113,7 +113,7 @@ class PluginConfigTest {
     File configFile = (File) fileField.get(pluginConfig);
 
     YamlConfiguration yaml = YamlConfiguration.loadConfiguration(configFile);
-    yaml.set("menu.open-sound", null);
+    yaml.set(PluginConfig.Keys.Menu.Sound.OPEN, null);
     yaml.save(configFile);
 
     pluginConfig.reloadConfig();
@@ -122,7 +122,9 @@ class PluginConfigTest {
     configField.setAccessible(true);
     FileConfiguration configuration = (FileConfiguration) configField.get(pluginConfig);
 
-    assertEquals("BLOCK_NOTE_BLOCK_PLING", configuration.getString("menu.open-sound"));
+    assertEquals(
+        "BLOCK_NOTE_BLOCK_PLING",
+        configuration.getString(PluginConfig.Keys.Menu.Sound.OPEN));
   }
 
   @Test
@@ -139,8 +141,8 @@ class PluginConfigTest {
     File configFile = (File) fileField.get(pluginConfig);
 
     YamlConfiguration yaml = YamlConfiguration.loadConfiguration(configFile);
-    yaml.set("menu.particle-effect", null);
-    yaml.set("team.max-members", 7);
+    yaml.set(PluginConfig.Keys.Menu.PARTICLE_EFFECT, null);
+    yaml.set(PluginConfig.Keys.Team.Membership.MAX_MEMBERS, 7);
     yaml.save(configFile);
 
     ConsoleCommandSender console = server.getConsoleSender();
@@ -151,8 +153,10 @@ class PluginConfigTest {
     configField.setAccessible(true);
     FileConfiguration configuration = (FileConfiguration) configField.get(pluginConfig);
 
-    assertEquals("FIREWORK", configuration.getString("menu.particle-effect"));
-    assertEquals(7, configuration.getInt("team.max-members"));
+    assertEquals(
+        "FIREWORK",
+        configuration.getString(PluginConfig.Keys.Menu.PARTICLE_EFFECT));
+    assertEquals(7, configuration.getInt(PluginConfig.Keys.Team.Membership.MAX_MEMBERS));
   }
 
   @Test

--- a/src/test/java/org/example/service/DeadlineSchedulerTest.java
+++ b/src/test/java/org/example/service/DeadlineSchedulerTest.java
@@ -94,11 +94,14 @@ class DeadlineSchedulerTest {
     File configFile = new File(dataFolder, "config.yml");
     String contents =
         "team:\n"
-            + "  max-members: 2\n"
-            + "  enforce-max-members-on-reload: false\n"
-            + "  grace-period-enabled: true\n"
-            + "  grace-period-minutes: 5\n"
-            + "  deadline-display-mode: SCOREBOARD\n";
+            + "  membership:\n"
+            + "    max-members: 2\n"
+            + "    enforce-max-members-on-reload: false\n"
+            + "    grace-period:\n"
+            + "      enabled: true\n"
+            + "      minutes: 5\n"
+            + "  deadlines:\n"
+            + "    display-mode: SCOREBOARD\n";
     Files.writeString(configFile.toPath(), contents, StandardCharsets.UTF_8);
   }
 }


### PR DESCRIPTION
## Summary
- reorganize PluginConfig to expose structured key constants and migrate legacy paths
- update configuration accessors to use the new hierarchy with legacy fallbacks and refresh the bundled config.yml
- adjust tests and manual configuration overrides to match the new paths

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d1a6af5b1c832ea46c459a8c55e576