### PR TITLE
Add team invitation workflow with interactive messaging

### DIFF
--- a/src/main/java/org/example/command/TeamCommand.java
+++ b/src/main/java/org/example/command/TeamCommand.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.Command;
@@ -13,14 +15,20 @@ import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.example.MyPurpurPlugin;
 import org.example.command.sub.CreateSubCommand;
+import org.example.command.sub.AcceptInviteSubCommand;
+import org.example.command.sub.DeclineInviteSubCommand;
 import org.example.command.sub.HelpSubCommand;
 import org.example.command.sub.JoinSubCommand;
 import org.example.command.sub.LeaveSubCommand;
 import org.example.command.sub.ListSubCommand;
 import org.example.command.sub.MembersSubCommand;
+import org.example.command.sub.InviteSubCommand;
+import org.example.command.sub.InvitesSubCommand;
 import org.example.command.sub.SubCommand;
 import org.example.config.PluginConfig;
+import org.example.config.JoinMode;
 import org.example.service.TeamService;
+import org.example.util.TeamMessageUtils;
 import org.jetbrains.annotations.NotNull;
 
 /** Обработчик команд, связанных с командами игроков. */
@@ -29,6 +37,8 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
   private final TeamService teamManager;
   private final PluginConfig pluginConfig;
   private final Map<String, SubCommand> subCommands = new LinkedHashMap<>();
+  private static final Set<String> INVITE_ONLY_SUB_COMMANDS =
+      Set.of("invite", "invites", "accept", "decline");
 
   public TeamCommand(@NotNull TeamService teamManager, @NotNull PluginConfig pluginConfig) {
     this.teamManager = teamManager;
@@ -42,6 +52,10 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
     subCommands.put("leave", new LeaveSubCommand(teamManager));
     subCommands.put("list", new ListSubCommand(teamManager, pluginConfig));
     subCommands.put("members", new MembersSubCommand(teamManager, pluginConfig));
+    subCommands.put("invite", new InviteSubCommand(teamManager));
+    subCommands.put("invites", new InvitesSubCommand(teamManager));
+    subCommands.put("accept", new AcceptInviteSubCommand(teamManager));
+    subCommands.put("decline", new DeclineInviteSubCommand(teamManager));
     subCommands.put("help", new HelpSubCommand());
   }
 
@@ -95,6 +109,10 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
       sendUnknownSubCommandMessage(player);
       return true;
     }
+    if (!isSubCommandEnabled(subCommandName)) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesDisabledMessage());
+      return true;
+    }
 
     return subCommand.execute(player, args);
   }
@@ -114,7 +132,9 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
   }
 
   private String getSubCommandList() {
-    return String.join(" | ", subCommands.keySet());
+    return subCommands.keySet().stream()
+        .filter(this::isSubCommandEnabled)
+        .collect(Collectors.joining(" | "));
   }
 
   @Override
@@ -128,6 +148,9 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
       String partial = args.length == 0 ? "" : args[0].toLowerCase(Locale.ROOT);
       List<String> suggestions = new ArrayList<>();
       for (String name : subCommands.keySet()) {
+        if (!isSubCommandEnabled(name)) {
+          continue;
+        }
         if (name.startsWith(partial)) {
           suggestions.add(name);
         }
@@ -141,7 +164,17 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
     if (subCommand == null) {
       return new ArrayList<>();
     }
+    if (!isSubCommandEnabled(args[0].toLowerCase(Locale.ROOT))) {
+      return new ArrayList<>();
+    }
 
     return subCommand.tabComplete(sender, args);
+  }
+
+  private boolean isSubCommandEnabled(@NotNull String name) {
+    if (!INVITE_ONLY_SUB_COMMANDS.contains(name)) {
+      return true;
+    }
+    return teamManager.getJoinMode() == JoinMode.INVITE_ONLY;
   }
 }

--- a/src/main/java/org/example/command/sub/AcceptInviteSubCommand.java
+++ b/src/main/java/org/example/command/sub/AcceptInviteSubCommand.java
@@ -1,0 +1,61 @@
+package org.example.command.sub;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.example.config.JoinMode;
+import org.example.model.PendingInvite;
+import org.example.service.TeamService;
+import org.example.util.TeamMessageUtils;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team accept. */
+public class AcceptInviteSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public AcceptInviteSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    if (teamService.getJoinMode() != JoinMode.INVITE_ONLY) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesDisabledMessage());
+      return true;
+    }
+    if (args.length < 2) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.acceptInviteUsageMessage());
+      return true;
+    }
+    String teamName = args[1];
+    teamService.acceptInvite(player, teamName);
+    return true;
+  }
+
+  @Override
+  public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    List<String> suggestions = new ArrayList<>();
+    if (!(sender instanceof Player player)) {
+      return suggestions;
+    }
+    if (teamService.getJoinMode() != JoinMode.INVITE_ONLY) {
+      return suggestions;
+    }
+    if (args.length == 2) {
+      String partial = args[1].toLowerCase(Locale.ROOT);
+      UUID playerId = player.getUniqueId();
+      for (PendingInvite invite : teamService.getInvitesForPlayer(playerId)) {
+        String teamName = invite.getTeamName();
+        if (teamName.toLowerCase(Locale.ROOT).startsWith(partial)) {
+          suggestions.add(teamName);
+        }
+      }
+    }
+    return suggestions;
+  }
+}
+

--- a/src/main/java/org/example/command/sub/DeclineInviteSubCommand.java
+++ b/src/main/java/org/example/command/sub/DeclineInviteSubCommand.java
@@ -1,0 +1,61 @@
+package org.example.command.sub;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.example.config.JoinMode;
+import org.example.model.PendingInvite;
+import org.example.service.TeamService;
+import org.example.util.TeamMessageUtils;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team decline. */
+public class DeclineInviteSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public DeclineInviteSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    if (teamService.getJoinMode() != JoinMode.INVITE_ONLY) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesDisabledMessage());
+      return true;
+    }
+    if (args.length < 2) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.declineInviteUsageMessage());
+      return true;
+    }
+    String teamName = args[1];
+    teamService.declineInvite(player, teamName);
+    return true;
+  }
+
+  @Override
+  public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    List<String> suggestions = new ArrayList<>();
+    if (!(sender instanceof Player player)) {
+      return suggestions;
+    }
+    if (teamService.getJoinMode() != JoinMode.INVITE_ONLY) {
+      return suggestions;
+    }
+    if (args.length == 2) {
+      String partial = args[1].toLowerCase(Locale.ROOT);
+      UUID playerId = player.getUniqueId();
+      for (PendingInvite invite : teamService.getInvitesForPlayer(playerId)) {
+        String teamName = invite.getTeamName();
+        if (teamName.toLowerCase(Locale.ROOT).startsWith(partial)) {
+          suggestions.add(teamName);
+        }
+      }
+    }
+    return suggestions;
+  }
+}
+

