### PR TITLE
Refactor help command layout and add tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     compileOnly("org.jetbrains:annotations:24.0.1")
 
     testImplementation("org.junit.jupiter:junit-jupiter:5.10.1")
+    testImplementation("net.kyori:adventure-api:4.19.0")
     testImplementation("com.github.seeseemelk:MockBukkit-v1.21:3.133.2")
     testImplementation("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
     testImplementation("org.spigotmc:spigot-api:1.21.1-R0.1-SNAPSHOT")

--- a/src/main/java/org/example/command/sub/HelpSubCommand.java
+++ b/src/main/java/org/example/command/sub/HelpSubCommand.java
@@ -1,7 +1,9 @@
 package org.example.command.sub;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.JoinConfiguration;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,22 +12,41 @@ public class HelpSubCommand implements SubCommand {
 
   @Override
   public boolean execute(@NotNull Player player, @NotNull String[] args) {
-    player.sendMessage(Component.text(""));
-    player.sendMessage(Component.text("ℹ Использование /team:", NamedTextColor.AQUA));
-    player.sendMessage(Component.text(""));
-    player.sendMessage(
-        Component.text(
-            "/team create <название> <префикс> <цвет> — создать команду (цвет: RED, BLUE, GREEN и т.д.)",
-            NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text("/team join <название> — вступить в команду", NamedTextColor.AQUA));
-    player.sendMessage(Component.text("/team leave — покинуть команду", NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text("/team list — показать список всех команд", NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text("/team members — показать участников вашей команды", NamedTextColor.AQUA));
-    player.sendMessage(Component.text("/team help — показать эту справку", NamedTextColor.AQUA));
-    player.sendMessage(Component.text(""));
+    Component helpMessage =
+        joinLines(
+            heading("ℹ Использование /team:"),
+            Component.empty(),
+            sectionHeading("Основные команды"),
+            bullet(
+                "/team create <название> <префикс> <цвет>",
+                "создать команду (цвет: RED, BLUE, GREEN и т.д.)"),
+            bullet("/team join <название>", "вступить в команду"),
+            bullet("/team leave", "покинуть команду"),
+            bullet("/team help", "показать эту справку"),
+            Component.empty(),
+            sectionHeading("Управление командой"),
+            bullet("/team list", "показать список всех команд"),
+            bullet("/team members", "показать участников вашей команды"));
+
+    player.sendMessage(helpMessage);
     return true;
+  }
+
+  private static Component heading(String text) {
+    return Component.text(text, NamedTextColor.AQUA).decorate(TextDecoration.BOLD);
+  }
+
+  private static Component sectionHeading(String text) {
+    return Component.text(text, NamedTextColor.AQUA).decorate(TextDecoration.BOLD);
+  }
+
+  private static Component bullet(String command, String description) {
+    return Component.text("• ", NamedTextColor.DARK_GRAY)
+        .append(Component.text(command, NamedTextColor.GOLD))
+        .append(Component.text(" — " + description, NamedTextColor.WHITE));
+  }
+
+  private static Component joinLines(Component... components) {
+    return Component.join(JoinConfiguration.newlines(), components);
   }
 }

--- a/src/test/java/org/example/command/sub/HelpSubCommandTest.java
+++ b/src/test/java/org/example/command/sub/HelpSubCommandTest.java
@@ -1,0 +1,50 @@
+package org.example.command.sub;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import be.seeseemelk.mockbukkit.MockBukkit;
+import be.seeseemelk.mockbukkit.ServerMock;
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HelpSubCommandTest {
+
+  private ServerMock server;
+  private PlayerMock player;
+  private HelpSubCommand command;
+
+  @BeforeEach
+  void setUp() {
+    server = MockBukkit.mock();
+    player = server.addPlayer();
+    command = new HelpSubCommand();
+  }
+
+  @AfterEach
+  void tearDown() {
+    MockBukkit.unmock();
+  }
+
+  @Test
+  void executeSendsFormattedHelpMessage() {
+    boolean result = command.execute(player, new String[0]);
+
+    assertTrue(result, "Help command should return true");
+
+    Component message = player.nextComponentMessage();
+    assertNotNull(message, "Help message should be sent to the player");
+
+    String plainText = PlainTextComponentSerializer.plainText().serialize(message);
+
+    assertTrue(
+        plainText.contains("/team create"),
+        "Help text should still mention the /team create command");
+    assertTrue(
+        plainText.contains("/team help"), "Help text should still mention the /team help command");
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the /team help subcommand to build a single formatted component with headings, bullets, and colour accents
- add an Adventure API test dependency and a regression test to confirm key help strings remain present

## Testing
- `./gradlew --no-daemon test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d279357304832ea164867eb6bb71e3