### PR TITLE
Notify team about automatic leader transfer

### DIFF
--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -129,6 +129,8 @@ public class MembershipService {
       return false;
     }
     boolean wasLeader = team.isLeader(playerId);
+    UUID newLeaderId = null;
+    String newLeaderName = null;
     team.removeMember(playerId);
     storage.clearPlayerTeam(playerId);
     boolean removedTeam = false;
@@ -141,9 +143,22 @@ public class MembershipService {
         UUID newLeader = team.getFirstMember();
         if (newLeader != null) {
           team.setLeader(newLeader);
+          newLeaderId = newLeader;
+          newLeaderName = resolvePlayerName(newLeader, null);
         }
         scheduler.handleLeaderTransfer(team);
       }
+    }
+    if (newLeaderId != null && !removedTeam) {
+      Player newLeaderPlayer = plugin.getServer().getPlayer(newLeaderId);
+      if (newLeaderPlayer != null) {
+        TeamMessageUtils.sendTeamMessage(
+            newLeaderPlayer, TeamMessageUtils.leadershipTransferIncomingMessage(team.getName()));
+      }
+      sendMessageToOnlinePlayers(
+          team.getMembers(),
+          TeamMessageUtils.leadershipTransferBroadcastMessage(newLeaderName),
+          newLeaderId);
     }
     if (!removedTeam) {
       storage.markTeamDirty(team);


### PR DESCRIPTION
## Summary
- track the automatically promoted leader when the previous leader leaves
- notify the promoted leader and broadcast the transfer to remaining online members

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f70dfbd974832e9f60a9bc05edc79b