--- a/src/main/java/org/example/command/sub/InviteSubCommand.java
+++ b/src/main/java/org/example/command/sub/InviteSubCommand.java
@@ -1,0 +1,94 @@
+package org.example.command.sub;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.example.config.JoinMode;
+import org.example.service.TeamService;
+import org.example.util.TeamMessageUtils;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team invite. */
+public class InviteSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public InviteSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    if (teamService.getJoinMode() != JoinMode.INVITE_ONLY) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesDisabledMessage());
+      return true;
+    }
+    if (args.length < 2) {
+      player.sendMessage(
+          Component.text("❌ Использование: /team invite <игрок> [минуты]", NamedTextColor.RED));
+      return true;
+    }
+    String targetName = args[1];
+    Player target = teamService.getPlugin().getServer().getPlayerExact(targetName);
+    if (target == null) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.playerNotFoundMessage(targetName));
+      return true;
+    }
+
+    Duration ttl = null;
+    if (args.length >= 3) {
+      try {
+        long minutes = Long.parseLong(args[2]);
+        if (minutes > 0) {
+          ttl = Duration.ofMinutes(minutes);
+        } else if (minutes == 0) {
+          ttl = Duration.ZERO;
+        } else {
+          TeamMessageUtils.sendTeamMessage(
+              player, TeamMessageUtils.invalidInviteDurationMessage());
+          return true;
+        }
+      } catch (NumberFormatException ex) {
+        TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invalidInviteDurationMessage());
+        return true;
+      }
+    }
+
+    teamService.sendInvite(player, target, ttl);
+    return true;
+  }
+
+  @Override
+  public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    List<String> suggestions = new ArrayList<>();
+    if (!(sender instanceof Player player)) {
+      return suggestions;
+    }
+    if (teamService.getJoinMode() != JoinMode.INVITE_ONLY) {
+      return suggestions;
+    }
+    if (args.length == 2) {
+      String partial = args[1].toLowerCase(Locale.ROOT);
+      teamService
+          .getPlugin()
+          .getServer()
+          .getOnlinePlayers()
+          .stream()
+          .filter(online -> !online.getUniqueId().equals(player.getUniqueId()))
+          .map(Player::getName)
+          .filter(name -> name != null && name.toLowerCase(Locale.ROOT).startsWith(partial))
+          .forEach(suggestions::add);
+    } else if (args.length == 3) {
+      suggestions.add("15");
+      suggestions.add("30");
+      suggestions.add("60");
+    }
+    return suggestions;
+  }
+}
+

--- a/src/main/java/org/example/command/sub/InvitesSubCommand.java
+++ b/src/main/java/org/example/command/sub/InvitesSubCommand.java
@@ -1,0 +1,50 @@
+package org.example.command.sub;
+
+import java.util.List;
+import java.util.UUID;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.example.config.JoinMode;
+import org.example.model.PendingInvite;
+import org.example.service.TeamService;
+import org.example.util.TeamMessageUtils;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team invites. */
+public class InvitesSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public InvitesSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    if (teamService.getJoinMode() != JoinMode.INVITE_ONLY) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesDisabledMessage());
+      return true;
+    }
+    UUID playerId = player.getUniqueId();
+    List<PendingInvite> invites = teamService.getInvitesForPlayer(playerId);
+    if (invites.isEmpty()) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.noInvitesMessage());
+      return true;
+    }
+    TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesHeaderMessage());
+    for (PendingInvite invite : invites) {
+      String teamName = invite.getTeamName();
+      String acceptCommand = "/team accept " + teamName;
+      String declineCommand = "/team decline " + teamName;
+      TeamMessageUtils.sendTeamMessage(
+          player, TeamMessageUtils.inviteListEntry(invite, acceptCommand, declineCommand));
+    }
+    return true;
+  }
+
+  @Override
+  public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    return List.of();
+  }
+}
+

--- a/src/main/java/org/example/model/PendingInvite.java
+++ b/src/main/java/org/example/model/PendingInvite.java
@@ -1,0 +1,115 @@
+package org.example.model;
+
+import java.time.Duration;
+import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** Represents a pending invitation for a player to join a team. */
+public final class PendingInvite {
+
+  private final UUID teamId;
+  private final UUID targetPlayerId;
+  private final UUID inviterId;
+  private final String teamName;
+  private final String inviterName;
+  private final String targetName;
+  private final long createdAt;
+  private final Long expiresAt;
+
+  public PendingInvite(
+      @NotNull UUID teamId,
+      @NotNull UUID targetPlayerId,
+      @NotNull UUID inviterId,
+      @NotNull String teamName,
+      @NotNull String inviterName,
+      @NotNull String targetName,
+      @Nullable Duration ttl) {
+    this.teamId = teamId;
+    this.targetPlayerId = targetPlayerId;
+    this.inviterId = inviterId;
+    this.teamName = teamName;
+    this.inviterName = inviterName;
+    this.targetName = targetName;
+    this.createdAt = System.currentTimeMillis();
+    if (ttl == null) {
+      this.expiresAt = null;
+    } else {
+      long ttlMillis = ttl.toMillis();
+      long now = this.createdAt;
+      if (ttlMillis <= 0L) {
+        this.expiresAt = now;
+      } else {
+        this.expiresAt = now + ttlMillis;
+      }
+    }
+  }
+
+  private PendingInvite(
+      @NotNull UUID teamId,
+      @NotNull UUID targetPlayerId,
+      @NotNull UUID inviterId,
+      @NotNull String teamName,
+      @NotNull String inviterName,
+      @NotNull String targetName,
+      long createdAt,
+      @Nullable Long expiresAt) {
+    this.teamId = teamId;
+    this.targetPlayerId = targetPlayerId;
+    this.inviterId = inviterId;
+    this.teamName = teamName;
+    this.inviterName = inviterName;
+    this.targetName = targetName;
+    this.createdAt = createdAt;
+    this.expiresAt = expiresAt;
+  }
+
+  public @NotNull UUID getTeamId() {
+    return teamId;
+  }
+
+  public @NotNull UUID getTargetPlayerId() {
+    return targetPlayerId;
+  }
+
+  public @NotNull UUID getInviterId() {
+    return inviterId;
+  }
+
+  public @NotNull String getTeamName() {
+    return teamName;
+  }
+
+  public @NotNull String getInviterName() {
+    return inviterName;
+  }
+
+  public @NotNull String getTargetName() {
+    return targetName;
+  }
+
+  public long getCreatedAt() {
+    return createdAt;
+  }
+
+  public @Nullable Long getExpiresAt() {
+    return expiresAt;
+  }
+
+  public boolean isExpired() {
+    return expiresAt != null && System.currentTimeMillis() >= expiresAt;
+  }
+
+  public PendingInvite withUpdatedNames(String updatedTeamName, String updatedTargetName) {
+    return new PendingInvite(
+        teamId,
+        targetPlayerId,
+        inviterId,
+        updatedTeamName,
+        inviterName,
+        updatedTargetName,
+        createdAt,
+        expiresAt);
+  }
+}
+

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -1,5 +1,6 @@
 package org.example.service;
 
