### PR TITLE
Cache player teams for fast lookup

### DIFF
--- a/src/main/java/org/example/service/DeadlineScheduler.java
+++ b/src/main/java/org/example/service/DeadlineScheduler.java
@@ -512,7 +512,7 @@ public class DeadlineScheduler {
         break;
       }
       team.removeMember(removed);
-      storage.getPlayerTeams().remove(removed);
+      storage.clearPlayerTeam(removed);
       removedCount++;
       changed = true;
       Player player = plugin.getServer().getPlayer(removed);

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -61,7 +61,7 @@ public class MembershipService {
         new Team(normalizedTeamName, leader.getUniqueId(), normalizedPrefix, normalizedColor);
     storage.addTeam(team);
     updateTeamMembersPrefixes(team);
-    storage.getPlayerTeams().put(leader.getUniqueId(), team.getId());
+    storage.assignPlayerToTeam(leader.getUniqueId(), team);
     TeamMessageUtils.sendTeamMessage(
         leader, Component.text("✅ Команда создана", NamedTextColor.GREEN));
     scheduler.evaluateTeam(team);
@@ -91,7 +91,7 @@ public class MembershipService {
     }
     // Добавляем игрока и фиксируем изменения в хранилище.
     team.addMember(player.getUniqueId());
-    storage.getPlayerTeams().put(player.getUniqueId(), team.getId());
+    storage.assignPlayerToTeam(player.getUniqueId(), team);
     storage.markTeamDirty(team);
     TeamMessageUtils.sendTeamMessage(
         player, Component.text("✅ Вы вступили в команду", NamedTextColor.GREEN));
@@ -107,7 +107,7 @@ public class MembershipService {
     if (!team.hasMember(playerId) && !team.isLeader(playerId)) return;
     // Удаляем игрока и очищаем обратные ссылки.
     team.removeMember(playerId);
-    storage.getPlayerTeams().remove(playerId);
+    storage.clearPlayerTeam(playerId);
     boolean removedTeam = false;
     // Если ушедший игрок был лидером, либо закрываем команду, либо назначаем нового.
     if (team.isLeader(playerId)) {
@@ -150,7 +150,7 @@ public class MembershipService {
     // Удаляем участника и фиксируем изменения.
 
     team.removeMember(targetId);
-    storage.getPlayerTeams().remove(targetId);
+    storage.clearPlayerTeam(targetId);
     storage.markTeamDirty(team);
     scheduler.evaluateTeam(team);
     notifyPrefixUpdate(targetId, null);
@@ -185,7 +185,7 @@ public class MembershipService {
     }
     // После уведомления очищаем соответствия игроков и команд.
     for (UUID memberId : members) {
-      storage.getPlayerTeams().remove(memberId);
+      storage.clearPlayerTeam(memberId);
     }
   }
 

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -27,6 +27,7 @@ public class TeamStorage {
   private final Map<UUID, Team> teams = new ConcurrentHashMap<>();
   private final Map<String, UUID> teamIdsByName = new ConcurrentHashMap<>();
   private final Map<UUID, UUID> playerTeams = new ConcurrentHashMap<>();
+  private final Map<UUID, Team> playerTeamCache = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, UUID> resolvedProfileCache = new ConcurrentHashMap<>();
   private final ConcurrentMap<String, CompletableFuture<UUID>> pendingProfileLookups =
       new ConcurrentHashMap<>();
@@ -64,6 +65,7 @@ public class TeamStorage {
       teams.clear();
       teamIdsByName.clear();
       playerTeams.clear();
+      playerTeamCache.clear();
       pendingTeamLoads.clear();
       deadlines.clear();
       var section = teamsConfig.getConfigurationSection("teams");
@@ -217,6 +219,13 @@ public class TeamStorage {
       if (normalizedName != null) {
         teamIdsByName.remove(normalizedName);
       }
+      for (UUID memberId : team.getMembers()) {
+        clearPlayerTeam(memberId);
+      }
+      UUID leaderId = team.getLeaderId();
+      if (leaderId != null) {
+        clearPlayerTeam(leaderId);
+      }
       markTeamDirty(team);
     }
   }
@@ -266,9 +275,22 @@ public class TeamStorage {
   }
 
   public String getPlayerTeam(@NotNull Player player) {
-    UUID id = playerTeams.get(player.getUniqueId());
-    Team team = id != null ? teams.get(id) : null;
+    Team team = playerTeamCache.get(player.getUniqueId());
     return team != null ? team.getName() : null;
+  }
+
+  public void assignPlayerToTeam(@NotNull UUID playerId, @NotNull Team team) {
+    cachePlayerTeam(playerId, team);
+  }
+
+  public void clearPlayerTeam(@NotNull UUID playerId) {
+    playerTeams.remove(playerId);
+    playerTeamCache.remove(playerId);
+  }
+
+  private void cachePlayerTeam(@NotNull UUID playerId, @NotNull Team team) {
+    playerTeams.put(playerId, team.getId());
+    playerTeamCache.put(playerId, team);
   }
 
   @NotNull
@@ -483,7 +505,7 @@ public class TeamStorage {
     }
     addTeamInternal(team, false);
     for (UUID member : team.getMembers()) {
-      playerTeams.put(member, team.getId());
+      cachePlayerTeam(member, team);
     }
     if (convertedMembers) {
       markTeamDirty(team);
@@ -632,7 +654,7 @@ public class TeamStorage {
       if (!members.contains(resolvedUuid)) {
         members.add(resolvedUuid);
         team.setMembersByUuid(members);
-        playerTeams.put(resolvedUuid, team.getId());
+        cachePlayerTeam(resolvedUuid, team);
         teamsConfig.set(
             "teams." + team.getId() + ".members",
             members.stream().map(UUID::toString).collect(Collectors.toList()));


### PR DESCRIPTION
## Summary
- cache player-to-team relationships inside `TeamStorage` and expose helpers to maintain the map
- update membership workflows and deadline cleanup to keep the cache in sync with joins, leaves, and removals

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68d1cd7f2944832e83553f6156697af4