### PR TITLE
Fix inspection warnings and modernize team utilities

### DIFF
--- a/src/main/java/org/example/MyPurpurPlugin.java
+++ b/src/main/java/org/example/MyPurpurPlugin.java
@@ -79,7 +79,7 @@ public class MyPurpurPlugin extends JavaPlugin {
    * @param message Сообщение для логирования
    */
   public void debug(String message) {
-    if (debugMode) {
+    if (isDebugMode()) {
       getLogger().info("[DEBUG] " + message);
     }
   }
@@ -108,7 +108,6 @@ public class MyPurpurPlugin extends JavaPlugin {
    *
    * @return true, если режим отладки включён, иначе false
    */
-  @SuppressWarnings("unused")
   public boolean isDebugMode() {
     return debugMode;
   }

--- a/src/main/java/org/example/command/TeamCommand.java
+++ b/src/main/java/org/example/command/TeamCommand.java
@@ -46,7 +46,6 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
   }
 
   @Override
-  @SuppressWarnings("unused")
   public boolean onCommand(
       @NotNull CommandSender sender,
       @NotNull Command command,
@@ -119,7 +118,6 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
   }
 
   @Override
-  @SuppressWarnings("unused")
   public List<String> onTabComplete(
       @NotNull CommandSender sender,
       @NotNull Command command,

--- a/src/main/java/org/example/config/PluginConfig.java
+++ b/src/main/java/org/example/config/PluginConfig.java
@@ -159,7 +159,8 @@ public class PluginConfig {
             "team.deadline-notify-period-seconds", Keys.Team.Deadlines.NOTIFY_PERIOD_SECONDS);
     changed |= migrateLegacyKey("team.deadline-display-mode", Keys.Team.Deadlines.DISPLAY_MODE);
     changed |= migrateLegacyKey("team.deadline-removal-policy", Keys.Team.Deadlines.REMOVAL_POLICY);
-    changed |= migrateLegacyKey("team.save-interval-seconds", Keys.Team.Storage.SAVE_INTERVAL_SECONDS);
+    changed |=
+        migrateLegacyKey("team.save-interval-seconds", Keys.Team.Storage.SAVE_INTERVAL_SECONDS);
     changed |= migrateLegacyKey("menu.open-sound", Keys.Menu.Sound.OPEN);
     changed |= migrateLegacyKey("menu.sound-volume", Keys.Menu.Sound.VOLUME);
     changed |= migrateLegacyKey("menu.sound-pitch", Keys.Menu.Sound.PITCH);

--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -19,6 +19,7 @@ import org.example.service.TeamService;
 import org.example.util.TeamMessageUtils;
 import org.example.util.TeamUtils;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Слушатель событий, связанных с командами и чатом игроков. */
 public class TeamChatListener implements Listener {
@@ -247,7 +248,7 @@ public class TeamChatListener implements Listener {
   }
 
   private @NotNull Component cacheOriginalPlayerListName(
-      @NotNull Player player, Component applyingPrefix) {
+      @NotNull Player player, @Nullable Component applyingPrefix) {
     UUID playerId = player.getUniqueId();
     Component existing = originalPlayerListNames.get(playerId);
     if (existing != null) {
@@ -281,7 +282,7 @@ public class TeamChatListener implements Listener {
   }
 
   private @NotNull Component getOrStoreOriginalPlayerDisplayName(
-      @NotNull Player player, Component applyingPrefix) {
+      @NotNull Player player, @Nullable Component applyingPrefix) {
     UUID playerId = player.getUniqueId();
     Component existing = originalPlayerDisplayNames.get(playerId);
     if (existing != null) {
@@ -314,8 +315,10 @@ public class TeamChatListener implements Listener {
     return Component.text(player.getName());
   }
 
-  private Component stripKnownPrefix(
-      @NotNull Component current, Component activePrefix, Component applyingPrefix) {
+  private @Nullable Component stripKnownPrefix(
+      @NotNull Component current,
+      @Nullable Component activePrefix,
+      @Nullable Component applyingPrefix) {
     Component prefixToStrip = activePrefix != null ? activePrefix : applyingPrefix;
     if (prefixToStrip == null) {
       return null;
@@ -323,7 +326,8 @@ public class TeamChatListener implements Listener {
     return stripPrefixIfPresent(current, prefixToStrip);
   }
 
-  private Component stripPrefixIfPresent(@NotNull Component current, @NotNull Component prefix) {
+  private @Nullable Component stripPrefixIfPresent(
+      @NotNull Component current, @NotNull Component prefix) {
     if (!(current instanceof TextComponent currentText)
         || !(prefix instanceof TextComponent prefixText)) {
       return null;
@@ -336,7 +340,7 @@ public class TeamChatListener implements Listener {
       return Component.empty();
     }
     if (current.children().size() == 1) {
-      return current.children().get(0);
+      return current.children().getFirst();
     }
     Component remainder = Component.empty();
     for (Component child : current.children()) {
@@ -374,7 +378,7 @@ public class TeamChatListener implements Listener {
     private final Player player;
     private final Component prefix;
 
-    public PlayerPrefixUpdateEvent(@NotNull Player player, Component prefix) {
+    public PlayerPrefixUpdateEvent(@NotNull Player player, @Nullable Component prefix) {
       this.player = player;
       this.prefix = prefix;
     }
@@ -383,8 +387,7 @@ public class TeamChatListener implements Listener {
       return player;
     }
 
-    @SuppressWarnings("unused")
-    public Component getPrefix() {
+    public @Nullable Component getPrefix() {
       return prefix;
     }
 
@@ -393,7 +396,6 @@ public class TeamChatListener implements Listener {
       return HANDLERS;
     }
 
-    @SuppressWarnings("unused")
     public static @NotNull org.bukkit.event.HandlerList getHandlerList() {
       return HANDLERS;
     }

--- a/src/main/java/org/example/model/Team.java
+++ b/src/main/java/org/example/model/Team.java
@@ -9,6 +9,7 @@ import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.example.util.TeamUtils;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** Представляет команду с уникальным идентификатором и изменяемыми данными. */
@@ -43,27 +44,27 @@ public class Team {
     return id;
   }
 
-  public String getName() {
+  public @NotNull String getName() {
     return name;
   }
 
-  public UUID getLeaderId() {
+  public @Nullable UUID getLeaderId() {
     return leader;
   }
 
-  public List<UUID> getMembers() {
+  public @NotNull List<UUID> getMembers() {
     return new ArrayList<>(members);
   }
 
-  public UUID getFirstMember() {
-    return members.isEmpty() ? null : members.get(0);
+  public @Nullable UUID getFirstMember() {
+    return members.isEmpty() ? null : members.getFirst();
   }
 
-  public String getPrefix() {
+  public @NotNull String getPrefix() {
     return prefix;
   }
 
-  public NamedTextColor getColor() {
+  public @NotNull NamedTextColor getColor() {
     return color;
   }
 
@@ -72,7 +73,7 @@ public class Team {
     this.name = normalizeName(name);
   }
 
-  public void setLeader(UUID leader) {
+  public void setLeader(@Nullable UUID leader) {
     this.leader = leader;
     addMember(leader);
   }
@@ -141,7 +142,7 @@ public class Team {
   }
 
   // Утилитный метод для префикса
-  public Component getPrefixComponent() {
+  public @NotNull Component getPrefixComponent() {
     return TeamUtils.createPrefixComponent(prefix, color);
   }
 

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -116,7 +116,10 @@ public class MembershipService {
         storage.removeTeam(team);
         removedTeam = true;
       } else {
-        team.setLeader(team.getMembers().get(0));
+        UUID newLeader = team.getFirstMember();
+        if (newLeader != null) {
+          team.setLeader(newLeader);
+        }
         scheduler.handleLeaderTransfer(team);
       }
     }

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -17,6 +17,7 @@ import org.bukkit.scheduler.BukkitTask;
 import org.example.config.PluginConfig;
 import org.example.model.Team;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Handles persistence of team data and keeps track of player memberships. */
 public class TeamStorage {
@@ -55,7 +56,13 @@ public class TeamStorage {
       teamsFile = new File(plugin.getDataFolder(), "teams.yml");
       if (!teamsFile.exists()) {
         try {
-          teamsFile.getParentFile().mkdirs();
+          File parent = teamsFile.getParentFile();
+          if (parent != null && !parent.exists() && !parent.mkdirs()) {
+            plugin
+                .getLogger()
+                .severe("Failed to create directory for teams.yml at " + parent.getAbsolutePath());
+            return;
+          }
           teamsFile.createNewFile();
         } catch (IOException e) {
           plugin.getLogger().severe("Failed to create teams.yml: " + e.getMessage());
@@ -191,7 +198,7 @@ public class TeamStorage {
     }
   }
 
-  public Map<UUID, Team> getTeams() {
+  public @NotNull Map<UUID, Team> getTeams() {
     return teams;
   }
 
@@ -256,11 +263,11 @@ public class TeamStorage {
     }
   }
 
-  public Map<UUID, UUID> getPlayerTeams() {
+  public @NotNull Map<UUID, UUID> getPlayerTeams() {
     return playerTeams;
   }
 
-  public Team getTeamByName(String teamName) {
+  public @Nullable Team getTeamByName(@Nullable String teamName) {
     String normalizedName = normalizeTeamKey(teamName);
     if (normalizedName == null) {
       return null;
@@ -269,12 +276,12 @@ public class TeamStorage {
     return teamId != null ? teams.get(teamId) : null;
   }
 
-  public UUID getTeamIdByName(String teamName) {
+  public @Nullable UUID getTeamIdByName(@Nullable String teamName) {
     String normalizedName = normalizeTeamKey(teamName);
     return normalizedName != null ? teamIdsByName.get(normalizedName) : null;
   }
 
-  public String getPlayerTeam(@NotNull Player player) {
+  public @Nullable String getPlayerTeam(@NotNull Player player) {
     Team team = playerTeamCache.get(player.getUniqueId());
     return team != null ? team.getName() : null;
   }
@@ -304,18 +311,17 @@ public class TeamStorage {
     return teams.values().stream().map(Team::getName).collect(Collectors.toList());
   }
 
-  public String getTeamPrefix(String teamName) {
+  public @NotNull String getTeamPrefix(@Nullable String teamName) {
     Team team = getTeamByName(teamName);
     return team != null ? team.getPrefix() : "";
   }
 
-  @NotNull
-  public NamedTextColor getTeamColor(String teamName) {
+  public @NotNull NamedTextColor getTeamColor(@Nullable String teamName) {
     Team team = getTeamByName(teamName);
     return team != null ? team.getColor() : NamedTextColor.WHITE;
   }
 
-  public UUID getTeamLeaderId(String teamName) {
+  public @Nullable UUID getTeamLeaderId(@Nullable String teamName) {
     Team team = getTeamByName(teamName);
     return team != null ? team.getLeaderId() : null;
   }
@@ -490,7 +496,7 @@ public class TeamStorage {
     if (!memberIds.contains(leaderId)) {
       memberIds.add(0, leaderId);
       convertedMembers = true;
-    } else if (!memberIds.isEmpty() && !leaderId.equals(memberIds.get(0))) {
+    } else if (!memberIds.isEmpty() && !leaderId.equals(memberIds.getFirst())) {
       memberIds.remove(leaderId);
       memberIds.add(0, leaderId);
       convertedMembers = true;

--- a/src/test/java/org/example/service/TeamManagerTest.java
+++ b/src/test/java/org/example/service/TeamManagerTest.java
@@ -41,7 +41,7 @@ class TeamManagerTest extends MockBukkitTestBase {
             mockConstruction(MembershipService.class)) {
 
       TeamManager manager = new TeamManager(plugin, pluginConfig);
-      MembershipService membership = membershipMock.constructed().get(0);
+      MembershipService membership = membershipMock.constructed().getFirst();
 
       PlayerMock leader = server.addPlayer("Leader");
       PlayerMock member = server.addPlayer("Member");


### PR DESCRIPTION
## Summary
- annotate key team and storage APIs with nullability hints and remove redundant suppress warnings
- replace brittle get(0) usages with modern getFirst()/Team#getFirstMember and improve leader reassignment safety
- handle mkdirs() failures when creating teams.yml to avoid silent load issues

## Testing
- ./gradlew spotlessApply --console=plain
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d1d003057c832e8bcd3e3e268f2c2f