### PR TITLE
Use explicit permissions instead of op checks

### DIFF
--- a/src/main/java/org/example/command/TeamCommand.java
+++ b/src/main/java/org/example/command/TeamCommand.java
@@ -69,10 +69,12 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
 
     // При необходимости проверяем статус оператора, чтобы выполнить требование
     // конфигурации.
-    if (pluginConfig.isTeamCommandRequiresOp() && !player.isOp()) {
+    if (pluginConfig.isTeamCommandRequiresOp()
+        && !player.hasPermission("mypurpurplugin.team.requiresop")) {
       player.sendMessage(
           Component.text(
-              "❌ У вас нет прав для использования этой команды! Требуются права OP.",
+              "❌ У вас нет прав для использования этой команды! Требуется разрешение "
+                  + "mypurpurplugin.team.requiresop.",
               NamedTextColor.RED));
       return true;
     }

--- a/src/main/java/org/example/config/PluginConfig.java
+++ b/src/main/java/org/example/config/PluginConfig.java
@@ -137,20 +137,16 @@ public class PluginConfig {
     newKeysAdded |= migrateLegacyKey("force-white-chat", Keys.CHAT_FORCE_WHITE);
     newKeysAdded |= migrateLegacyKey("team.requires-op", Keys.Team.Commands.REQUIRES_OP);
     newKeysAdded |= migrateLegacyKey("team.notify-admins", Keys.Team.Notifications.NOTIFY_ADMINS);
-    newKeysAdded |=
-        migrateLegacyKey("team.max-members", Keys.Team.Membership.MAX_MEMBERS);
+    newKeysAdded |= migrateLegacyKey("team.max-members", Keys.Team.Membership.MAX_MEMBERS);
     newKeysAdded |=
         migrateLegacyKey(
-            "team.enforce-max-members-on-reload",
-            Keys.Team.Membership.ENFORCE_MAX_ON_RELOAD);
+            "team.enforce-max-members-on-reload", Keys.Team.Membership.ENFORCE_MAX_ON_RELOAD);
     newKeysAdded |=
         migrateLegacyKey("team.grace-period-enabled", Keys.Team.Membership.GracePeriod.ENABLED);
     newKeysAdded |=
         migrateLegacyKey("team.grace-period-minutes", Keys.Team.Membership.GracePeriod.MINUTES);
-    newKeysAdded |=
-        migrateLegacyKey("team.min-prefix-length", Keys.Team.Naming.Prefix.MIN_LENGTH);
-    newKeysAdded |=
-        migrateLegacyKey("team.max-prefix-length", Keys.Team.Naming.Prefix.MAX_LENGTH);
+    newKeysAdded |= migrateLegacyKey("team.min-prefix-length", Keys.Team.Naming.Prefix.MIN_LENGTH);
+    newKeysAdded |= migrateLegacyKey("team.max-prefix-length", Keys.Team.Naming.Prefix.MAX_LENGTH);
     newKeysAdded |=
         migrateLegacyKey("team.min-team-name-length", Keys.Team.Naming.TeamName.MIN_LENGTH);
     newKeysAdded |=
@@ -230,7 +226,8 @@ public class PluginConfig {
     return defaultValue;
   }
 
-  private int getIntWithLegacyFallback(@NotNull String path, int defaultValue, String... legacyPaths) {
+  private int getIntWithLegacyFallback(
+      @NotNull String path, int defaultValue, String... legacyPaths) {
     if (config.contains(path)) {
       return config.getInt(path, defaultValue);
     }
@@ -321,8 +318,7 @@ public class PluginConfig {
    * @return true, если требуется OP, иначе false
    */
   public boolean isTeamCommandRequiresOp() {
-    return getBooleanWithLegacyFallback(
-        Keys.Team.Commands.REQUIRES_OP, false, "team.requires-op");
+    return getBooleanWithLegacyFallback(Keys.Team.Commands.REQUIRES_OP, false, "team.requires-op");
   }
 
   /**
@@ -351,9 +347,7 @@ public class PluginConfig {
    */
   public boolean isEnforceMaxMembersOnReload() {
     return getBooleanWithLegacyFallback(
-        Keys.Team.Membership.ENFORCE_MAX_ON_RELOAD,
-        true,
-        "team.enforce-max-members-on-reload");
+        Keys.Team.Membership.ENFORCE_MAX_ON_RELOAD, true, "team.enforce-max-members-on-reload");
   }
 
   /**
@@ -383,9 +377,7 @@ public class PluginConfig {
    */
   public long getDeadlineNotifyPeriodSeconds() {
     return getLongWithLegacyFallback(
-        Keys.Team.Deadlines.NOTIFY_PERIOD_SECONDS,
-        300L,
-        "team.deadline-notify-period-seconds");
+        Keys.Team.Deadlines.NOTIFY_PERIOD_SECONDS, 300L, "team.deadline-notify-period-seconds");
   }
 
   /**

--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -709,7 +709,7 @@ public class DeadlineScheduler {
       return;
     }
     plugin.getServer().getOnlinePlayers().stream()
-        .filter(player -> player.isOp() || player.hasPermission("mypurpurplugin.admin"))
+        .filter(player -> player.hasPermission("mypurpurplugin.admin"))
         .forEach(player -> TeamMessageUtils.sendTeamMessage(player, message));
   }
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -21,13 +21,13 @@ commands:
     permission-message: "❌ У вас нет прав для использования этой команды!"
 
   getteamsuuidlist:
-    description: Показывает список команд и их UUID (только для OP)
+    description: Показывает список команд и их UUID (требуется разрешение mypurpurplugin.getteamsuuidlist)
     usage: /<command>
     permission: mypurpurplugin.getteamsuuidlist
     permission-message: "❌ У вас нет прав для использования этой команды!"
 
   getteamuuid:
-    description: Показывает UUID команды по названию (только для OP)
+    description: Показывает UUID команды по названию (требуется разрешение mypurpurplugin.getteamuuid)
     usage: /<command> <название>
     permission: mypurpurplugin.getteamuuid
     permission-message: "❌ У вас нет прав для использования этой команды!"
@@ -61,6 +61,9 @@ permissions:
   mypurpurplugin.teamadmin:
     description: Доступ к команде /teamadmin (для лидеров)
     default: true
+  mypurpurplugin.team.requiresop:
+    description: Доступ к дополнительным возможностям команды /team, требующим прав администратора
+    default: op
   mypurpurplugin.admin:
     description: Получает уведомления о действиях с командами
     default: op

--- a/src/test/java/org/example/config/PluginConfigTest.java
+++ b/src/test/java/org/example/config/PluginConfigTest.java
@@ -123,8 +123,7 @@ class PluginConfigTest {
     FileConfiguration configuration = (FileConfiguration) configField.get(pluginConfig);
 
     assertEquals(
-        "BLOCK_NOTE_BLOCK_PLING",
-        configuration.getString(PluginConfig.Keys.Menu.Sound.OPEN));
+        "BLOCK_NOTE_BLOCK_PLING", configuration.getString(PluginConfig.Keys.Menu.Sound.OPEN));
   }
 
   @Test
@@ -153,9 +152,7 @@ class PluginConfigTest {
     configField.setAccessible(true);
     FileConfiguration configuration = (FileConfiguration) configField.get(pluginConfig);
 
-    assertEquals(
-        "FIREWORK",
-        configuration.getString(PluginConfig.Keys.Menu.PARTICLE_EFFECT));
+    assertEquals("FIREWORK", configuration.getString(PluginConfig.Keys.Menu.PARTICLE_EFFECT));
     assertEquals(7, configuration.getInt(PluginConfig.Keys.Team.Membership.MAX_MEMBERS));
   }
 

--- a/src/test/java/org/example/service/TeamStorageTest.java
+++ b/src/test/java/org/example/service/TeamStorageTest.java
@@ -99,8 +99,7 @@ class TeamStorageTest {
 
     PlayerMock leader = server.addPlayer("LeaderMember");
     PlayerMock member = server.addPlayer("SecondMember");
-    Team team =
-        new Team(UUID.randomUUID(), "MembersTeam", leader.getUniqueId(), "[M]", "yellow");
+    Team team = new Team(UUID.randomUUID(), "MembersTeam", leader.getUniqueId(), "[M]", "yellow");
     team.setMembersByUuid(List.of(leader.getUniqueId(), member.getUniqueId()));
     storage.addTeam(team);
     storage.saveTeams(deadlines);


### PR DESCRIPTION
## Summary
- require the dedicated mypurpurplugin.team.requiresop permission when the /team command demands elevated rights and show a clear denial message
- notify administrators based solely on the mypurpurplugin.admin permission and document the new permission in plugin.yml

## Testing
- ./gradlew build

------
https://chatgpt.com/codex/tasks/task_e_68d1aa2be07c832ea9b919e99abe579d