+import java.time.Duration;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import net.kyori.adventure.text.Component;
@@ -7,8 +8,10 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
 import org.example.listener.TeamChatListener;
+import org.example.model.PendingInvite;
 import org.example.model.Team;
 import org.example.util.TeamMessageUtils;
 import org.example.util.TeamUtils;
@@ -23,6 +26,8 @@ public class MembershipService {
   private final TeamStorage storage;
   private final DeadlineScheduler scheduler;
   private final Map<UUID, Set<UUID>> pendingJoinRequests = new ConcurrentHashMap<>();
+  private final Map<UUID, Map<UUID, PendingInvite>> invitesByPlayer = new ConcurrentHashMap<>();
+  private final Map<UUID, Map<UUID, PendingInvite>> invitesByTeam = new ConcurrentHashMap<>();
 
   public MembershipService(
       @NotNull JavaPlugin plugin,
@@ -94,6 +99,7 @@ public class MembershipService {
     // Добавляем игрока и фиксируем изменения в хранилище.
     team.addMember(player.getUniqueId());
     storage.assignPlayerToTeam(player.getUniqueId(), team);
+    clearInvitesForPlayer(player.getUniqueId());
     removeJoinRequest(team.getId(), player.getUniqueId());
     storage.markTeamDirty(team);
     TeamMessageUtils.sendTeamMessage(
@@ -152,6 +158,217 @@ public class MembershipService {
     return requests != null && requests.contains(playerId);
   }
 
+  public void sendInvite(@NotNull Player leader, @NotNull Player target, @Nullable Duration ttl) {
+    if (pluginConfig.getJoinMode() != JoinMode.INVITE_ONLY) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.invitesDisabledMessage());
+      return;
+    }
+    UUID leaderId = leader.getUniqueId();
+    UUID teamId = storage.getPlayerTeams().get(leaderId);
+    if (teamId == null) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.playerNotInAnyTeamMessage());
+      return;
+    }
+    Team team = storage.getTeams().get(teamId);
+    if (team == null) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.teamDoesNotExistMessage(null));
+      return;
+    }
+    if (!team.isLeader(leaderId)) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.notTeamLeaderMessage());
+      return;
+    }
+    UUID targetId = target.getUniqueId();
+    if (leaderId.equals(targetId)) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.cannotInviteSelfMessage());
+      return;
+    }
+    String targetTeamName = storage.getPlayerTeam(target);
+    if (targetTeamName != null) {
+      TeamMessageUtils.sendTeamMessage(
+          leader, TeamMessageUtils.targetAlreadyInTeamMessage(target.getName(), targetTeamName));
+      return;
+    }
+    int maxMembers = pluginConfig.getMaxMembers();
+    if (maxMembers > 0 && team.getMembers().size() >= maxMembers) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.teamIsFullMessage(team.getName()));
+      return;
+    }
+    PendingInvite existing = peekInvite(teamId, targetId);
+    if (existing != null) {
+      if (!existing.isExpired()) {
+        TeamMessageUtils.sendTeamMessage(
+            leader, TeamMessageUtils.inviteAlreadyExistsMessage(existing.getTargetName(), team.getName()));
+        return;
+      }
+      removeInvite(teamId, targetId);
+    }
+
+    PendingInvite invite =
+        new PendingInvite(
+            teamId,
+            targetId,
+            leaderId,
+            team.getName(),
+            leader.getName() != null ? leader.getName() : resolvePlayerName(leaderId, null),
+            target.getName(),
+            ttl);
+    storeInvite(invite);
+
+    TeamMessageUtils.sendTeamMessage(
+        target,
+        TeamMessageUtils.inviteReceivedMessage(
+            invite.getTeamName(),
+            invite.getInviterName(),
+            invite.getExpiresAt(),
+            "/team accept " + invite.getTeamName(),
+            "/team decline " + invite.getTeamName()));
+    TeamMessageUtils.sendTeamMessage(
+        leader, TeamMessageUtils.inviteSentLeaderMessage(invite.getTargetName(), invite.getExpiresAt()));
+    sendMessageToOnlinePlayers(
+        team.getMembers(),
+        TeamMessageUtils.inviteSentTeamBroadcastMessage(invite.getTargetName(), invite.getInviterName()),
+        leaderId);
+    notifyAdmins(
+        TeamMessageUtils.inviteSentAdminMessage(
+            invite.getInviterName(), invite.getTargetName(), invite.getTeamName()));
+  }
+
+  public void revokeInvite(@NotNull Player leader, @NotNull String targetName) {
+    if (pluginConfig.getJoinMode() != JoinMode.INVITE_ONLY) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.invitesDisabledMessage());
+      return;
+    }
+    UUID leaderId = leader.getUniqueId();
+    UUID teamId = storage.getPlayerTeams().get(leaderId);
+    if (teamId == null) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.playerNotInAnyTeamMessage());
+      return;
+    }
+    Team team = storage.getTeams().get(teamId);
+    if (team == null || !team.isLeader(leaderId)) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.notTeamLeaderMessage());
+      return;
+    }
+    PendingInvite invite = findInviteForTeam(teamId, targetName);
+    if (invite == null) {
+      TeamMessageUtils.sendTeamMessage(
+          leader, TeamMessageUtils.inviteNotFoundForLeaderMessage(targetName, team.getName()));
+      return;
+    }
+    removeInvite(invite.getTeamId(), invite.getTargetPlayerId());
+    TeamMessageUtils.sendTeamMessage(
+        leader, TeamMessageUtils.inviteRevokedLeaderMessage(invite.getTargetName()));
+    Player targetPlayer = plugin.getServer().getPlayer(invite.getTargetPlayerId());
+    if (targetPlayer != null) {
+      TeamMessageUtils.sendTeamMessage(
+          targetPlayer, TeamMessageUtils.inviteRevokedTargetMessage(invite.getTeamName()));
+    }
+    notifyAdmins(
+        TeamMessageUtils.inviteRevokedAdminMessage(
+            invite.getInviterName(), invite.getTargetName(), invite.getTeamName()));
+  }
+
+  public void acceptInvite(@NotNull Player player, @NotNull String teamName) {
+    if (pluginConfig.getJoinMode() != JoinMode.INVITE_ONLY) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesDisabledMessage());
+      return;
+    }
+    Team team = storage.getTeamByName(teamName);
+    if (team == null) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.teamDoesNotExistMessage(teamName));
+      return;
+    }
+    UUID playerId = player.getUniqueId();
+    PendingInvite invite = peekInvite(team.getId(), playerId);
+    if (invite == null) {
+      TeamMessageUtils.sendTeamMessage(
+          player, TeamMessageUtils.inviteNotFoundForPlayerMessage(teamName));
+      return;
+    }
+    if (invite.isExpired()) {
+      removeInvite(invite.getTeamId(), invite.getTargetPlayerId());
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.inviteExpiredMessage(team.getName()));
+      return;
+    }
+    if (storage.getPlayerTeam(player) != null) {
+      TeamMessageUtils.sendTeamMessage(
+          player, Component.text("❌ Вы уже состоите в команде", NamedTextColor.RED));
+      removeInvite(invite.getTeamId(), invite.getTargetPlayerId());
+      return;
+    }
+    int maxMembers = pluginConfig.getMaxMembers();
+    if (maxMembers > 0 && team.getMembers().size() >= maxMembers) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.teamIsFullMessage(team.getName()));
+      return;
+    }
+
+    removeInvite(invite.getTeamId(), invite.getTargetPlayerId());
+    addPlayerToTeam(team.getName(), player);
+    TeamMessageUtils.sendTeamMessage(
+        player, TeamMessageUtils.inviteAcceptedMessage(team.getName()));
+    sendMessageToOnlinePlayers(
+        team.getMembers(),
+        TeamMessageUtils.inviteAcceptedBroadcastMessage(player.getName()),
+        playerId);
+    notifyAdmins(
+        TeamMessageUtils.inviteAcceptedAdminMessage(
+            invite.getInviterName(), invite.getTargetName(), invite.getTeamName()));
+  }
+
+  public void declineInvite(@NotNull Player player, @NotNull String teamName) {
+    if (pluginConfig.getJoinMode() != JoinMode.INVITE_ONLY) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesDisabledMessage());
+      return;
+    }
+    Team team = storage.getTeamByName(teamName);
+    if (team == null) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.teamDoesNotExistMessage(teamName));
+      return;
+    }
+    UUID playerId = player.getUniqueId();
+    PendingInvite invite = peekInvite(team.getId(), playerId);
+    if (invite == null) {
+      TeamMessageUtils.sendTeamMessage(
+          player, TeamMessageUtils.inviteNotFoundForPlayerMessage(teamName));
+      return;
+    }
+    if (invite.isExpired()) {
+      removeInvite(invite.getTeamId(), invite.getTargetPlayerId());
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.inviteExpiredMessage(team.getName()));
+      return;
+    }
+    removeInvite(invite.getTeamId(), invite.getTargetPlayerId());
+    TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.inviteDeclinedMessage(team.getName()));
+    sendMessageToOnlinePlayers(
+        team.getMembers(),
+        TeamMessageUtils.inviteDeclinedBroadcastMessage(player.getName()),
+        playerId);
+    notifyAdmins(
+        TeamMessageUtils.inviteDeclinedAdminMessage(
+            invite.getInviterName(), invite.getTargetName(), invite.getTeamName()));
+  }
+
+  public @NotNull List<PendingInvite> getInvitesForPlayer(@NotNull UUID playerId) {
+    Map<UUID, PendingInvite> invites = invitesByPlayer.get(playerId);
+    if (invites == null || invites.isEmpty()) {
+      return List.of();
+    }
+    List<PendingInvite> activeInvites = new ArrayList<>();
+    List<PendingInvite> expiredInvites = new ArrayList<>();
+    for (PendingInvite invite : invites.values()) {
+      if (invite.isExpired()) {
+        expiredInvites.add(invite);
+      } else {
+        activeInvites.add(invite);
+      }
+    }
+    for (PendingInvite expired : expiredInvites) {
+      removeInvite(expired.getTeamId(), expired.getTargetPlayerId());
+    }
+    return List.copyOf(activeInvites);
+  }
+
   public void removePlayerFromTeam(String teamName, @NotNull Player player) {
     removePlayerFromTeam(teamName, player, MemberRemovalCause.LEAVE, null, player.getUniqueId());
   }
