### PR TITLE
Handle team rename conflicts and notifications

### DIFF
--- a/src/main/java/org/example/command/TeamAdminCommand.java
+++ b/src/main/java/org/example/command/TeamAdminCommand.java
@@ -18,6 +18,7 @@ import org.bukkit.entity.Player;
 import org.example.MyPurpurPlugin;
 import org.example.config.PluginConfig;
 import org.example.service.TeamService;
+import org.example.service.RenameResult;
 import org.example.util.TeamMessageUtils;
 import org.example.util.TeamUtils;
 import org.jetbrains.annotations.NotNull;
@@ -154,7 +155,30 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
     if (TeamUtils.isTeamNameLengthInvalid(newTeamName, pluginConfig, player)) {
       return true;
     }
-    teamManager.renameTeam(oldTeamName, newTeamName, player);
+    RenameResult result = teamManager.renameTeam(oldTeamName, newTeamName, player);
+    return handleRenameResult(player, oldTeamName, newTeamName, result);
+  }
+
+  private boolean handleRenameResult(
+      Player player, String oldTeamName, String newTeamName, RenameResult result) {
+    if (result == RenameResult.SUCCESS) {
+      TeamMessageUtils.sendTeamMessage(
+          player, TeamMessageUtils.teamRenamedLeaderMessage(oldTeamName, newTeamName));
+      return true;
+    }
+    if (result == RenameResult.NAME_TAKEN) {
+      TeamMessageUtils.sendTeamMessage(
+          player, TeamMessageUtils.teamAlreadyExistsMessage(newTeamName));
+      return true;
+    }
+    if (result == RenameResult.TEAM_NOT_FOUND) {
+      TeamMessageUtils.sendTeamMessage(
+          player, TeamMessageUtils.teamDoesNotExistMessage(oldTeamName));
+      return true;
+    }
+    if (result == RenameResult.NOT_LEADER) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.notTeamLeaderMessage());
+    }
     return true;
   }
 

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -227,13 +227,31 @@ public class MembershipService {
     }
   }
 
