### PR TITLE
Fix chat prefix rendering and strengthen team admin feedback

### DIFF
--- a/src/main/java/org/example/command/TeamAdminCommand.java
+++ b/src/main/java/org/example/command/TeamAdminCommand.java
@@ -3,11 +3,14 @@ package org.example.command;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
@@ -67,6 +70,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       case "rename" -> handleRenameCommand(player, args);
       case "setprefix" -> handleSetPrefixCommand(player, args);
       case "setcolor" -> handleSetColorCommand(player, args);
+      case "getplinfo" -> handleGetPlayerInfoCommand(player, args);
       case "help" -> {
         sendHelp(player);
         yield true;
@@ -74,7 +78,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       default -> {
         player.sendMessage(
             Component.text(
-                "❌ Неизвестная подкоманда! Используйте: /teamadmin <transfer | kick | disband | rename | setprefix | setcolor | help>",
+                "❌ Неизвестная подкоманда! Используйте: /teamadmin <transfer | kick | disband | rename | setprefix | setcolor | getplinfo | help>",
                 NamedTextColor.RED));
         yield true;
       }
@@ -88,11 +92,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       return true;
     }
     String teamName = teamManager.getPlayerTeam(player);
-    if (teamName == null) {
-      TeamMessageUtils.sendTeamMessage(
-          player,
-          Component.text(
-              "❌ Вы не состоите в команде и не можете передать лидерство!", NamedTextColor.RED));
+    if (!ensurePlayerIsLeader(player, teamName)) {
       return true;
     }
     String newLeaderName = args[1].trim();
@@ -116,11 +116,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       return true;
     }
     String teamName = teamManager.getPlayerTeam(player);