@@ -186,6 +403,7 @@ public class MembershipService {
     String newLeaderName = null;
     team.removeMember(playerId);
     storage.clearPlayerTeam(playerId);
+    clearInvitesForPlayer(playerId);
     boolean removedTeam = false;
     if (wasLeader) {
       if (team.getMembers().isEmpty()) {
@@ -219,6 +437,7 @@ public class MembershipService {
     }
     if (removedTeam) {
       clearJoinRequests(team.getId());
+      clearInvitesForTeam(team.getId());
     }
     if (onlinePlayer != null) {
       notifyPrefixUpdate(onlinePlayer, null);
@@ -379,6 +598,7 @@ public class MembershipService {
     // Удаляем команду и уведомляем игроков о сбросе префикса.
     storage.removeTeam(team);
     clearJoinRequests(team.getId());
+    clearInvitesForTeam(team.getId());
     TeamMessageUtils.sendTeamMessage(
         leader, TeamMessageUtils.teamDisbandedLeaderMessage(team.getName()));
     sendMessageToOnlinePlayers(
@@ -492,6 +712,114 @@ public class MembershipService {
 
   private void clearJoinRequests(@NotNull UUID teamId) {
     pendingJoinRequests.remove(teamId);
+  }
+
+  private @Nullable PendingInvite getActiveInvite(@NotNull UUID teamId, @NotNull UUID playerId) {
+    PendingInvite invite = peekInvite(teamId, playerId);
+    if (invite == null) {
+      return null;
+    }
+    if (invite.isExpired()) {
+      removeInvite(teamId, playerId);
+      return null;
+    }
+    return invite;
+  }
+
+  private @Nullable PendingInvite peekInvite(@NotNull UUID teamId, @NotNull UUID playerId) {
+    Map<UUID, PendingInvite> invites = invitesByPlayer.get(playerId);
+    if (invites == null) {
+      return null;
+    }
+    return invites.get(teamId);
+  }
+
+  private @Nullable PendingInvite findInviteForTeam(@NotNull UUID teamId, @NotNull String targetName) {
+    Map<UUID, PendingInvite> invites = invitesByTeam.get(teamId);
+    if (invites == null) {
+      return null;
+    }
+    List<PendingInvite> expired = new ArrayList<>();
+    PendingInvite matched = null;
+    for (PendingInvite invite : invites.values()) {
+      if (invite.isExpired()) {
+        expired.add(invite);
+        continue;
+      }
+      String storedName = invite.getTargetName();
+      String resolvedName = resolvePlayerName(invite.getTargetPlayerId(), storedName);
+      if (storedName.equalsIgnoreCase(targetName) || resolvedName.equalsIgnoreCase(targetName)) {
+        matched = invite;
+        break;
+      }
+    }
+    for (PendingInvite invite : expired) {
+      removeInvite(invite.getTeamId(), invite.getTargetPlayerId());
+    }
+    return matched;
+  }
+
+  private void storeInvite(@NotNull PendingInvite invite) {
+    invitesByPlayer
+        .computeIfAbsent(invite.getTargetPlayerId(), id -> new ConcurrentHashMap<>())
+        .put(invite.getTeamId(), invite);
+    invitesByTeam
+        .computeIfAbsent(invite.getTeamId(), id -> new ConcurrentHashMap<>())
+        .put(invite.getTargetPlayerId(), invite);
+  }
+
+  private void removeInvite(@NotNull UUID teamId, @NotNull UUID playerId) {
+    invitesByPlayer.computeIfPresent(
+        playerId,
+        (id, invites) -> {
+          invites.remove(teamId);
+          return invites.isEmpty() ? null : invites;
+        });
+    invitesByTeam.computeIfPresent(
+        teamId,
+        (id, invites) -> {
+          invites.remove(playerId);
+          return invites.isEmpty() ? null : invites;
+        });
+  }
+
+  private void clearInvitesForPlayer(@NotNull UUID playerId) {
+    Map<UUID, PendingInvite> invites = invitesByPlayer.remove(playerId);
+    if (invites == null) {
+      return;
+    }
+    for (PendingInvite invite : invites.values()) {
+      invitesByTeam.computeIfPresent(
+          invite.getTeamId(),
+          (id, teamInvites) -> {
+            teamInvites.remove(playerId);
+            return teamInvites.isEmpty() ? null : teamInvites;
+          });
+    }
+  }
+
+  private void clearInvitesForTeam(@NotNull UUID teamId) {
+    Map<UUID, PendingInvite> invites = invitesByTeam.remove(teamId);
+    if (invites == null) {
+      return;
+    }
+    for (PendingInvite invite : invites.values()) {
+      invitesByPlayer.computeIfPresent(
+          invite.getTargetPlayerId(),
+          (id, playerInvites) -> {
+            playerInvites.remove(teamId);
+            return playerInvites.isEmpty() ? null : playerInvites;
+          });
+    }
+  }
+
+  private void notifyAdmins(@Nullable Component message) {
+    if (message == null || !pluginConfig.shouldNotifyAdmins()) {
+      return;
+    }
+    plugin.getServer().getOnlinePlayers().stream()
+        .filter(player -> player.hasPermission("mypurpurplugin.admin"))
+        .forEach(player -> TeamMessageUtils.sendTeamMessage(player, message));
   }
 
   private void notifyPrefixUpdate(@NotNull UUID playerId, @Nullable Component prefix) {

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -1,5 +1,6 @@
 package org.example.service;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -9,6 +10,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
 import org.example.listener.TeamChatListener;
+import org.example.model.PendingInvite;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -169,6 +171,31 @@ public class TeamManager implements TeamService {
   @Override
   public boolean isEnforceMaxMembersOnReload() {
     return pluginConfig.isEnforceMaxMembersOnReload();
+  }
+
+  @Override
+  public void sendInvite(@NotNull Player leader, @NotNull Player target, @Nullable Duration ttl) {
+    runWithTiming("sendInvite", () -> membership.sendInvite(leader, target, ttl));
+  }
+
+  @Override
+  public void revokeInvite(@NotNull Player leader, @NotNull String targetName) {
+    runWithTiming("revokeInvite", () -> membership.revokeInvite(leader, targetName));
+  }
+
+  @Override
+  public void acceptInvite(@NotNull Player player, @NotNull String teamName) {
+    runWithTiming("acceptInvite", () -> membership.acceptInvite(player, teamName));
+  }
+
+  @Override
+  public void declineInvite(@NotNull Player player, @NotNull String teamName) {
+    runWithTiming("declineInvite", () -> membership.declineInvite(player, teamName));
+  }
+
+  @Override
+  public @NotNull List<PendingInvite> getInvitesForPlayer(@NotNull UUID playerId) {
+    return runWithTiming("getInvitesForPlayer", () -> membership.getInvitesForPlayer(playerId));
   }
 
   @Override

--- a/src/main/java/org/example/service/TeamService.java
+++ b/src/main/java/org/example/service/TeamService.java
@@ -1,5 +1,6 @@
 package org.example.service;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 import net.kyori.adventure.text.format.NamedTextColor;
@@ -7,6 +8,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
+import org.example.model.PendingInvite;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -198,6 +200,48 @@ public interface TeamService {
    * @return true, если ограничение активно
    */
   boolean isEnforceMaxMembersOnReload();
+
+  /**
+   * Отправляет приглашение игроку присоединиться к команде лидера.
+   *
+   * @param leader лидер команды, инициирующий приглашение
+   * @param target целевой игрок
+   * @param ttl время жизни приглашения (null — без ограничения)
+   */
+  void sendInvite(@NotNull Player leader, @NotNull Player target, @Nullable Duration ttl);
+
+  /**
+   * Отменяет ранее отправленное приглашение.
+   *
+   * @param leader лидер команды
+   * @param targetName имя игрока, приглашение которого нужно отозвать
+   */
+  void revokeInvite(@NotNull Player leader, @NotNull String targetName);
+
+  /**
+   * Принимает приглашение в указанную команду.
+   *
+   * @param player игрок, принимающий приглашение
+   * @param teamName команда, в которую осуществляется вступление
+   */
+  void acceptInvite(@NotNull Player player, @NotNull String teamName);
+
+  /**
+   * Отклоняет приглашение в указанную команду.
+   *
+   * @param player игрок, отклоняющий приглашение
+   * @param teamName команда, приглашение от которой отклоняется
+   */
+  void declineInvite(@NotNull Player player, @NotNull String teamName);
+
+  /**
+   * Возвращает список активных приглашений игрока.
+   *
+   * @param playerId идентификатор игрока
+   * @return список приглашений
+   */
+  @NotNull
+  List<PendingInvite> getInvitesForPlayer(@NotNull UUID playerId);
 
   /**
    * Отправляет заявку на вступление игрока в команду.

--- a/src/main/java/org/example/util/TeamMessageUtils.java
+++ b/src/main/java/org/example/util/TeamMessageUtils.java
@@ -1,8 +1,14 @@
 package org.example.util;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.event.ClickEvent;
+import net.kyori.adventure.text.event.HoverEvent;
 import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
+import org.example.model.PendingInvite;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** Утилитарный класс для работы с сообщениями команд. */
 public class TeamMessageUtils {
@@ -73,6 +79,100 @@ public class TeamMessageUtils {
     return Component.text("❌ Игрок ", NamedTextColor.RED)
         .append(Component.text(playerName, NamedTextColor.WHITE))
         .append(Component.text(" не найден!", NamedTextColor.RED));
+  }
+
+  /** Возвращает сообщение о том, что команды приглашений сейчас недоступны. */
+  public static Component invitesDisabledMessage() {
+    return Component.text(
+        "❌ Управление приглашениями доступно только в режиме приглашений.",
+        NamedTextColor.RED);
+  }
+
+  /** Сообщение о том, что нельзя пригласить самого себя. */
+  public static Component cannotInviteSelfMessage() {
+    return Component.text("❌ Нельзя пригласить самого себя!", NamedTextColor.RED);
+  }
+
+  /** Уведомление о том, что цель уже состоит в команде. */
+  public static Component targetAlreadyInTeamMessage(String playerName, String teamName) {
+    return Component.text("❌ Игрок ", NamedTextColor.RED)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" уже состоит в команде ", NamedTextColor.RED))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.RED));
+  }
+
+  /** Сообщение об ошибочном формате времени приглашения. */
+  public static Component invalidInviteDurationMessage() {
+    return Component.text(
+        "❌ Укажите неотрицательное целое число минут для времени действия приглашения.",
+        NamedTextColor.RED);
+  }
+
+  /** Сообщение о том, что команда заполнена. */
+  public static Component teamIsFullMessage(String teamName) {
+    return Component.text("❌ Команда ", NamedTextColor.RED)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" заполнена.", NamedTextColor.RED));
+  }
+
+  /** Сообщает лидеру, что приглашение уже отправлено. */
+  public static Component inviteAlreadyExistsMessage(String playerName, String teamName) {
+    return Component.text("ℹ️ У игрока ", NamedTextColor.YELLOW)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" уже есть приглашение в команду ", NamedTextColor.YELLOW))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  /** Создаёт сообщение о получении приглашения с интерактивными действиями. */
+  public static Component inviteReceivedMessage(
+      String teamName,
+      String inviterName,
+      @Nullable Long expiresAt,
+      String acceptCommand,
+      String declineCommand) {
+    Component message =
+        Component.text("📨 Вас пригласили в команду ", NamedTextColor.AQUA)
+            .append(Component.text(teamName, NamedTextColor.GOLD))
+            .append(Component.text(" от ", NamedTextColor.AQUA))
+            .append(Component.text(inviterName, NamedTextColor.GOLD))
+            .append(expiryInfo(expiresAt));
+    Component actions =
+        Component.space()
+            .append(clickableAction(
+                "[Принять]", NamedTextColor.GREEN, acceptCommand, "Принять приглашение"))
+            .append(Component.space())
+            .append(clickableAction(
+                "[Отклонить]", NamedTextColor.RED, declineCommand, "Отклонить приглашение"));
+    return message.append(actions);
+  }
+
+  /** Сообщает лидеру об успешной отправке приглашения. */
+  public static Component inviteSentLeaderMessage(String playerName, @Nullable Long expiresAt) {
+    return Component.text("📨 Приглашение отправлено игроку ", NamedTextColor.GREEN)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(expiryInfo(expiresAt));
+  }
+
+  /** Сообщение для участников команды о новом приглашении. */
+  public static Component inviteSentTeamBroadcastMessage(String playerName, String inviterName) {
+    return Component.text("📨 Лидер ", NamedTextColor.AQUA)
+        .append(Component.text(inviterName, NamedTextColor.WHITE))
+        .append(Component.text(" пригласил ", NamedTextColor.AQUA))
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" в команду.", NamedTextColor.AQUA));
+  }
+
+  /** Сообщение для администраторов о новом приглашении. */
+  public static Component inviteSentAdminMessage(String inviter, String target, String teamName) {
+    return Component.text("📨 ", NamedTextColor.YELLOW)
+        .append(Component.text(inviter, NamedTextColor.WHITE))
+        .append(Component.text(" пригласил ", NamedTextColor.YELLOW))
+        .append(Component.text(target, NamedTextColor.WHITE))
+        .append(Component.text(" в команду ", NamedTextColor.YELLOW))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.YELLOW));
   }
 
   /**
@@ -157,6 +257,144 @@ public class TeamMessageUtils {
         .append(Component.text(" !", NamedTextColor.RED));
   }
 
+  /** Сообщает лидеру, что приглашение для указанного игрока не найдено. */
+  public static Component inviteNotFoundForLeaderMessage(String playerName, String teamName) {
+    return Component.text("❌ Приглашение для ", NamedTextColor.RED)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" в команду ", NamedTextColor.RED))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" не найдено.", NamedTextColor.RED));
+  }
+
+  /** Сообщает игроку, что у него нет активного приглашения от команды. */
+  public static Component inviteNotFoundForPlayerMessage(String teamName) {
+    return Component.text("❌ Активное приглашение от команды ", NamedTextColor.RED)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" не найдено.", NamedTextColor.RED));
+  }
+
+  /** Подтверждает игроку отзыв приглашения. */
+  public static Component inviteRevokedLeaderMessage(String playerName) {
+    return Component.text("ℹ️ Приглашение для ", NamedTextColor.YELLOW)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" отозвано.", NamedTextColor.YELLOW));
+  }
+
+  /** Информирует цель об отзыве приглашения. */
+  public static Component inviteRevokedTargetMessage(String teamName) {
+    return Component.text("ℹ️ Приглашение команды ", NamedTextColor.YELLOW)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" было отозвано.", NamedTextColor.YELLOW));
+  }
+
+  /** Оповещает администраторов о том, что приглашение было отозвано. */
+  public static Component inviteRevokedAdminMessage(String inviter, String target, String teamName) {
+    return Component.text("📨 ", NamedTextColor.YELLOW)
+        .append(Component.text(inviter, NamedTextColor.WHITE))
+        .append(Component.text(" отозвал приглашение для ", NamedTextColor.YELLOW))
+        .append(Component.text(target, NamedTextColor.WHITE))
+        .append(Component.text(" в команду ", NamedTextColor.YELLOW))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  /** Уведомляет игрока о принятии приглашения. */
+  public static Component inviteAcceptedMessage(String teamName) {
+    return Component.text("✅ Вы приняли приглашение команды ", NamedTextColor.GREEN)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text("!", NamedTextColor.GREEN));
+  }
+
+  /** Сообщение об использовании команды принятия приглашения. */
+  public static Component acceptInviteUsageMessage() {
+    return Component.text("❌ Использование: /team accept <команда>", NamedTextColor.RED);
+  }
+
+  /** Сообщает участникам команды об успешном вступлении приглашённого. */
+  public static Component inviteAcceptedBroadcastMessage(String playerName) {
+    return Component.text("ℹ️ Игрок ", NamedTextColor.YELLOW)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" принял приглашение и вступил в команду.", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщение для администраторов о принятии приглашения. */
+  public static Component inviteAcceptedAdminMessage(String inviter, String target, String teamName) {
+    return Component.text("📨 ", NamedTextColor.YELLOW)
+        .append(Component.text(target, NamedTextColor.WHITE))
+        .append(Component.text(" принял приглашение команды ", NamedTextColor.YELLOW))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" от ", NamedTextColor.YELLOW))
+        .append(Component.text(inviter, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщает игроку, что приглашение было отклонено. */
+  public static Component inviteDeclinedMessage(String teamName) {
+    return Component.text("ℹ️ Приглашение команды ", NamedTextColor.YELLOW)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" отклонено.", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщение об использовании команды отклонения приглашения. */
+  public static Component declineInviteUsageMessage() {
+    return Component.text("❌ Использование: /team decline <команда>", NamedTextColor.RED);
+  }
+
+  /** Броадкаст для команды о том, что приглашение отклонено. */
+  public static Component inviteDeclinedBroadcastMessage(String playerName) {
+    return Component.text("ℹ️ Игрок ", NamedTextColor.YELLOW)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" отклонил приглашение в команду.", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщение для администраторов об отклонении приглашения. */
+  public static Component inviteDeclinedAdminMessage(String inviter, String target, String teamName) {
+    return Component.text("📨 ", NamedTextColor.YELLOW)
+        .append(Component.text(target, NamedTextColor.WHITE))
+        .append(Component.text(" отклонил приглашение команды ", NamedTextColor.YELLOW))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" от ", NamedTextColor.YELLOW))
+        .append(Component.text(inviter, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщение о том, что срок действия приглашения истёк. */
+  public static Component inviteExpiredMessage(String teamName) {
+    return Component.text("❌ Срок действия приглашения команды ", NamedTextColor.RED)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" истёк.", NamedTextColor.RED));
+  }
+
+  /** Сообщает игроку об отсутствии активных приглашений. */
+  public static Component noInvitesMessage() {
+    return Component.text("ℹ️ У вас нет активных приглашений.", NamedTextColor.YELLOW);
+  }
+
+  /** Заголовок списка приглашений. */
+  public static Component invitesHeaderMessage() {
+    return Component.text("📨 Ваши приглашения:", NamedTextColor.AQUA);
+  }
+
+  /** Строка списка приглашений с интерактивными действиями. */
+  public static Component inviteListEntry(
+      @NotNull PendingInvite invite, String acceptCommand, String declineCommand) {
+    Component entry =
+        Component.text("• ", NamedTextColor.GRAY)
+            .append(Component.text(invite.getTeamName(), NamedTextColor.GOLD))
+            .append(Component.text(" (", NamedTextColor.GRAY))
+            .append(Component.text(invite.getInviterName(), NamedTextColor.WHITE))
+            .append(Component.text(")", NamedTextColor.GRAY))
+            .append(expiryInfo(invite.getExpiresAt()));
+    Component actions =
+        Component.space()
+            .append(clickableAction(
+                "[Принять]", NamedTextColor.GREEN, acceptCommand, "Принять приглашение"))
+            .append(Component.space())
+            .append(clickableAction(
+                "[Отклонить]", NamedTextColor.RED, declineCommand, "Отклонить приглашение"));
+    return entry.append(actions);
+  }
+
   /**
    * Формирует предупреждение о необходимости сократить команду.
    *
@@ -201,6 +439,50 @@ public class TeamMessageUtils {
         .append(Component.text(" чтобы исключить ", NamedTextColor.YELLOW))
         .append(Component.text(excess + " участника(ов)", NamedTextColor.WHITE))
         .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  private static Component expiryInfo(@Nullable Long expiresAt) {
+    if (expiresAt == null) {
+      return Component.text(" (без срока действия)", NamedTextColor.GRAY);
+    }
+    long remaining = expiresAt - System.currentTimeMillis();
+    if (remaining <= 0) {
+      return Component.text(" (истёк)", NamedTextColor.RED);
+    }
+    return Component.text(
+        " (истекает через " + formatDuration(remaining) + ")", NamedTextColor.GRAY);
+  }
+
+  private static String formatDuration(long millis) {
+    long totalSeconds = Math.max(0L, millis / 1000L);
+    long hours = totalSeconds / 3600L;
+    long minutes = (totalSeconds % 3600L) / 60L;
+    long seconds = totalSeconds % 60L;
+    StringBuilder builder = new StringBuilder();
+    if (hours > 0) {
+      builder.append(hours).append(" ч");
+    }
+    if (minutes > 0 || hours > 0) {
+      if (builder.length() > 0) {
+        builder.append(' ');
+      }
+      builder.append(minutes).append(" мин");
+    }
+    if (seconds > 0 || builder.length() == 0) {
+      if (builder.length() > 0) {
+        builder.append(' ');
+      }
+      builder.append(seconds).append(" сек");
+    }
+    return builder.toString();
+  }
+
+  private static Component clickableAction(
+      String label, NamedTextColor color, String command, String hoverText) {
+    return Component.text(label, color)
+        .decorate(TextDecoration.BOLD)
+        .clickEvent(ClickEvent.runCommand(command))
+        .hoverEvent(HoverEvent.showText(Component.text(hoverText, color)));
   }
 
   public static Component teamDisbandedLeaderMessage(String teamName) {

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -22,6 +22,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.example.MockBukkitTestBase;
 import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
+import org.example.model.PendingInvite;
 import org.example.service.MemberRemovalCause;
 import org.example.service.TeamService;
 import org.junit.jupiter.api.AfterEach;
@@ -508,6 +509,34 @@ class TeamChatListenerTest extends MockBukkitTestBase {
     @Override
     public boolean hasPendingJoinRequest(String teamName, java.util.UUID playerId) {
       return false;
+    }
+
+    @Override
+    public void sendInvite(
+        org.bukkit.entity.Player leader,
+        org.bukkit.entity.Player target,
+        java.time.Duration ttl) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void revokeInvite(org.bukkit.entity.Player leader, String targetName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void acceptInvite(org.bukkit.entity.Player player, String teamName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void declineInvite(org.bukkit.entity.Player player, String teamName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.util.List<PendingInvite> getInvitesForPlayer(java.util.UUID playerId) {
+      return java.util.List.of();
     }
 
     @Override

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -4,12 +4,17 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import java.time.Duration;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.example.MockBukkitTestBase;
+import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
+import org.example.model.PendingInvite;
 import org.example.model.Team;
 import org.example.util.TeamMessageUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,12 +35,104 @@ class MembershipServiceTest extends MockBukkitTestBase {
     when(pluginConfig.getMinPrefixLength()).thenReturn(1);
     when(pluginConfig.getMaxPrefixLength()).thenReturn(16);
     when(pluginConfig.getMaxMembers()).thenReturn(10);
+    when(pluginConfig.getJoinMode()).thenReturn(JoinMode.OPEN);
     when(pluginConfig.isGracePeriodEnabled()).thenReturn(true);
     when(pluginConfig.getGracePeriodMinutes()).thenReturn(10);
+    when(pluginConfig.shouldNotifyAdmins()).thenReturn(false);
 
     storage = new TeamStorage(plugin, pluginConfig);
     scheduler = new TestDeadlineScheduler(plugin, pluginConfig, storage);
     membership = new MembershipService(plugin, pluginConfig, storage, scheduler);
+  }
+
+  @Test
+  void sendInviteStoresPendingInvite() {
+    when(pluginConfig.getJoinMode()).thenReturn(JoinMode.INVITE_ONLY);
+    PlayerMock leader = server.addPlayer("LeaderInvite");
+    PlayerMock target = server.addPlayer("TargetInvite");
+    membership.createTeam("InviteTeam", "IT", "red", leader);
+    drainMessages(leader);
+    drainMessages(target);
+
+    membership.sendInvite(leader, target, Duration.ofMinutes(5));
+
+    List<PendingInvite> invites = membership.getInvitesForPlayer(target.getUniqueId());
+    assertEquals(1, invites.size(), "Приглашение должно сохраняться");
+    PendingInvite invite = invites.get(0);
+    assertEquals("InviteTeam", invite.getTeamName(), "Название команды в приглашении сохраняется");
+
+    Component targetMessage = target.nextComponentMessage();
+    String plain = PlainTextComponentSerializer.plainText().serialize(targetMessage);
+    assertTrue(plain.contains("InviteTeam"), "Сообщение должно содержать имя команды");
+    Component leaderMessage = leader.nextComponentMessage();
+    String leaderPlain = PlainTextComponentSerializer.plainText().serialize(leaderMessage);
+    assertTrue(
+        leaderPlain.contains(target.getName()),
+        "Подтверждение для лидера должно содержать имя приглашённого");
+  }
+
+  @Test
+  void acceptInviteAddsPlayerAndBroadcasts() {
+    when(pluginConfig.getJoinMode()).thenReturn(JoinMode.INVITE_ONLY);
+    PlayerMock leader = server.addPlayer("LeaderAccept");
+    PlayerMock teammate = server.addPlayer("TeammateAccept");
+    PlayerMock target = server.addPlayer("TargetAccept");
+    membership.createTeam("AcceptTeam", "AT", "red", leader);
+    membership.addPlayerToTeam("AcceptTeam", teammate);
+    drainMessages(leader);
+    drainMessages(teammate);
+    drainMessages(target);
+
+    membership.sendInvite(leader, target, Duration.ofMinutes(2));
+    // consume invite messages
+    target.nextComponentMessage();
+    leader.nextComponentMessage();
+    teammate.nextComponentMessage();
+
+    membership.acceptInvite(target, "AcceptTeam");
+
+    Team team = storage.getTeamByName("AcceptTeam");
+    assertNotNull(team, "Команда должна существовать");
+    assertTrue(team.hasMember(target.getUniqueId()), "Игрок должен стать участником команды");
+    assertTrue(
+        membership.getInvitesForPlayer(target.getUniqueId()).isEmpty(),
+        "Приглашение удаляется после принятия");
+
+    // Первое сообщение — стандартное уведомление о вступлении
+    target.nextComponentMessage();
+    assertEquals(
+        TeamMessageUtils.inviteAcceptedMessage("AcceptTeam"),
+        target.nextComponentMessage(),
+        "Игрок получает подтверждение принятия");
+    assertEquals(
+        TeamMessageUtils.inviteAcceptedBroadcastMessage(target.getName()),
+        teammate.nextComponentMessage(),
+        "Сокоманник получает уведомление");
+  }
+
+  @Test
+  void acceptInviteFailsWhenExpired() {
+    when(pluginConfig.getJoinMode()).thenReturn(JoinMode.INVITE_ONLY);
+    PlayerMock leader = server.addPlayer("LeaderExpire");
+    PlayerMock target = server.addPlayer("TargetExpire");
+    membership.createTeam("ExpireTeam", "ET", "red", leader);
+    drainMessages(leader);
+    drainMessages(target);
+
+    membership.sendInvite(leader, target, Duration.ZERO);
+    // consume invite notifications
+    target.nextComponentMessage();
+    leader.nextComponentMessage();
+
+    membership.acceptInvite(target, "ExpireTeam");
+
+    Team team = storage.getTeamByName("ExpireTeam");
+    assertNotNull(team);
+    assertFalse(team.hasMember(target.getUniqueId()), "Истёкшее приглашение не добавляет игрока");
+    assertEquals(
+        TeamMessageUtils.inviteExpiredMessage("ExpireTeam"),
+        target.nextComponentMessage(),
+        "Игрок информируется об истечении приглашения");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- add a PendingInvite model and thread-safe tracking for team invitations inside MembershipService
- expose invitation lifecycle methods through TeamService/TeamManager and wire new /team invite-related subcommands
- send interactive invite notifications and expand membership tests for invite flows

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68f772d7dc88832e9c5d8b4621c8f1bb