### PR TITLE
Enhance team service notifications

### DIFF
--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -152,6 +152,12 @@ public class MembershipService {
     }
     // Удаляем участника и фиксируем изменения.
 
+    String actualTargetName = targetName;
+    String leaderName = leader.getName();
+    OfflinePlayer offlineTarget = plugin.getServer().getOfflinePlayer(targetId);
+    if (offlineTarget != null && offlineTarget.getName() != null) {
+      actualTargetName = offlineTarget.getName();
+    }
     team.removeMember(targetId);
     storage.clearPlayerTeam(targetId);
     storage.markTeamDirty(team);
@@ -159,6 +165,18 @@ public class MembershipService {
     notifyPrefixUpdate(targetId, null);
 
     updateTeamMembersPrefixes(team);
+    TeamMessageUtils.sendTeamMessage(
+        leader, TeamMessageUtils.memberKickedLeaderMessage(actualTargetName));
+    Player kickedPlayer = plugin.getServer().getPlayer(targetId);
+    if (kickedPlayer != null) {
+      TeamMessageUtils.sendTeamMessage(
+          kickedPlayer,
+          TeamMessageUtils.memberKickedTargetMessage(team.getName(), leaderName));
+    }
+    sendMessageToOnlinePlayers(
+        team.getMembers(),
+        TeamMessageUtils.memberKickedBroadcastMessage(actualTargetName),
+        leader.getUniqueId());
   }
 
   public void transferLeadership(
@@ -168,10 +186,21 @@ public class MembershipService {
     if (team == null || !team.isLeader(leader.getUniqueId())) return;
     // Назначать лидером можно только участника команды.
     if (!team.hasMember(newLeader.getUniqueId())) return;
+    UUID previousLeader = leader.getUniqueId();
     team.setLeader(newLeader.getUniqueId());
     storage.markTeamDirty(team);
     scheduler.handleLeaderTransfer(team);
     scheduler.evaluateTeam(team);
+    String newLeaderName = newLeader.getName();
+    TeamMessageUtils.sendTeamMessage(
+        leader, TeamMessageUtils.leadershipTransferOutgoingMessage(newLeaderName));
+    TeamMessageUtils.sendTeamMessage(
+        newLeader, TeamMessageUtils.leadershipTransferIncomingMessage(team.getName()));
+    sendMessageToOnlinePlayers(
+        team.getMembers(),
+        TeamMessageUtils.leadershipTransferBroadcastMessage(newLeaderName),
+        previousLeader,
+        newLeader.getUniqueId());
   }
 
   public void disbandTeam(String teamName, @NotNull Player leader) {
@@ -180,9 +209,16 @@ public class MembershipService {
     if (team == null || !team.isLeader(leader.getUniqueId())) return;
     // Сохраняем список участников до удаления, чтобы очистить их отображаемые префиксы.
     List<UUID> members = team.getMembers();
+    String leaderName = leader.getName();
     scheduler.cancelDeadline(team);
     // Удаляем команду и уведомляем игроков о сбросе префикса.
     storage.removeTeam(team);
+    TeamMessageUtils.sendTeamMessage(
+        leader, TeamMessageUtils.teamDisbandedLeaderMessage(team.getName()));
+    sendMessageToOnlinePlayers(
+        members,
+        TeamMessageUtils.teamDisbandedMemberMessage(team.getName(), leaderName),
+        leader.getUniqueId());
     for (UUID memberId : members) {
       notifyPrefixUpdate(memberId, null);
     }
@@ -210,6 +246,12 @@ public class MembershipService {
     team.setPrefix(normalizedPrefix);
     storage.markTeamDirty(team);
     updateTeamMembersPrefixes(team);
+    TeamMessageUtils.sendTeamMessage(
+        leader, TeamMessageUtils.teamPrefixUpdatedLeaderMessage(normalizedPrefix));
+    sendMessageToOnlinePlayers(
+        team.getMembers(),
+        TeamMessageUtils.teamPrefixUpdatedMemberMessage(normalizedPrefix),
+        leader.getUniqueId());
   }
 
   public void setTeamColor(String teamName, String newColor, @NotNull Player leader) {
@@ -226,6 +268,12 @@ public class MembershipService {
     team.setColor(normalizedColor);
     storage.markTeamDirty(team);
     updateTeamMembersPrefixes(team);
+    TeamMessageUtils.sendTeamMessage(
+        leader, TeamMessageUtils.teamColorUpdatedLeaderMessage(normalizedColor));
+    sendMessageToOnlinePlayers(
+        team.getMembers(),
+        TeamMessageUtils.teamColorUpdatedMemberMessage(normalizedColor),
+        leader.getUniqueId());
   }
 
   public void updatePlayerPrefixes(String teamName) {
@@ -253,6 +301,25 @@ public class MembershipService {
     Player onlinePlayer = plugin.getServer().getPlayer(playerId);
     if (onlinePlayer != null) {
       notifyPrefixUpdate(onlinePlayer, prefix);
+    }
+  }
+
+  private void sendMessageToOnlinePlayers(
+      @NotNull Collection<UUID> recipients,
+      @NotNull Component message,
+      UUID... excludedPlayers) {
+    Set<UUID> excluded = Collections.emptySet();
+    if (excludedPlayers != null && excludedPlayers.length > 0) {
+      excluded = new HashSet<>(Arrays.asList(excludedPlayers));
+    }
+    for (UUID memberId : recipients) {
+      if (excluded.contains(memberId)) {
+        continue;
+      }
+      Player member = plugin.getServer().getPlayer(memberId);
+      if (member != null) {
+        TeamMessageUtils.sendTeamMessage(member, message);
+      }
     }
   }
 

--- a/src/main/java/org/example/util/TeamMessageUtils.java
+++ b/src/main/java/org/example/util/TeamMessageUtils.java
@@ -118,4 +118,99 @@ public class TeamMessageUtils {
         .append(Component.text(excess + " участника(ов)", NamedTextColor.WHITE))
         .append(Component.text(".", NamedTextColor.YELLOW));
   }
+
+  public static Component teamDisbandedLeaderMessage(String teamName) {
+    return Component.text("✅ Команда ", NamedTextColor.GREEN)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" распущена.", NamedTextColor.GREEN));
+  }
+
+  public static Component teamDisbandedMemberMessage(String teamName, String leaderName) {
+    Component base =
+        Component.text("ℹ️ Команда ", NamedTextColor.YELLOW)
+            .append(Component.text(teamName, NamedTextColor.WHITE))
+            .append(Component.text(" была распущена", NamedTextColor.YELLOW));
+    if (leaderName != null && !leaderName.isBlank()) {
+      base =
+          base.append(Component.text(" лидером ", NamedTextColor.YELLOW))
+              .append(Component.text(leaderName, NamedTextColor.WHITE));
+    }
+    return base.append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  public static Component leadershipTransferOutgoingMessage(String newLeaderName) {
+    return Component.text("✅ Вы передали лидерство игроку ", NamedTextColor.GREEN)
+        .append(Component.text(newLeaderName, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.GREEN));
+  }
+
+  public static Component leadershipTransferIncomingMessage(String teamName) {
+    return Component.text("ℹ️ Вы стали лидером команды ", NamedTextColor.YELLOW)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  public static Component leadershipTransferBroadcastMessage(String newLeaderName) {
+    return Component.text("ℹ️ Новый лидер команды — ", NamedTextColor.YELLOW)
+        .append(Component.text(newLeaderName, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  public static Component memberKickedLeaderMessage(String targetName) {
+    return Component.text("✅ Игрок ", NamedTextColor.GREEN)
+        .append(Component.text(targetName, NamedTextColor.WHITE))
+        .append(Component.text(" исключён из команды.", NamedTextColor.GREEN));
+  }
+
+  public static Component memberKickedTargetMessage(String teamName, String leaderName) {
+    Component base =
+        Component.text("❌ Вас исключили из команды ", NamedTextColor.RED)
+            .append(Component.text(teamName, NamedTextColor.WHITE));
+    if (leaderName != null && !leaderName.isBlank()) {
+      base =
+          base.append(Component.text(" лидером ", NamedTextColor.RED))
+              .append(Component.text(leaderName, NamedTextColor.WHITE));
+    }
+    return base.append(Component.text(".", NamedTextColor.RED));
+  }
+
+  public static Component memberKickedBroadcastMessage(String targetName) {
+    return Component.text("ℹ️ Игрок ", NamedTextColor.YELLOW)
+        .append(Component.text(targetName, NamedTextColor.WHITE))
+        .append(Component.text(" был исключён из команды.", NamedTextColor.YELLOW));
+  }
+
+  public static Component teamPrefixUpdatedLeaderMessage(String prefix) {
+    return Component.text("✅ Префикс команды обновлён", NamedTextColor.GREEN)
+        .append(Component.text(prefixDisplay(prefix), NamedTextColor.WHITE));
+  }
+
+  public static Component teamPrefixUpdatedMemberMessage(String prefix) {
+    return Component.text("ℹ️ Префикс команды обновлён", NamedTextColor.YELLOW)
+        .append(Component.text(prefixDisplay(prefix), NamedTextColor.WHITE));
+  }
+
+  public static Component teamColorUpdatedLeaderMessage(String color) {
+    return Component.text("✅ Цвет команды обновлён", NamedTextColor.GREEN)
+        .append(Component.text(valueDisplay(color), NamedTextColor.WHITE));
+  }
+
+  public static Component teamColorUpdatedMemberMessage(String color) {
+    return Component.text("ℹ️ Цвет команды обновлён", NamedTextColor.YELLOW)
+        .append(Component.text(valueDisplay(color), NamedTextColor.WHITE));
+  }
+
+  private static String prefixDisplay(String prefix) {
+    if (prefix == null || prefix.isEmpty()) {
+      return " (пустой)";
+    }
+    return " — \"" + prefix + "\"";
+  }
+
+  private static String valueDisplay(String value) {
+    if (value == null || value.isEmpty()) {
+      return " (пустое значение)";
+    }
+    return " — \"" + value + "\"";
+  }
 }

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -6,10 +6,12 @@ import static org.mockito.Mockito.*;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import java.util.HashSet;
 import java.util.Set;
+import net.kyori.adventure.text.Component;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.example.MockBukkitTestBase;
 import org.example.config.PluginConfig;
 import org.example.model.Team;
+import org.example.util.TeamMessageUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -123,6 +125,216 @@ class MembershipServiceTest extends MockBukkitTestBase {
     assertTrue(
         scheduler.leaderTransfers.contains("Alpha"),
         "Планировщик должен быть уведомлён о смене лидера");
+  }
+
+  @Test
+  void disbandTeamSendsNotifications() {
+    PlayerMock leader = server.addPlayer("LeaderDisband");
+    PlayerMock member = server.addPlayer("MemberDisband");
+    membership.createTeam("Omega", "O", "red", leader);
+    membership.addPlayerToTeam("Omega", member);
+    drainMessages(leader);
+    drainMessages(member);
+
+    membership.disbandTeam("Omega", leader);
+
+    Component leaderMessage = leader.nextComponentMessage();
+    Component memberMessage = member.nextComponentMessage();
+    assertEquals(
+        TeamMessageUtils.teamDisbandedLeaderMessage("Omega"),
+        leaderMessage,
+        "Лидер должен получить подтверждение о роспуске");
+    assertEquals(
+        TeamMessageUtils.teamDisbandedMemberMessage("Omega", leader.getName()),
+        memberMessage,
+        "Участники должны быть уведомлены о роспуске");
+  }
+
+  @Test
+  void disbandTeamDoesNotNotifyNonLeader() {
+    PlayerMock leader = server.addPlayer("LeaderDisbandFail");
+    PlayerMock member = server.addPlayer("MemberDisbandFail");
+    membership.createTeam("Sigma", "S", "red", leader);
+    membership.addPlayerToTeam("Sigma", member);
+    drainMessages(leader);
+    drainMessages(member);
+
+    membership.disbandTeam("Sigma", member);
+
+    assertNull(
+        member.nextComponentMessage(),
+        "Игрок не должен получать сообщение при неудачной попытке роспуска");
+  }
+
+  @Test
+  void transferLeadershipSendsNotifications() {
+    PlayerMock leader = server.addPlayer("LeaderTransfer");
+    PlayerMock newLeader = server.addPlayer("NewLeaderTransfer");
+    PlayerMock teammate = server.addPlayer("TeammateTransfer");
+    membership.createTeam("Zeta", "Z", "red", leader);
+    membership.addPlayerToTeam("Zeta", newLeader);
+    membership.addPlayerToTeam("Zeta", teammate);
+    drainMessages(leader);
+    drainMessages(newLeader);
+    drainMessages(teammate);
+
+    membership.transferLeadership("Zeta", leader, newLeader);
+
+    assertEquals(
+        TeamMessageUtils.leadershipTransferOutgoingMessage(newLeader.getName()),
+        leader.nextComponentMessage(),
+        "Исходящий лидер получает подтверждение");
+    assertEquals(
+        TeamMessageUtils.leadershipTransferIncomingMessage("Zeta"),
+        newLeader.nextComponentMessage(),
+        "Новый лидер получает уведомление");
+    assertEquals(
+        TeamMessageUtils.leadershipTransferBroadcastMessage(newLeader.getName()),
+        teammate.nextComponentMessage(),
+        "Остальные участники получают уведомление о смене лидера");
+  }
+
+  @Test
+  void transferLeadershipDoesNotNotifyWhenInvalid() {
+    PlayerMock leader = server.addPlayer("LeaderTransferFail");
+    PlayerMock teammate = server.addPlayer("TeammateTransferFail");
+    membership.createTeam("Eta", "E", "red", leader);
+    membership.addPlayerToTeam("Eta", teammate);
+    drainMessages(leader);
+    drainMessages(teammate);
+
+    membership.transferLeadership("Eta", teammate, leader);
+
+    assertNull(
+        teammate.nextComponentMessage(),
+        "Игрок без прав не должен получать сообщение о передаче лидерства");
+  }
+
+  @Test
+  void kickPlayerFromTeamSendsNotifications() {
+    PlayerMock leader = server.addPlayer("LeaderKick");
+    PlayerMock target = server.addPlayer("TargetKick");
+    PlayerMock teammate = server.addPlayer("TeammateKick");
+    membership.createTeam("Theta", "T", "red", leader);
+    membership.addPlayerToTeam("Theta", target);
+    membership.addPlayerToTeam("Theta", teammate);
+    drainMessages(leader);
+    drainMessages(target);
+    drainMessages(teammate);
+
+    membership.kickPlayerFromTeam("Theta", leader, target.getName());
+
+    assertEquals(
+        TeamMessageUtils.memberKickedLeaderMessage(target.getName()),
+        leader.nextComponentMessage(),
+        "Лидер получает подтверждение об исключении");
+    assertEquals(
+        TeamMessageUtils.memberKickedTargetMessage("Theta", leader.getName()),
+        target.nextComponentMessage(),
+        "Исключённый игрок получает уведомление");
+    assertEquals(
+        TeamMessageUtils.memberKickedBroadcastMessage(target.getName()),
+        teammate.nextComponentMessage(),
+        "Остальные участники уведомляются об исключении");
+  }
+
+  @Test
+  void kickPlayerFromTeamDoesNotNotifyWhenTargetMissing() {
+    PlayerMock leader = server.addPlayer("LeaderKickFail");
+    membership.createTeam("Iota", "I", "red", leader);
+    drainMessages(leader);
+
+    membership.kickPlayerFromTeam("Iota", leader, "Ghost");
+
+    assertNull(
+        leader.nextComponentMessage(),
+        "Сообщение не должно отправляться при отсутствии цели");
+  }
+
+  @Test
+  void setTeamPrefixSendsNotifications() {
+    PlayerMock leader = server.addPlayer("LeaderPrefix");
+    PlayerMock member = server.addPlayer("MemberPrefix");
+    membership.createTeam("Kappa", "K", "red", leader);
+    membership.addPlayerToTeam("Kappa", member);
+    drainMessages(leader);
+    drainMessages(member);
+
+    membership.setTeamPrefix("Kappa", "KP", leader);
+
+    assertEquals(
+        TeamMessageUtils.teamPrefixUpdatedLeaderMessage("KP"),
+        leader.nextComponentMessage(),
+        "Лидер получает сообщение об обновлении префикса");
+    assertEquals(
+        TeamMessageUtils.teamPrefixUpdatedMemberMessage("KP"),
+        member.nextComponentMessage(),
+        "Участники получают уведомление об обновлении префикса");
+  }
+
+  @Test
+  void setTeamPrefixDoesNotNotifyNonLeader() {
+    PlayerMock leader = server.addPlayer("LeaderPrefixFail");
+    PlayerMock member = server.addPlayer("MemberPrefixFail");
+    membership.createTeam("Lambda", "L", "red", leader);
+    membership.addPlayerToTeam("Lambda", member);
+    drainMessages(leader);
+    drainMessages(member);
+
+    membership.setTeamPrefix("Lambda", "LP", member);
+
+    assertNull(
+        member.nextComponentMessage(),
+        "Игрок без прав не должен получать сообщение об изменении префикса");
+  }
+
+  @Test
+  void setTeamColorSendsNotifications() {
+    PlayerMock leader = server.addPlayer("LeaderColor");
+    PlayerMock member = server.addPlayer("MemberColor");
+    String teamName = "MuTeam";
+    membership.createTeam(teamName, "M", "red", leader);
+    membership.addPlayerToTeam(teamName, member);
+    drainMessages(leader);
+    drainMessages(member);
+
+    membership.setTeamColor(teamName, "blue", leader);
+
+    Component leaderMessage = leader.nextComponentMessage();
+    Component memberMessage = member.nextComponentMessage();
+
+    assertEquals(
+        TeamMessageUtils.teamColorUpdatedLeaderMessage("blue"),
+        leaderMessage,
+        "Лидер получает сообщение об изменении цвета");
+    assertEquals(
+        TeamMessageUtils.teamColorUpdatedMemberMessage("blue"),
+        memberMessage,
+        "Участники получают уведомление об изменении цвета");
+  }
+
+  @Test
+  void setTeamColorDoesNotNotifyNonLeader() {
+    PlayerMock leader = server.addPlayer("LeaderColorFail");
+    PlayerMock member = server.addPlayer("MemberColorFail");
+    String teamName = "NuTeam";
+    membership.createTeam(teamName, "N", "red", leader);
+    membership.addPlayerToTeam(teamName, member);
+    drainMessages(leader);
+    drainMessages(member);
+
+    membership.setTeamColor(teamName, "blue", member);
+
+    assertNull(
+        member.nextComponentMessage(),
+        "Игрок без прав не получает сообщение об изменении цвета");
+  }
+
+  private void drainMessages(PlayerMock player) {
+    Component message;
+    do {
+      message = player.nextComponentMessage();
+    } while (message != null);
   }
 
   private static class TestDeadlineScheduler extends DeadlineScheduler {


### PR DESCRIPTION
## Summary
- send confirmation and broadcast messages when teams are disbanded, leadership transfers, members kicked, or prefixes/colors updated
- add reusable TeamMessageUtils components for the new success notifications
- add MockBukkit-based MembershipService tests covering success and guard-path messaging behaviour

## Testing
- ./gradlew clean test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d269fd8e88832ea46ae4cdbc2d6e28