-    if (teamName == null) {
-      TeamMessageUtils.sendTeamMessage(
-          player,
-          Component.text(
-              "❌ Вы не состоите в команде и не можете исключать игроков!", NamedTextColor.RED));
+    if (!ensurePlayerIsLeader(player, teamName)) {
       return true;
     }
     String targetName = args[1].trim();
@@ -135,11 +131,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
 
   private boolean handleDisbandCommand(Player player) {
     String teamName = teamManager.getPlayerTeam(player);
-    if (teamName == null) {
-      TeamMessageUtils.sendTeamMessage(
-          player,
-          Component.text(
-              "❌ Вы не состоите в команде и не можете распустить её!", NamedTextColor.RED));
+    if (!ensurePlayerIsLeader(player, teamName)) {
       return true;
     }
     teamManager.disbandTeam(teamName, player);
@@ -155,11 +147,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       return true;
     }
     String oldTeamName = teamManager.getPlayerTeam(player);
-    if (oldTeamName == null) {
-      TeamMessageUtils.sendTeamMessage(
-          player,
-          Component.text(
-              "❌ Вы не состоите в команде и не можете её переименовать!", NamedTextColor.RED));
+    if (!ensurePlayerIsLeader(player, oldTeamName)) {
       return true;
     }
     String newTeamName = args[1].trim();
@@ -179,11 +167,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       return true;
     }
     String teamName = teamManager.getPlayerTeam(player);
-    if (teamName == null) {
-      TeamMessageUtils.sendTeamMessage(
-          player,
-          Component.text(
-              "❌ Вы не состоите в команде и не можете изменить её префикс!", NamedTextColor.RED));
+    if (!ensurePlayerIsLeader(player, teamName)) {
       return true;
     }
     String newPrefix = args[1].trim();
@@ -199,11 +183,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       return true;
     }
     String teamName = teamManager.getPlayerTeam(player);
-    if (teamName == null) {
-      TeamMessageUtils.sendTeamMessage(
-          player,
-          Component.text(
-              "❌ Вы не состоите в команде и не можете изменить её цвет!", NamedTextColor.RED));
+    if (!ensurePlayerIsLeader(player, teamName)) {
       return true;
     }
     String newColor = args[1].trim();
@@ -211,44 +191,121 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
     return true;
   }
 
+  private boolean handleGetPlayerInfoCommand(Player player, String[] args) {
+    if (args.length < 2) {
+      TeamMessageUtils.sendTeamMessage(
+          player,
+          Component.text("❌ Использование: /teamadmin getplinfo <ник>", NamedTextColor.RED));
+      return true;
+    }
+
+    String inputName = args[1].trim();
+    if (inputName.isEmpty()) {
+      TeamMessageUtils.sendTeamMessage(
+          player, Component.text("❌ Имя игрока не может быть пустым!", NamedTextColor.RED));
+      return true;
+    }
+
+    var server = teamManager.getPlugin().getServer();
+    Player onlineTarget = server.getPlayerExact(inputName);
+    boolean online = onlineTarget != null && onlineTarget.isOnline();
+    OfflinePlayer offlineTarget =
+        onlineTarget != null ? onlineTarget : server.getOfflinePlayer(inputName);
+
+    if (!online
+        && (offlineTarget.getName() == null
+            || (!offlineTarget.hasPlayedBefore() && !offlineTarget.isOnline()))) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.playerNotFoundMessage(inputName));
+      return true;
+    }
+
+    UUID targetId = onlineTarget != null ? onlineTarget.getUniqueId() : offlineTarget.getUniqueId();
+    String resolvedName =
+        onlineTarget != null
+            ? onlineTarget.getName()
+            : offlineTarget.getName() != null ? offlineTarget.getName() : inputName;
+
+    String teamName = null;
+    UUID leaderId = null;
+    for (String existingTeam : teamManager.getTeamNames()) {
+      List<UUID> members = teamManager.getTeamMembers(existingTeam);
+      if (members.contains(targetId)) {
+        teamName = existingTeam;
+        leaderId = teamManager.getTeamLeaderId(existingTeam);
+        break;
+      }
+    }
+
+    boolean isLeader = teamName != null && leaderId != null && leaderId.equals(targetId);
+
+    Component message =
+        Component.text()
+            .append(Component.text("ℹ Информация об игроке ", NamedTextColor.AQUA))
+            .append(Component.text(resolvedName, NamedTextColor.GOLD))
+            .append(Component.text(":", NamedTextColor.AQUA))
+            .append(Component.newline())
+            .append(Component.text("• UUID: ", NamedTextColor.GRAY))
+            .append(Component.text(targetId.toString(), NamedTextColor.WHITE))
+            .append(Component.newline())
+            .append(Component.text("• Статус: ", NamedTextColor.GRAY))
+            .append(
+                Component.text(
+                    online ? "В сети" : "Оффлайн",
+                    online ? NamedTextColor.GREEN : NamedTextColor.RED))
+            .append(Component.newline())
+            .append(Component.text("• Команда: ", NamedTextColor.GRAY))
+            .append(
+                Component.text(
+                    teamName != null ? teamName : "Не состоит",
+                    teamName != null ? NamedTextColor.GOLD : NamedTextColor.GRAY))
+            .append(teamName != null ? Component.newline() : Component.empty())
+            .append(
+                teamName != null
+                    ? Component.text("• Роль: ", NamedTextColor.GRAY)
+                        .append(
+                            Component.text(
+                                isLeader ? "Лидер" : "Участник",
+                                isLeader ? NamedTextColor.YELLOW : NamedTextColor.WHITE))
+                    : Component.empty())
+            .build();
+
+    player.sendMessage(message);
+    return true;
+  }
+
   private void sendUsage(Player player) {
     player.sendMessage(
         Component.text(
-            "❌ Использование: /teamadmin <transfer | kick | disband | rename | setprefix | setcolor | help> [аргументы]",
+            "❌ Использование: /teamadmin <transfer | kick | disband | rename | setprefix | setcolor | getplinfo | help> [аргументы]",
             NamedTextColor.RED));
   }
 
   private void sendHelp(Player player) {
-    player.sendMessage(Component.text("")); // Пустая строка перед списком
-    player.sendMessage(Component.text("ℹ Использование /teamadmin:", NamedTextColor.AQUA));
-    player.sendMessage(Component.text(""));
-    player.sendMessage(
-        Component.text(
-            "/teamadmin transfer <ник> — передать лидерство другому игроку в команде",
-            NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text(
-            "/teamadmin kick <ник> — выгнать участника из команды (требуется быть лидером)",
-            NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text(
-            "/teamadmin disband — распустить команду (требуется быть лидером)",
-            NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text(
-            "/teamadmin rename <новое_название> — переименовать команду (требуется быть лидером)",
-            NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text(
-            "/teamadmin setprefix <новый_префикс> — изменить префикс команды (требуется быть лидером)",
-            NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text(
-            "/teamadmin setcolor <новый_цвет> — изменить цвет команды (требуется быть лидером, цвет: RED, BLUE, GREEN и т.д.)",
-            NamedTextColor.AQUA));
-    player.sendMessage(
-        Component.text("/teamadmin help — показать эту справку", NamedTextColor.AQUA));
-    player.sendMessage(Component.text("")); // Пустая строка после списка
+    Component helpMessage =
+        Component.join(
+            net.kyori.adventure.text.JoinConfiguration.newlines(),
+            Component.empty(),
+            Component.text("ℹ Использование /teamadmin:", NamedTextColor.AQUA)
+                .decorate(net.kyori.adventure.text.format.TextDecoration.BOLD),
+            Component.empty(),
+            adminBullet("/teamadmin transfer <ник>", "передать лидерство другому игроку в команде"),
+            adminBullet(
+                "/teamadmin kick <ник>", "исключить участника команды (требуется быть лидером)"),
+            adminBullet("/teamadmin disband", "распустить команду (требуется быть лидером)"),
+            adminBullet(
+                "/teamadmin rename <новое_название>",
+                "переименовать команду (требуется быть лидером)"),
+            adminBullet(
+                "/teamadmin setprefix <новый_префикс>",
+                "изменить префикс команды (требуется быть лидером)"),
+            adminBullet(
+                "/teamadmin setcolor <новый_цвет>",
+                "изменить цвет команды (цвет: RED, BLUE, GREEN и т.д.)"),
+            adminBullet("/teamadmin getplinfo <ник>", "показать командную информацию об игроке"),
+            adminBullet("/teamadmin help", "показать эту справку"),
+            Component.empty());
+
+    player.sendMessage(helpMessage);
   }
 
   @Override
@@ -260,7 +317,15 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
     List<String> suggestions = new ArrayList<>();
     if (args.length == 1) {
       suggestions.addAll(
-          Arrays.asList("transfer", "kick", "disband", "rename", "setprefix", "setcolor", "help"));
+          Arrays.asList(
+              "transfer",
+              "kick",
+              "disband",
+              "rename",
+              "setprefix",
+              "setcolor",
+              "getplinfo",
+              "help"));
     } else if (args.length == 2) {
       if (sender instanceof Player player) {
         if (args[0].equalsIgnoreCase("transfer") || args[0].equalsIgnoreCase("kick")) {
@@ -293,6 +358,27 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
               suggestions.add(key.toUpperCase(Locale.ROOT));
             }
           }
+        } else if (args[0].equalsIgnoreCase("getplinfo")) {
+          String lowerInput = args[1].toLowerCase(Locale.ROOT);
+          Set<String> seen = new HashSet<>();
+          for (Player online : teamManager.getPlugin().getServer().getOnlinePlayers()) {
+            String name = online.getName();
+            if (name != null
+                && name.toLowerCase(Locale.ROOT).startsWith(lowerInput)
+                && seen.add(name.toLowerCase(Locale.ROOT))) {
+              suggestions.add(name);
+            }
+          }
+          for (String teamName : teamManager.getTeamNames()) {
+            for (UUID memberId : teamManager.getTeamMembers(teamName)) {
+              String memberName = resolveName(memberId);
+              if (!memberName.isEmpty()
+                  && memberName.toLowerCase(Locale.ROOT).startsWith(lowerInput)
+                  && seen.add(memberName.toLowerCase(Locale.ROOT))) {
+                suggestions.add(memberName);
+              }
+            }
+          }
         }
       }
     }
@@ -308,5 +394,31 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
     }
     String name = teamManager.getPlugin().getServer().getOfflinePlayer(playerId).getName();
     return name != null ? name : playerId.toString();
+  }
+
+  private boolean ensurePlayerIsLeader(Player player, String teamName) {
+    if (!ensurePlayerInTeam(player, teamName)) {
+      return false;
+    }
+    UUID leaderId = teamManager.getTeamLeaderId(teamName);
+    if (leaderId == null || !leaderId.equals(player.getUniqueId())) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.notTeamLeaderMessage());
+      return false;
+    }
+    return true;
+  }
+
+  private boolean ensurePlayerInTeam(Player player, String teamName) {
+    if (teamName == null) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.playerNotInAnyTeamMessage());
+      return false;
+    }
+    return true;
+  }
+
+  private Component adminBullet(String commandText, String description) {
+    return Component.text("• ", NamedTextColor.DARK_GRAY)
+        .append(Component.text(commandText, NamedTextColor.GOLD))
+        .append(Component.text(" — " + description, NamedTextColor.WHITE));
   }
 }