-  public void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader) {
+  public @NotNull RenameResult renameTeam(
+      String oldTeamName, String newTeamName, @NotNull Player leader) {
     Team team = storage.getTeamByName(oldTeamName);
     // Проверяем полномочия и уникальность нового имени.
-    if (team == null || !team.isLeader(leader.getUniqueId())) return;
+    if (team == null) {
+      return RenameResult.TEAM_NOT_FOUND;
+    }
+    if (!team.isLeader(leader.getUniqueId())) {
+      return RenameResult.NOT_LEADER;
+    }
     String normalizedNewName = newTeamName == null ? "" : newTeamName.trim();
-    if (storage.getTeamByName(normalizedNewName) != null) return;
+    Team existingTeam = storage.getTeamByName(normalizedNewName);
+    if (existingTeam != null && !existingTeam.getId().equals(team.getId())) {
+      return RenameResult.NAME_TAKEN;
+    }
+
+    String previousName = team.getName();
     storage.updateTeamName(team, normalizedNewName);
+    if (!Objects.equals(previousName, team.getName())) {
+      sendMessageToOnlinePlayers(
+          team.getMembers(),
+          TeamMessageUtils.teamRenamedMemberMessage(previousName, team.getName()),
+          leader.getUniqueId());
+    }
+    return RenameResult.SUCCESS;
   }
 
   public void setTeamPrefix(String teamName, String newPrefix, @NotNull Player leader) {

--- a/src/main/java/org/example/service/RenameResult.java
+++ b/src/main/java/org/example/service/RenameResult.java
@@ -1,0 +1,13 @@
+package org.example.service;
+
+/** Represents the outcome of a team rename operation. */
+public enum RenameResult {
+  /** Rename completed successfully. */
+  SUCCESS,
+  /** The requested name is already used by another team. */
+  NAME_TAKEN,
+  /** The target team could not be found. */
+  TEAM_NOT_FOUND,
+  /** The requesting player is not allowed to rename the team. */
+  NOT_LEADER;
+}

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -2,6 +2,7 @@ package org.example.service;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Supplier;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -32,12 +33,20 @@ public class TeamManager implements TeamService {
   }
 
   private void runWithTiming(String methodName, Runnable action) {
+    runWithTiming(methodName, () -> {
+      action.run();
+      return null;
+    });
+  }
+
+  private <T> T runWithTiming(String methodName, Supplier<T> action) {
     long start = System.nanoTime();
-    action.run();
+    T result = action.get();
     long durationMs = (System.nanoTime() - start) / 1_000_000;
     if (durationMs > EXECUTION_THRESHOLD_MS) {
       plugin.getLogger().warning(methodName + " took " + durationMs + " ms");
     }
+    return result;
   }
 
   @Override
@@ -75,8 +84,10 @@ public class TeamManager implements TeamService {
   }
 
   @Override
-  public void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader) {
-    runWithTiming("renameTeam", () -> membership.renameTeam(oldTeamName, newTeamName, leader));
+  public @NotNull RenameResult renameTeam(
+      String oldTeamName, String newTeamName, @NotNull Player leader) {
+    return runWithTiming(
+        "renameTeam", () -> membership.renameTeam(oldTeamName, newTeamName, leader));
   }
 
   @Override

--- a/src/main/java/org/example/service/TeamService.java
+++ b/src/main/java/org/example/service/TeamService.java
@@ -70,7 +70,8 @@ public interface TeamService {
    * @param newTeamName Новое название команды
    * @param leader Лидер команды, выполняющий переименование
    */
-  void renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader);
+  @NotNull
+  RenameResult renameTeam(String oldTeamName, String newTeamName, @NotNull Player leader);
 
   /**
    * Устанавливает новый префикс для команды.

--- a/src/main/java/org/example/util/TeamMessageUtils.java
+++ b/src/main/java/org/example/util/TeamMessageUtils.java
@@ -220,6 +220,22 @@ public class TeamMessageUtils {
         .append(Component.text(prefixDisplay(prefix), NamedTextColor.WHITE));
   }
 
+  public static Component teamRenamedLeaderMessage(String oldName, String newName) {
+    return Component.text("✅ Команда ", NamedTextColor.GREEN)
+        .append(nameComponent(oldName))
+        .append(Component.text(" переименована в ", NamedTextColor.GREEN))
+        .append(nameComponent(newName))
+        .append(Component.text(".", NamedTextColor.GREEN));
+  }
+
+  public static Component teamRenamedMemberMessage(String oldName, String newName) {
+    return Component.text("ℹ️ Команда ", NamedTextColor.YELLOW)
+        .append(nameComponent(oldName))
+        .append(Component.text(" переименована в ", NamedTextColor.YELLOW))
+        .append(nameComponent(newName))
+        .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
   public static Component teamColorUpdatedLeaderMessage(String color) {
     return Component.text("✅ Цвет команды обновлён", NamedTextColor.GREEN)
         .append(Component.text(valueDisplay(color), NamedTextColor.WHITE));
@@ -242,5 +258,10 @@ public class TeamMessageUtils {
       return " (пустое значение)";
     }
     return " — \"" + value + "\"";
+  }
+
+  private static Component nameComponent(String name) {
+    String value = (name == null || name.isEmpty()) ? "(без названия)" : name;
+    return Component.text(value, NamedTextColor.WHITE);
   }
 }

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -412,7 +412,7 @@ class TeamChatListenerTest extends MockBukkitTestBase {
     }
 
     @Override
-    public void renameTeam(
+    public org.example.service.RenameResult renameTeam(
         String oldTeamName, String newTeamName, org.bukkit.entity.Player leader) {
       throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
## Summary
- add a `RenameResult` outcome that propagates rename success or conflict details across the service layer
- update `MembershipService` and `TeamManager` to return the rename result and broadcast notifications to team members
- enhance the admin command to react to rename outcomes with success or "name taken" messaging using new helpers

## Testing
- ./gradlew test --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68f5bfed62f4832ebd7985139df3e767