### PR TITLE
Add membership removal notifications

### DIFF
--- a/src/main/java/org/example/service/MemberRemovalCause.java
+++ b/src/main/java/org/example/service/MemberRemovalCause.java
@@ -1,0 +1,9 @@
+package org.example.service;
+
+/** Reason for removing a player from a team. */
+public enum MemberRemovalCause {
+  /** Player left the team voluntarily. */
+  LEAVE,
+  /** Player was removed forcibly by another actor. */
+  KICK
+}

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -100,17 +100,45 @@ public class MembershipService {
   }
 
   public void removePlayerFromTeam(String teamName, @NotNull Player player) {
+    removePlayerFromTeam(teamName, player, MemberRemovalCause.LEAVE, null, player.getUniqueId());
+  }
+
+  public void removePlayerFromTeam(
+      String teamName,
+      @NotNull Player player,
+      @NotNull MemberRemovalCause cause,
+      @Nullable String initiatorName,
+      @Nullable UUID initiatorId) {
     Team team = storage.getTeamByName(teamName);
-    // Проводим проверки существования команды и членства игрока.
-    if (team == null) return;
-    UUID playerId = player.getUniqueId();
-    if (!team.hasMember(playerId) && !team.isLeader(playerId)) return;
-    // Удаляем игрока и очищаем обратные ссылки.
+    if (team == null) {
+      return;
+    }
+    removeMember(
+        team,
+        player.getUniqueId(),
+        player,
+        player.getName(),
+        cause,
+        initiatorName,
+        initiatorId);
+  }
+
+  private boolean removeMember(
+      @NotNull Team team,
+      @NotNull UUID playerId,
+      @Nullable Player onlinePlayer,
+      @Nullable String providedName,
+      @NotNull MemberRemovalCause cause,
+      @Nullable String initiatorName,
+      @Nullable UUID initiatorId) {
+    if (!team.hasMember(playerId) && !team.isLeader(playerId)) {
+      return false;
+    }
+    boolean wasLeader = team.isLeader(playerId);
     team.removeMember(playerId);
     storage.clearPlayerTeam(playerId);
     boolean removedTeam = false;
-    // Если ушедший игрок был лидером, либо закрываем команду, либо назначаем нового.
-    if (team.isLeader(playerId)) {
+    if (wasLeader) {
       if (team.getMembers().isEmpty()) {
         scheduler.cancelDeadline(team);
         storage.removeTeam(team);
@@ -123,17 +151,94 @@ public class MembershipService {
         scheduler.handleLeaderTransfer(team);
       }
     }
-    // Отмечаем изменившуюся команду и пересчитываем дедлайны.
     if (!removedTeam) {
       storage.markTeamDirty(team);
-    }
-    if (!removedTeam) {
       scheduler.evaluateTeam(team);
     }
-    notifyPrefixUpdate(player, null);
+    if (onlinePlayer != null) {
+      notifyPrefixUpdate(onlinePlayer, null);
+    } else {
+      notifyPrefixUpdate(playerId, null);
+    }
     if (!removedTeam) {
       updateTeamMembersPrefixes(team);
     }
+    sendRemovalMessages(
+        team,
+        playerId,
+        onlinePlayer,
+        resolvePlayerName(playerId, providedName),
+        cause,
+        initiatorName,
+        initiatorId,
+        wasLeader,
+        removedTeam);
+    return true;
+  }
+
+  private @NotNull String resolvePlayerName(
+      @NotNull UUID playerId, @Nullable String providedName) {
+    if (providedName != null && !providedName.isBlank()) {
+      return providedName;
+    }
+    OfflinePlayer offlinePlayer = plugin.getServer().getOfflinePlayer(playerId);
+    if (offlinePlayer != null) {
+      String name = offlinePlayer.getName();
+      if (name != null && !name.isBlank()) {
+        return name;
+      }
+    }
+    return playerId.toString();
+  }
+
+  private void sendRemovalMessages(
+      @NotNull Team team,
+      @NotNull UUID playerId,
+      @Nullable Player onlinePlayer,
+      @NotNull String playerName,
+      @NotNull MemberRemovalCause cause,
+      @Nullable String initiatorName,
+      @Nullable UUID initiatorId,
+      boolean wasLeader,
+      boolean removedTeam) {
+    if (cause == MemberRemovalCause.LEAVE) {
+      if (onlinePlayer != null) {
+        TeamMessageUtils.sendTeamMessage(
+            onlinePlayer, TeamMessageUtils.memberLeftSelfMessage(team.getName()));
+        if (removedTeam && wasLeader) {
+          TeamMessageUtils.sendTeamMessage(
+              onlinePlayer, TeamMessageUtils.teamDisbandedLeaderMessage(team.getName()));
+        }
+      }
+      if (!removedTeam) {
+        sendMessageToOnlinePlayers(
+            team.getMembers(),
+            TeamMessageUtils.memberLeftBroadcastMessage(playerName),
+            mergeExcluded(playerId, initiatorId));
+      }
+      return;
+    }
+
+    if (onlinePlayer != null) {
+      TeamMessageUtils.sendTeamMessage(
+          onlinePlayer, TeamMessageUtils.memberKickedTargetMessage(team.getName(), initiatorName));
+    }
+    if (!removedTeam) {
+      sendMessageToOnlinePlayers(
+          team.getMembers(),
+          TeamMessageUtils.memberKickedBroadcastMessage(playerName),
+          mergeExcluded(playerId, initiatorId));
+    } else if (onlinePlayer != null && wasLeader) {
+      TeamMessageUtils.sendTeamMessage(
+          onlinePlayer, TeamMessageUtils.teamDisbandedLeaderMessage(team.getName()));
+    }
+  }
+
+  private UUID[] mergeExcluded(@NotNull UUID playerId, @Nullable UUID initiatorId) {
+    if (initiatorId == null || initiatorId.equals(playerId)) {
+      return new UUID[] {playerId};
+    }
+    return new UUID[] {playerId, initiatorId};
   }
 
   public void kickPlayerFromTeam(
@@ -147,7 +252,7 @@ public class MembershipService {
       return;
     }
     if (team.isLeader(targetId)) {
-      removePlayerFromTeam(teamName, leader);
+      removePlayerFromTeam(teamName, leader, MemberRemovalCause.LEAVE, null, leader.getUniqueId());
       return;
     }
     // Удаляем участника и фиксируем изменения.
@@ -158,24 +263,21 @@ public class MembershipService {
     if (offlineTarget != null && offlineTarget.getName() != null) {
       actualTargetName = offlineTarget.getName();
     }
-    team.removeMember(targetId);
-    storage.clearPlayerTeam(targetId);
-    storage.markTeamDirty(team);
-    scheduler.evaluateTeam(team);
-    notifyPrefixUpdate(targetId, null);
-
-    updateTeamMembersPrefixes(team);
+    Player kickedPlayer = plugin.getServer().getPlayer(targetId);
+    boolean removed =
+        removeMember(
+            team,
+            targetId,
+            kickedPlayer,
+            actualTargetName,
+            MemberRemovalCause.KICK,
+            leaderName,
+            leader.getUniqueId());
+    if (!removed) {
+      return;
+    }
     TeamMessageUtils.sendTeamMessage(
         leader, TeamMessageUtils.memberKickedLeaderMessage(actualTargetName));
-    Player kickedPlayer = plugin.getServer().getPlayer(targetId);
-    if (kickedPlayer != null) {
-      TeamMessageUtils.sendTeamMessage(
-          kickedPlayer, TeamMessageUtils.memberKickedTargetMessage(team.getName(), leaderName));
-    }
-    sendMessageToOnlinePlayers(
-        team.getMembers(),
-        TeamMessageUtils.memberKickedBroadcastMessage(actualTargetName),
-        leader.getUniqueId());
   }
 
   public void transferLeadership(

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -9,6 +9,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.example.config.PluginConfig;
 import org.example.listener.TeamChatListener;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Facade over team related services. Delegates work to specialised classes. */
 public class TeamManager implements TeamService {
@@ -62,6 +63,18 @@ public class TeamManager implements TeamService {
   @Override
   public void removePlayerFromTeam(String teamName, @NotNull Player player) {
     runWithTiming("removePlayerFromTeam", () -> membership.removePlayerFromTeam(teamName, player));
+  }
+
+  @Override
+  public void removePlayerFromTeam(
+      String teamName,
+      @NotNull Player player,
+      @NotNull MemberRemovalCause cause,
+      @Nullable String initiatorName,
+      @Nullable UUID initiatorId) {
+    runWithTiming(
+        "removePlayerFromTeam",
+        () -> membership.removePlayerFromTeam(teamName, player, cause, initiatorName, initiatorId));
   }
 
   @Override

--- a/src/main/java/org/example/service/TeamService.java
+++ b/src/main/java/org/example/service/TeamService.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.example.config.PluginConfig;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Сервис для управления командами. */
 public interface TeamService {
@@ -35,7 +36,25 @@ public interface TeamService {
    * @param teamName Название команды
    * @param player Игрок, которого нужно удалить
    */
-  void removePlayerFromTeam(String teamName, @NotNull Player player);
+  default void removePlayerFromTeam(String teamName, @NotNull Player player) {
+    removePlayerFromTeam(teamName, player, MemberRemovalCause.LEAVE, null, null);
+  }
+
+  /**
+   * Удаляет игрока из команды с указанием причины.
+   *
+   * @param teamName Название команды
+   * @param player Игрок, которого нужно удалить
+   * @param cause Причина удаления
+   * @param initiatorName Имя инициатора (может быть null)
+   * @param initiatorId UUID инициатора (может быть null)
+   */
+  void removePlayerFromTeam(
+      String teamName,
+      @NotNull Player player,
+      @NotNull MemberRemovalCause cause,
+      @Nullable String initiatorName,
+      @Nullable UUID initiatorId);
 
   /**
    * Исключает игрока из команды по приказу лидера.

--- a/src/main/java/org/example/util/TeamMessageUtils.java
+++ b/src/main/java/org/example/util/TeamMessageUtils.java
@@ -210,6 +210,18 @@ public class TeamMessageUtils {
         .append(Component.text(" был исключён из команды.", NamedTextColor.YELLOW));
   }
 
+  public static Component memberLeftSelfMessage(String teamName) {
+    return Component.text("ℹ️ Вы покинули команду ", NamedTextColor.YELLOW)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  public static Component memberLeftBroadcastMessage(String playerName) {
+    return Component.text("ℹ️ Игрок ", NamedTextColor.YELLOW)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" покинул команду.", NamedTextColor.YELLOW));
+  }
+
   public static Component teamPrefixUpdatedLeaderMessage(String prefix) {
     return Component.text("✅ Префикс команды обновлён", NamedTextColor.GREEN)
         .append(Component.text(prefixDisplay(prefix), NamedTextColor.WHITE));

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -21,6 +21,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.example.MockBukkitTestBase;
 import org.example.config.PluginConfig;
+import org.example.service.MemberRemovalCause;
 import org.example.service.TeamService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -391,6 +392,16 @@ class TeamChatListenerTest extends MockBukkitTestBase {
 
     @Override
     public void removePlayerFromTeam(String teamName, org.bukkit.entity.Player player) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removePlayerFromTeam(
+        String teamName,
+        org.bukkit.entity.Player player,
+        MemberRemovalCause cause,
+        String initiatorName,
+        java.util.UUID initiatorId) {
       throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -92,6 +92,74 @@ class MembershipServiceTest extends MockBukkitTestBase {
   }
 
   @Test
+  void memberLeavingTeamSendsNotifications() {
+    PlayerMock leader = server.addPlayer("LeaderLeave");
+    PlayerMock member = server.addPlayer("MemberLeave");
+    membership.createTeam("Alpha", "A", "red", leader);
+    membership.addPlayerToTeam("Alpha", member);
+    drainMessages(leader);
+    drainMessages(member);
+
+    membership.removePlayerFromTeam("Alpha", member);
+
+    assertEquals(
+        TeamMessageUtils.memberLeftSelfMessage("Alpha"),
+        member.nextComponentMessage(),
+        "Участник должен получить сообщение о выходе");
+    assertEquals(
+        TeamMessageUtils.memberLeftBroadcastMessage("MemberLeave"),
+        leader.nextComponentMessage(),
+        "Лидер получает уведомление о выходе участника");
+  }
+
+  @Test
+  void leaderLeavingAloneDisbandsTeamAndSendsMessage() {
+    PlayerMock leader = server.addPlayer("SoloLeader");
+    membership.createTeam("Solo", "S", "red", leader);
+    drainMessages(leader);
+
+    membership.removePlayerFromTeam("Solo", leader);
+
+    assertEquals(
+        TeamMessageUtils.memberLeftSelfMessage("Solo"),
+        leader.nextComponentMessage(),
+        "Лидер получает сообщение о выходе");
+    assertEquals(
+        TeamMessageUtils.teamDisbandedLeaderMessage("Solo"),
+        leader.nextComponentMessage(),
+        "Лидер информируется о роспуске команды");
+    assertNull(storage.getTeamByName("Solo"), "Команда должна быть удалена");
+  }
+
+  @Test
+  void kickPlayerFromTeamSendsMessagesToAllParties() {
+    PlayerMock leader = server.addPlayer("LeaderKick");
+    PlayerMock member = server.addPlayer("MemberKick");
+    PlayerMock teammate = server.addPlayer("TeammateKick");
+    membership.createTeam("Omega", "O", "red", leader);
+    membership.addPlayerToTeam("Omega", member);
+    membership.addPlayerToTeam("Omega", teammate);
+    drainMessages(leader);
+    drainMessages(member);
+    drainMessages(teammate);
+
+    membership.kickPlayerFromTeam("Omega", leader, member.getName());
+
+    assertEquals(
+        TeamMessageUtils.memberKickedLeaderMessage(member.getName()),
+        leader.nextComponentMessage(),
+        "Лидер получает подтверждение об исключении");
+    assertEquals(
+        TeamMessageUtils.memberKickedTargetMessage("Omega", leader.getName()),
+        member.nextComponentMessage(),
+        "Исключённый игрок получает уведомление");
+    assertEquals(
+        TeamMessageUtils.memberKickedBroadcastMessage(member.getName()),
+        teammate.nextComponentMessage(),
+        "Остальные участники получают уведомление");
+  }
+
+  @Test
   void leaderCanDisbandTeam() {
     PlayerMock leader = server.addPlayer("Leader");
     PlayerMock member = server.addPlayer("Member");


### PR DESCRIPTION
## Summary
- add a removal cause enum and extend the membership service so that leaving or kicking a player sends appropriate messages and handles team disbanding when the leader exits
- expose the new removal API through TeamService/TeamManager and add utility messages for voluntary departures
- cover the new behaviour with unit tests and adjust supporting stubs

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68f5da71d96c832e80370c6df3fa72f3