--- a/src/main/java/org/example/command/sub/MembersSubCommand.java
+++ b/src/main/java/org/example/command/sub/MembersSubCommand.java
@@ -7,6 +7,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.example.config.PluginConfig;
 import org.example.service.TeamService;
+import org.example.util.TeamMessageUtils;
 import org.example.util.TeamUtils;
 import org.jetbrains.annotations.NotNull;
 
@@ -25,7 +26,7 @@ public class MembersSubCommand implements SubCommand {
   public boolean execute(@NotNull Player player, @NotNull String[] args) {
     String playerTeam = teamService.getPlayerTeam(player);
     if (playerTeam == null) {
-      player.sendMessage(Component.text("❌ Вы не состоите в команде!", NamedTextColor.RED));
+      player.sendMessage(TeamMessageUtils.playerNotInAnyTeamMessage());
       return true;
     }
 

--- a/src/main/java/org/example/listener/TeamChatListener.java
+++ b/src/main/java/org/example/listener/TeamChatListener.java
@@ -37,6 +37,7 @@ public class TeamChatListener implements Listener {
         .forEach(
             player -> {
               cacheOriginalPlayerListName(player);
+              getOrStoreOriginalPlayerDisplayName(player, null);
               updatePlayerPrefix(player);
             });
   }
@@ -100,20 +101,22 @@ public class TeamChatListener implements Listener {
     event.renderer(
         (source, sourceDisplayName, message, viewer) -> {
           Component latestPrefixComponent = lastPlayerPrefixes.get(playerId);
-          Component sanitized =
-              stripKnownPrefix(sourceDisplayName, latestPrefixComponent, null);
-          Component displayBase =
-              sanitized != null
-                  ? sanitized
-                  : originalPlayerDisplayNames.getOrDefault(playerId, sourceDisplayName);
+          Component baseDisplay = originalPlayerDisplayNames.get(playerId);
+          if (baseDisplay == null) {
+            Component stripped = stripKnownPrefix(sourceDisplayName, latestPrefixComponent, null);
+            baseDisplay = stripped != null ? stripped : sourceDisplayName;
+            originalPlayerDisplayNames.put(playerId, baseDisplay);
+          }
+
           Component formattedMessage =
               forceWhiteChat ? message.color(NamedTextColor.WHITE) : message;
-          Component nameWithPrefix = displayBase;
+          Component nameComponent = baseDisplay;
           if (latestPrefixComponent != null) {
-            nameWithPrefix =
-                latestPrefixComponent.append(displayBase.colorIfAbsent(NamedTextColor.WHITE));
+            nameComponent =
+                latestPrefixComponent.append(baseDisplay.colorIfAbsent(NamedTextColor.WHITE));
           }
-          return nameWithPrefix.append(Component.text(": "))
+          return nameComponent
+              .append(Component.text(": ", NamedTextColor.GRAY))
               .append(formattedMessage);
         });
   }

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -170,8 +170,7 @@ public class MembershipService {
     Player kickedPlayer = plugin.getServer().getPlayer(targetId);
     if (kickedPlayer != null) {
       TeamMessageUtils.sendTeamMessage(
-          kickedPlayer,
-          TeamMessageUtils.memberKickedTargetMessage(team.getName(), leaderName));
+          kickedPlayer, TeamMessageUtils.memberKickedTargetMessage(team.getName(), leaderName));
     }
     sendMessageToOnlinePlayers(
         team.getMembers(),
@@ -305,9 +304,7 @@ public class MembershipService {
   }
 
   private void sendMessageToOnlinePlayers(
-      @NotNull Collection<UUID> recipients,
-      @NotNull Component message,
-      UUID... excludedPlayers) {
+      @NotNull Collection<UUID> recipients, @NotNull Component message, UUID... excludedPlayers) {
     Set<UUID> excluded = Collections.emptySet();
     if (excludedPlayers != null && excludedPlayers.length > 0) {
       excluded = new HashSet<>(Arrays.asList(excludedPlayers));

--- a/src/main/java/org/example/util/TeamMessageUtils.java
+++ b/src/main/java/org/example/util/TeamMessageUtils.java
@@ -46,6 +46,36 @@ public class TeamMessageUtils {
   }
 
   /**
+   * Формирует сообщение о том, что игрок не состоит ни в одной команде.
+   *
+   * @return сообщение об ошибке
+   */
+  public static Component playerNotInAnyTeamMessage() {
+    return Component.text("❌ Вы не состоите в команде!", NamedTextColor.RED);
+  }
+
+  /**
+   * Формирует сообщение о том, что действие доступно только лидеру команды.
+   *
+   * @return сообщение об ошибке
+   */
+  public static Component notTeamLeaderMessage() {
+    return Component.text("❌ Это действие доступно только лидеру команды!", NamedTextColor.RED);
+  }
+
+  /**
+   * Формирует сообщение об ошибке, если запрошенный игрок не найден.
+   *
+   * @param playerName имя игрока
+   * @return сообщение об ошибке
+   */
+  public static Component playerNotFoundMessage(String playerName) {
+    return Component.text("❌ Игрок ", NamedTextColor.RED)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" не найден!", NamedTextColor.RED));
+  }
+
+  /**
    * Формирует сообщение об ошибке, если игрок уже состоит в команде.
    *
    * @param teamName Название команды

--- a/src/test/java/org/example/command/TeamAdminCommandTest.java
+++ b/src/test/java/org/example/command/TeamAdminCommandTest.java
@@ -1,0 +1,96 @@
+package org.example.command;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.command.CommandMap;
+import org.example.MockBukkitTestBase;
+import org.example.service.TeamService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class TeamAdminCommandTest extends MockBukkitTestBase {
+
+  private TeamService teamService;
+
+  @BeforeEach
+  void setUp() {
+    teamService = plugin.getTeamManager();
+  }
+
+  @Test
+  void getPlayerInfoDisplaysOnlineLeaderDetails() {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock inspector = server.addPlayer("Inspector");
+    inspector.addAttachment(plugin, "mypurpurplugin.teamadmin", true);
+    drainMessages(inspector);
+
+    PlayerMock leader = server.addPlayer("LeaderInfo");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    drainMessages(leader);
+
+    teamService.createTeam("InfoTeam", "IT", "WHITE", leader);
+    drainMessages(leader);
+
+    assertTrue(commandMap.dispatch(inspector, "teamadmin getplinfo LeaderInfo"));
+
+    Component response = inspector.nextComponentMessage();
+    assertNotNull(response, "Админ должен получить сообщение с данными игрока");
+    String plain = PlainTextComponentSerializer.plainText().serialize(response);
+
+    assertTrue(plain.contains("LeaderInfo"), "Сообщение содержит имя игрока");
+    assertTrue(plain.contains("В сети"), "Должен отображаться статус 'В сети'");
+    assertTrue(plain.contains("InfoTeam"), "Должно отображаться название команды");
+    assertTrue(plain.contains("Лидер"), "Роль лидера должна быть указана");
+    assertTrue(
+        plain.contains(leader.getUniqueId().toString()), "UUID игрока должен присутствовать");
+  }
+
+  @Test
+  void getPlayerInfoDisplaysOfflineMemberDetails() {
+    CommandMap commandMap = server.getCommandMap();
+
+    PlayerMock inspector = server.addPlayer("Moderator");
+    inspector.addAttachment(plugin, "mypurpurplugin.teamadmin", true);
+    drainMessages(inspector);
+
+    PlayerMock leader = server.addPlayer("OfflineLeader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    drainMessages(leader);
+
+    teamService.createTeam("OfflineTeam", "OT", "WHITE", leader);
+    drainMessages(leader);
+
+    PlayerMock member = server.addPlayer("OfflineMember");
+    member.addAttachment(plugin, "mypurpurplugin.team", true);
+    drainMessages(member);
+
+    teamService.addPlayerToTeam("OfflineTeam", member);
+    drainMessages(member);
+
+    member.disconnect();
+
+    assertTrue(commandMap.dispatch(inspector, "teamadmin getplinfo OfflineMember"));
+
+    Component response = inspector.nextComponentMessage();
+    assertNotNull(response, "Админ должен получить сообщение с данными игрока");
+    String plain = PlainTextComponentSerializer.plainText().serialize(response);
+
+    assertTrue(plain.contains("OfflineMember"), "Имя оффлайн игрока отображается");
+    assertTrue(plain.contains("Оффлайн"), "Должен отображаться статус 'Оффлайн'");
+    assertTrue(plain.contains("OfflineTeam"), "Команда оффлайн игрока указана");
+    assertTrue(plain.contains("Участник"), "Роль участника должна быть указана");
+    assertTrue(
+        plain.contains(member.getUniqueId().toString()),
+        "UUID оффлайн игрока должен присутствовать");
+  }
+
+  private void drainMessages(PlayerMock player) {
+    while (player.nextComponentMessage() != null) {
+      // discard
+    }
+  }
+}

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -84,14 +84,12 @@ class TeamChatListenerTest extends MockBukkitTestBase {
     server.getPluginManager().callEvent(event);
 
     Component rendered =
-        event
-            .renderer()
-            .render(player, player.displayName(), event.message(), Audience.empty());
+        event.renderer().render(player, player.displayName(), event.message(), Audience.empty());
 
     Component expected =
         prefixComponent
             .append(Component.text(player.getName(), NamedTextColor.WHITE))
-            .append(Component.text(": "))
+            .append(Component.text(": ", NamedTextColor.GRAY))
             .append(Component.text("Привет", NamedTextColor.WHITE));
 
     assertEquals(expected, rendered);
@@ -120,12 +118,13 @@ class TeamChatListenerTest extends MockBukkitTestBase {
     server.getPluginManager().callEvent(event);
 
     Component rendered =
-        event
-            .renderer()
-            .render(player, player.displayName(), event.message(), Audience.empty());
+        event.renderer().render(player, player.displayName(), event.message(), Audience.empty());
 
     Component expected =
-        prefixComponent.append(originalName).append(Component.text(": ")).append(message);
+        prefixComponent
+            .append(originalName)
+            .append(Component.text(": ", NamedTextColor.GRAY))
+            .append(message);
 
     assertEquals(expected, rendered);
   }

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -247,8 +247,7 @@ class MembershipServiceTest extends MockBukkitTestBase {
     membership.kickPlayerFromTeam("Iota", leader, "Ghost");
 
     assertNull(
-        leader.nextComponentMessage(),
-        "Сообщение не должно отправляться при отсутствии цели");
+        leader.nextComponentMessage(), "Сообщение не должно отправляться при отсутствии цели");
   }
 
   @Test
@@ -326,8 +325,7 @@ class MembershipServiceTest extends MockBukkitTestBase {
     membership.setTeamColor(teamName, "blue", member);
 
     assertNull(
-        member.nextComponentMessage(),
-        "Игрок без прав не получает сообщение об изменении цвета");
+        member.nextComponentMessage(), "Игрок без прав не получает сообщение об изменении цвета");
   }
 
   private void drainMessages(PlayerMock player) {


### PR DESCRIPTION
## Summary
- ensure TeamChatListener caches original display names, renders the team prefix once, and keeps the player's name color separate in chat output
- add reusable TeamMessageUtils helpers plus stricter leader validation and redesigned help text for /teamadmin, including clearer player lookup errors
- reuse the shared "not in team" message in /team members and update unit tests to cover the refined formatting

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68b1c1c6e90c832ea88e325f4adc7328