### PR TITLE
Add join request workflow and admin controls

### DIFF
--- a/src/main/java/org/example/command/TeamAdminCommand.java
+++ b/src/main/java/org/example/command/TeamAdminCommand.java
@@ -19,6 +19,7 @@ import org.example.MyPurpurPlugin;
 import org.example.config.PluginConfig;
 import org.example.service.RenameResult;
 import org.example.service.TeamService;
+import org.example.model.PendingRequest;
 import org.example.util.TeamMessageUtils;
 import org.example.util.TeamUtils;
 import org.jetbrains.annotations.NotNull;
@@ -72,6 +73,10 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       case "setprefix" -> handleSetPrefixCommand(player, args);
       case "setcolor" -> handleSetColorCommand(player, args);
       case "getplinfo" -> handleGetPlayerInfoCommand(player, args);
+      case "requests" -> handleRequestsCommand(player);
+      case "acceptrequest" -> handleAcceptRequestCommand(player, args);
+      case "denyrequest" -> handleDenyRequestCommand(player, args);
+      case "clearrequests" -> handleClearRequestsCommand(player);
       case "help" -> {
         sendHelp(player);
         yield true;
@@ -79,7 +84,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
       default -> {
         player.sendMessage(
             Component.text(
-                "❌ Неизвестная подкоманда! Используйте: /teamadmin <transfer | kick | disband | rename | setprefix | setcolor | getplinfo | help>",
+                "❌ Неизвестная подкоманда! Используйте: /teamadmin <transfer | kick | disband | rename | setprefix | setcolor | getplinfo | requests | acceptrequest | denyrequest | clearrequests | help>",
                 NamedTextColor.RED));
         yield true;
       }
@@ -215,6 +220,81 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
     return true;
   }
 
+  private boolean handleRequestsCommand(Player player) {
+    String teamName = teamManager.getPlayerTeam(player);
+    if (!ensurePlayerIsLeader(player, teamName)) {
+      return true;
+    }
+    List<PendingRequest> requests = teamManager.listJoinRequests(teamName);
+    if (requests.isEmpty()) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.noJoinRequestsMessage());
+      return true;
+    }
+    TeamMessageUtils.sendTeamMessage(
+        player, TeamMessageUtils.joinRequestsTeamHeaderMessage(teamName));
+    for (PendingRequest request : requests) {
+      TeamMessageUtils.sendTeamMessage(
+          player,
+          TeamMessageUtils.joinRequestTeamListEntry(
+              request,
+              "/teamadmin acceptrequest " + request.getPlayerName(),
+              "/teamadmin denyrequest " + request.getPlayerName()));
+    }
+    return true;
+  }
+
+  private boolean handleAcceptRequestCommand(Player player, String[] args) {
+    if (args.length < 2) {
+      TeamMessageUtils.sendTeamMessage(
+          player,
+          Component.text(
+              "❌ Использование: /teamadmin acceptrequest <ник>", NamedTextColor.RED));
+      return true;
+    }
+    String teamName = teamManager.getPlayerTeam(player);
+    if (!ensurePlayerIsLeader(player, teamName)) {
+      return true;
+    }
+    String targetName = args[1].trim();
+    teamManager.approveJoinRequest(teamName, player, targetName);
+    return true;
+  }
+
+  private boolean handleDenyRequestCommand(Player player, String[] args) {
+    if (args.length < 2) {
+      TeamMessageUtils.sendTeamMessage(
+          player,
+          Component.text(
+              "❌ Использование: /teamadmin denyrequest <ник>", NamedTextColor.RED));
+      return true;
+    }
+    String teamName = teamManager.getPlayerTeam(player);
+    if (!ensurePlayerIsLeader(player, teamName)) {
+      return true;
+    }
+    String targetName = args[1].trim();
+    teamManager.denyJoinRequest(teamName, player, targetName);
+    return true;
+  }
+
+  private boolean handleClearRequestsCommand(Player player) {
+    String teamName = teamManager.getPlayerTeam(player);
+    if (!ensurePlayerIsLeader(player, teamName)) {
+      return true;
+    }
+    List<PendingRequest> requests = teamManager.listJoinRequests(teamName);
+    if (requests.isEmpty()) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.noJoinRequestsMessage());
+      return true;
+    }
+    for (PendingRequest request : requests) {
+      teamManager.denyJoinRequest(teamName, player, request.getPlayerName());
+    }
+    TeamMessageUtils.sendTeamMessage(
+        player, TeamMessageUtils.joinRequestsClearedLeaderMessage(requests.size()));
+    return true;
+  }
+
   private boolean handleGetPlayerInfoCommand(Player player, String[] args) {
     if (args.length < 2) {
       TeamMessageUtils.sendTeamMessage(
@@ -305,7 +385,7 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
   private void sendUsage(Player player) {
     player.sendMessage(
         Component.text(
-            "❌ Использование: /teamadmin <transfer | kick | disband | rename | setprefix | setcolor | getplinfo | help> [аргументы]",
+            "❌ Использование: /teamadmin <transfer | kick | disband | rename | setprefix | setcolor | getplinfo | requests | acceptrequest | denyrequest | clearrequests | help> [аргументы]",
             NamedTextColor.RED));
   }
 
@@ -344,6 +424,26 @@ public class TeamAdminCommand implements org.bukkit.command.CommandExecutor, Tab
                 adminBullet(
                     "/teamadmin setcolor <новый_цвет>",
                     "изменить цвет команды (цвет: RED, BLUE, GREEN и т.д.)"))
+            .append(Component.newline())
+            .append(
+                adminBullet(
+                    "/teamadmin requests",
+                    "посмотреть заявки на вступление в вашу команду"))
+            .append(Component.newline())
+            .append(
+                adminBullet(
+                    "/teamadmin acceptrequest <ник>",
+                    "одобрить заявку игрока на вступление"))
+            .append(Component.newline())
+            .append(
+                adminBullet(
+                    "/teamadmin denyrequest <ник>",
+                    "отклонить заявку игрока"))
+            .append(Component.newline())
+            .append(
+                adminBullet(
+                    "/teamadmin clearrequests",
+                    "очистить все заявки на вступление"))
             .append(Component.newline())
             .append(
                 adminBullet(

--- a/src/main/java/org/example/command/TeamCommand.java
+++ b/src/main/java/org/example/command/TeamCommand.java
@@ -14,8 +14,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.example.MyPurpurPlugin;
-import org.example.command.sub.CreateSubCommand;
 import org.example.command.sub.AcceptInviteSubCommand;
+import org.example.command.sub.CreateSubCommand;
+import org.example.command.sub.CancelRequestSubCommand;
 import org.example.command.sub.DeclineInviteSubCommand;
 import org.example.command.sub.HelpSubCommand;
 import org.example.command.sub.JoinSubCommand;
@@ -24,6 +25,8 @@ import org.example.command.sub.ListSubCommand;
 import org.example.command.sub.MembersSubCommand;
 import org.example.command.sub.InviteSubCommand;
 import org.example.command.sub.InvitesSubCommand;
+import org.example.command.sub.RequestSubCommand;
+import org.example.command.sub.RequestsSubCommand;
 import org.example.command.sub.SubCommand;
 import org.example.config.PluginConfig;
 import org.example.config.JoinMode;
@@ -39,6 +42,8 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
   private final Map<String, SubCommand> subCommands = new LinkedHashMap<>();
   private static final Set<String> INVITE_ONLY_SUB_COMMANDS =
       Set.of("invite", "invites", "accept", "decline");
+  private static final Set<String> REQUEST_ONLY_SUB_COMMANDS =
+      Set.of("request", "cancelrequest", "requests");
 
   public TeamCommand(@NotNull TeamService teamManager, @NotNull PluginConfig pluginConfig) {
     this.teamManager = teamManager;
@@ -56,6 +61,9 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
     subCommands.put("invites", new InvitesSubCommand(teamManager));
     subCommands.put("accept", new AcceptInviteSubCommand(teamManager));
     subCommands.put("decline", new DeclineInviteSubCommand(teamManager));
+    subCommands.put("request", new RequestSubCommand(teamManager));
+    subCommands.put("cancelrequest", new CancelRequestSubCommand(teamManager));
+    subCommands.put("requests", new RequestsSubCommand(teamManager));
     subCommands.put("help", new HelpSubCommand());
   }
 
@@ -172,9 +180,12 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
   }
 
   private boolean isSubCommandEnabled(@NotNull String name) {
-    if (!INVITE_ONLY_SUB_COMMANDS.contains(name)) {
-      return true;
+    if (INVITE_ONLY_SUB_COMMANDS.contains(name)) {
+      return teamManager.getJoinMode() == JoinMode.INVITE_ONLY;
     }
-    return teamManager.getJoinMode() == JoinMode.INVITE_ONLY;
+    if (REQUEST_ONLY_SUB_COMMANDS.contains(name)) {
+      return teamManager.getJoinMode() == JoinMode.REQUEST_TO_JOIN;
+    }
+    return true;
   }
 }

--- a/src/main/java/org/example/command/sub/CancelRequestSubCommand.java
+++ b/src/main/java/org/example/command/sub/CancelRequestSubCommand.java
@@ -1,0 +1,51 @@
+package org.example.command.sub;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.example.model.PendingRequest;
+import org.example.service.TeamService;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team cancelrequest. */
+public class CancelRequestSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public CancelRequestSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    if (args.length < 2) {
+      player.sendMessage(
+          Component.text("❌ Использование: /team cancelrequest <название>", NamedTextColor.RED));
+      return true;
+    }
+    teamService.cancelJoinRequest(args[1].trim(), player);
+    return true;
+  }
+
+  @Override
+  public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    List<String> suggestions = new ArrayList<>();
+    if (!(sender instanceof Player player)) {
+      return suggestions;
+    }
+    if (args.length == 2) {
+      String partial = args[1].toLowerCase(Locale.ROOT);
+      for (PendingRequest request : teamService.getJoinRequestsForPlayer(player.getUniqueId())) {
+        String teamName = request.getTeamName();
+        if (teamName.toLowerCase(Locale.ROOT).startsWith(partial)) {
+          suggestions.add(teamName);
+        }
+      }
+    }
+    return suggestions;
+  }
+}

--- a/src/main/java/org/example/command/sub/RequestSubCommand.java
+++ b/src/main/java/org/example/command/sub/RequestSubCommand.java
@@ -8,17 +8,15 @@ import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
-import org.example.config.JoinMode;
 import org.example.service.TeamService;
-import org.example.util.TeamMessageUtils;
 import org.jetbrains.annotations.NotNull;
 
-/** Подкоманда /team join. */
-public class JoinSubCommand implements SubCommand {
+/** Подкоманда /team request. */
+public class RequestSubCommand implements SubCommand {
 
   private final TeamService teamService;
 
-  public JoinSubCommand(@NotNull TeamService teamService) {
+  public RequestSubCommand(@NotNull TeamService teamService) {
     this.teamService = teamService;
   }
 
@@ -26,29 +24,10 @@ public class JoinSubCommand implements SubCommand {
   public boolean execute(@NotNull Player player, @NotNull String[] args) {
     if (args.length < 2) {
       player.sendMessage(
-          Component.text("❌ Использование: /team join <название>", NamedTextColor.RED));
+          Component.text("❌ Использование: /team request <название>", NamedTextColor.RED));
       return true;
     }
-    String teamName = args[1].trim();
-    JoinMode joinMode = teamService.getJoinMode();
-    switch (joinMode) {
-      case OPEN:
-        teamService.addPlayerToTeam(teamName, player);
-        break;
-      case INVITE_ONLY:
-        player.sendMessage(TeamMessageUtils.joinInviteOnlyMessage());
-        break;
-      case REQUEST_TO_JOIN:
-        if (teamService.hasPendingJoinRequest(teamName, player.getUniqueId())) {
-          teamService.cancelJoinRequest(teamName, player);
-        } else {
-          teamService.submitJoinRequest(teamName, player);
-        }
-        break;
-      default:
-        teamService.addPlayerToTeam(teamName, player);
-        break;
-    }
+    teamService.submitJoinRequest(args[1].trim(), player);
     return true;
   }
 

--- a/src/main/java/org/example/command/sub/RequestsSubCommand.java
+++ b/src/main/java/org/example/command/sub/RequestsSubCommand.java
@@ -1,0 +1,42 @@
+package org.example.command.sub;
+
+import java.util.Collections;
+import java.util.List;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.example.model.PendingRequest;
+import org.example.service.TeamService;
+import org.example.util.TeamMessageUtils;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team requests. */
+public class RequestsSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public RequestsSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    List<PendingRequest> requests = teamService.getJoinRequestsForPlayer(player.getUniqueId());
+    if (requests.isEmpty()) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.noJoinRequestsMessage());
+      return true;
+    }
+    TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.joinRequestsHeaderMessage());
+    for (PendingRequest request : requests) {
+      TeamMessageUtils.sendTeamMessage(
+          player,
+          TeamMessageUtils.joinRequestListEntry(
+              request, "/team cancelrequest " + request.getTeamName()));
+    }
+    return true;
+  }
+
+  @Override
+  public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    return Collections.emptyList();
+  }
+}

--- a/src/main/java/org/example/model/PendingRequest.java
+++ b/src/main/java/org/example/model/PendingRequest.java
@@ -1,0 +1,59 @@
+package org.example.model;
+
+import java.time.Instant;
+import java.util.UUID;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/** Describes a join request submitted by a player for a specific team. */
+public final class PendingRequest {
+
+  private final UUID teamId;
+  private final UUID playerId;
+  private final String teamName;
+  private final String playerName;
+  private final long createdAt;
+  @Nullable private final Long expiresAt;
+
+  public PendingRequest(
+      @NotNull UUID teamId,
+      @NotNull UUID playerId,
+      @NotNull String teamName,
+      @NotNull String playerName,
+      @Nullable Long expiresAt) {
+    this.teamId = teamId;
+    this.playerId = playerId;
+    this.teamName = teamName;
+    this.playerName = playerName;
+    this.createdAt = Instant.now().toEpochMilli();
+    this.expiresAt = expiresAt;
+  }
+
+  public @NotNull UUID getTeamId() {
+    return teamId;
+  }
+
+  public @NotNull UUID getPlayerId() {
+    return playerId;
+  }
+
+  public @NotNull String getTeamName() {
+    return teamName;
+  }
+
+  public @NotNull String getPlayerName() {
+    return playerName;
+  }
+
+  public long getCreatedAt() {
+    return createdAt;
+  }
+
+  public @Nullable Long getExpiresAt() {
+    return expiresAt;
+  }
+
+  public boolean isExpired() {
+    return expiresAt != null && expiresAt <= System.currentTimeMillis();
+  }
+}

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -12,6 +12,7 @@ import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
 import org.example.listener.TeamChatListener;
 import org.example.model.PendingInvite;
+import org.example.model.PendingRequest;
 import org.example.model.Team;
 import org.example.util.TeamMessageUtils;
 import org.example.util.TeamUtils;
@@ -25,7 +26,10 @@ public class MembershipService {
   private final PluginConfig pluginConfig;
   private final TeamStorage storage;
   private final DeadlineScheduler scheduler;
-  private final Map<UUID, Set<UUID>> pendingJoinRequests = new ConcurrentHashMap<>();
+  private final Map<UUID, Map<UUID, PendingRequest>> joinRequestsByTeam =
+      new ConcurrentHashMap<>();
+  private final Map<UUID, Map<UUID, PendingRequest>> joinRequestsByPlayer =
+      new ConcurrentHashMap<>();
   private final Map<UUID, Map<UUID, PendingInvite>> invitesByPlayer = new ConcurrentHashMap<>();
   private final Map<UUID, Map<UUID, PendingInvite>> invitesByTeam = new ConcurrentHashMap<>();
 
@@ -100,7 +104,13 @@ public class MembershipService {
     team.addMember(player.getUniqueId());
     storage.assignPlayerToTeam(player.getUniqueId(), team);
     clearInvitesForPlayer(player.getUniqueId());
-    removeJoinRequest(team.getId(), player.getUniqueId());
+    removeJoinRequest(
+        team.getId(),
+        player.getUniqueId(),
+        JoinRequestRemovalCause.JOINED,
+        player.getName(),
+        player.getUniqueId(),
+        team);
     storage.markTeamDirty(team);
     TeamMessageUtils.sendTeamMessage(
         player, Component.text("✅ Вы вступили в команду", NamedTextColor.GREEN));
@@ -108,7 +118,7 @@ public class MembershipService {
     updateTeamMembersPrefixes(team);
   }
 
-  public void requestToJoinTeam(String teamName, @NotNull Player player) {
+  public void submitJoinRequest(String teamName, @NotNull Player player) {
     String normalizedTeamName = teamName == null ? "" : teamName.trim();
     Team team = storage.getTeamByName(normalizedTeamName);
     if (team == null) {
@@ -124,29 +134,180 @@ public class MembershipService {
     int max = pluginConfig.getMaxMembers();
     if (max > 0 && team.getMembers().size() >= max) {
       TeamMessageUtils.sendTeamMessage(
-          player, Component.text("❌ Команда полная", NamedTextColor.RED));
+          player, TeamMessageUtils.teamIsFullMessage(team.getName()));
       return;
     }
     UUID teamId = team.getId();
     UUID playerId = player.getUniqueId();
-    Set<UUID> requests =
-        pendingJoinRequests.computeIfAbsent(teamId, key -> ConcurrentHashMap.newKeySet());
-    if (!requests.add(playerId)) {
+    PendingRequest existing = peekJoinRequest(teamId, playerId);
+    if (existing != null && !existing.isExpired()) {
       TeamMessageUtils.sendTeamMessage(
           player, TeamMessageUtils.joinRequestAlreadySentMessage(team.getName()));
       return;
     }
+    if (existing != null) {
+      removeJoinRequest(teamId, playerId, JoinRequestRemovalCause.EXPIRED, null, null, team);
+    }
+    PendingRequest request =
+        new PendingRequest(
+            teamId,
+            playerId,
+            team.getName(),
+            player.getName() != null ? player.getName() : resolvePlayerName(playerId, null),
+            null);
+    storeJoinRequest(request);
     TeamMessageUtils.sendTeamMessage(
-        player, TeamMessageUtils.joinRequestSentMessage(team.getName()));
-    UUID leaderId = team.getLeaderId();
-    if (leaderId != null) {
-      Player leaderPlayer = plugin.getServer().getPlayer(leaderId);
-      if (leaderPlayer != null) {
-        TeamMessageUtils.sendTeamMessage(
-            leaderPlayer,
-            TeamMessageUtils.joinRequestReceivedLeaderMessage(player.getName(), team.getName()));
+        player, TeamMessageUtils.joinRequestSentPlayerMessage(team.getName()));
+    Player leaderPlayer = resolveOnlineLeader(team);
+    if (leaderPlayer != null) {
+      TeamMessageUtils.sendTeamMessage(
+          leaderPlayer,
+          TeamMessageUtils.joinRequestReceivedLeaderMessage(request.getPlayerName(), team.getName()));
+    }
+  }
+
+  public void cancelJoinRequest(String teamName, @NotNull Player player) {
+    Team team = storage.getTeamByName(teamName);
+    if (team == null) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.teamDoesNotExistMessage(teamName));
+      return;
+    }
+    PendingRequest request = peekJoinRequest(team.getId(), player.getUniqueId());
+    if (request == null) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.joinRequestNotFoundMessage(teamName));
+      return;
+    }
+    removeJoinRequest(
+        request.getTeamId(),
+        request.getPlayerId(),
+        JoinRequestRemovalCause.CANCELLED,
+        player.getName(),
+        null,
+        team);
+  }
+
+  public void approveJoinRequest(
+      String teamName, @NotNull Player leader, @NotNull String targetName) {
+    Team team = storage.getTeamByName(teamName);
+    if (team == null) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.teamDoesNotExistMessage(teamName));
+      return;
+    }
+    if (!team.isLeader(leader.getUniqueId())) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.notTeamLeaderMessage());
+      return;
+    }
+    PendingRequest request = findJoinRequestForTeam(team, targetName);
+    if (request == null) {
+      TeamMessageUtils.sendTeamMessage(
+          leader, TeamMessageUtils.joinRequestNotFoundLeaderMessage(targetName));
+      return;
+    }
+    int max = pluginConfig.getMaxMembers();
+    if (max > 0 && team.getMembers().size() >= max) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.teamIsFullMessage(team.getName()));
+      return;
+    }
+    Player target = plugin.getServer().getPlayer(request.getPlayerId());
+    if (target == null) {
+      OfflinePlayer offline = plugin.getServer().getOfflinePlayer(request.getPlayerId());
+      String targetDisplayName =
+          offline != null && offline.getName() != null
+              ? offline.getName()
+              : request.getPlayerName();
+      TeamMessageUtils.sendTeamMessage(
+          leader, TeamMessageUtils.joinRequestTargetOfflineMessage(targetDisplayName));
+      return;
+    }
+    removeJoinRequest(
+        request.getTeamId(),
+        request.getPlayerId(),
+        JoinRequestRemovalCause.APPROVED,
+        leader.getName(),
+        leader.getUniqueId(),
+        team);
+    addPlayerToTeam(team.getName(), target);
+  }
+
+  public void denyJoinRequest(String teamName, @NotNull Player leader, @NotNull String targetName) {
+    Team team = storage.getTeamByName(teamName);
+    if (team == null) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.teamDoesNotExistMessage(teamName));
+      return;
+    }
+    if (!team.isLeader(leader.getUniqueId())) {
+      TeamMessageUtils.sendTeamMessage(leader, TeamMessageUtils.notTeamLeaderMessage());
+      return;
+    }
+    PendingRequest request = findJoinRequestForTeam(team, targetName);
+    if (request == null) {
+      TeamMessageUtils.sendTeamMessage(
+          leader, TeamMessageUtils.joinRequestNotFoundLeaderMessage(targetName));
+      return;
+    }
+    removeJoinRequest(
+        request.getTeamId(),
+        request.getPlayerId(),
+        JoinRequestRemovalCause.DENIED,
+        leader.getName(),
+        leader.getUniqueId(),
+        team);
+  }
+
+  public @NotNull List<PendingRequest> listJoinRequests(String teamName) {
+    Team team = storage.getTeamByName(teamName);
+    if (team == null) {
+      return List.of();
+    }
+    Map<UUID, PendingRequest> requests = joinRequestsByTeam.get(team.getId());
+    if (requests == null || requests.isEmpty()) {
+      return List.of();
+    }
+    List<PendingRequest> active = new ArrayList<>();
+    List<PendingRequest> expired = new ArrayList<>();
+    for (PendingRequest request : requests.values()) {
+      if (request.isExpired()) {
+        expired.add(request);
+      } else {
+        active.add(request);
       }
     }
+    for (PendingRequest expiredRequest : expired) {
+      removeJoinRequest(
+          expiredRequest.getTeamId(),
+          expiredRequest.getPlayerId(),
+          JoinRequestRemovalCause.EXPIRED,
+          null,
+          null,
+          team);
+    }
+    return List.copyOf(active);
+  }
+
+  public @NotNull List<PendingRequest> getJoinRequestsForPlayer(@NotNull UUID playerId) {
+    Map<UUID, PendingRequest> requests = joinRequestsByPlayer.get(playerId);
+    if (requests == null || requests.isEmpty()) {
+      return List.of();
+    }
+    List<PendingRequest> active = new ArrayList<>();
+    List<PendingRequest> expired = new ArrayList<>();
+    for (PendingRequest request : requests.values()) {
+      if (request.isExpired()) {
+        expired.add(request);
+      } else {
+        active.add(request);
+      }
+    }
+    for (PendingRequest expiredRequest : expired) {
+      removeJoinRequest(
+          expiredRequest.getTeamId(),
+          expiredRequest.getPlayerId(),
+          JoinRequestRemovalCause.EXPIRED,
+          null,
+          null,
+          storage.getTeams().get(expiredRequest.getTeamId()));
+    }
+    return List.copyOf(active);
   }
 
   public boolean hasPendingJoinRequest(String teamName, @NotNull UUID playerId) {
@@ -154,8 +315,21 @@ public class MembershipService {
     if (team == null) {
       return false;
     }
-    Set<UUID> requests = pendingJoinRequests.get(team.getId());
-    return requests != null && requests.contains(playerId);
+    PendingRequest request = peekJoinRequest(team.getId(), playerId);
+    if (request == null) {
+      return false;
+    }
+    if (request.isExpired()) {
+      removeJoinRequest(
+          request.getTeamId(),
+          request.getPlayerId(),
+          JoinRequestRemovalCause.EXPIRED,
+          null,
+          null,
+          team);
+      return false;
+    }
+    return true;
   }
 
   public void sendInvite(@NotNull Player leader, @NotNull Player target, @Nullable Duration ttl) {
@@ -436,7 +610,7 @@ public class MembershipService {
       scheduler.evaluateTeam(team);
     }
     if (removedTeam) {
-      clearJoinRequests(team.getId());
+      clearJoinRequests(team, JoinRequestRemovalCause.EXPIRED, null);
       clearInvitesForTeam(team.getId());
     }
     if (onlinePlayer != null) {
@@ -597,7 +771,7 @@ public class MembershipService {
     scheduler.cancelDeadline(team);
     // Удаляем команду и уведомляем игроков о сбросе префикса.
     storage.removeTeam(team);
-    clearJoinRequests(team.getId());
+    clearJoinRequests(team, JoinRequestRemovalCause.EXPIRED, leader.getName());
     clearInvitesForTeam(team.getId());
     TeamMessageUtils.sendTeamMessage(
         leader, TeamMessageUtils.teamDisbandedLeaderMessage(team.getName()));
@@ -701,17 +875,191 @@ public class MembershipService {
         .callEvent(new TeamChatListener.PlayerPrefixUpdateEvent(player, prefix));
   }
 
-  private void removeJoinRequest(@NotNull UUID teamId, @NotNull UUID playerId) {
-    pendingJoinRequests.computeIfPresent(
-        teamId,
-        (id, requests) -> {
-          requests.remove(playerId);
-          return requests.isEmpty() ? null : requests;
-        });
+  private void storeJoinRequest(@NotNull PendingRequest request) {
+    joinRequestsByTeam
+        .computeIfAbsent(request.getTeamId(), id -> new ConcurrentHashMap<>())
+        .put(request.getPlayerId(), request);
+    joinRequestsByPlayer
+        .computeIfAbsent(request.getPlayerId(), id -> new ConcurrentHashMap<>())
+        .put(request.getTeamId(), request);
   }
 
-  private void clearJoinRequests(@NotNull UUID teamId) {
-    pendingJoinRequests.remove(teamId);
+  private @Nullable PendingRequest peekJoinRequest(@NotNull UUID teamId, @NotNull UUID playerId) {
+    Map<UUID, PendingRequest> requests = joinRequestsByTeam.get(teamId);
+    if (requests == null) {
+      return null;
+    }
+    return requests.get(playerId);
+  }
+
+  private @Nullable PendingRequest findJoinRequestForTeam(
+      @NotNull Team team, @NotNull String targetName) {
+    Map<UUID, PendingRequest> requests = joinRequestsByTeam.get(team.getId());
+    if (requests == null) {
+      return null;
+    }
+    List<PendingRequest> expired = new ArrayList<>();
+    PendingRequest matched = null;
+    for (PendingRequest request : requests.values()) {
+      if (request.isExpired()) {
+        expired.add(request);
+        continue;
+      }
+      String storedName = request.getPlayerName();
+      String resolvedName = resolvePlayerName(request.getPlayerId(), storedName);
+      if (storedName.equalsIgnoreCase(targetName) || resolvedName.equalsIgnoreCase(targetName)) {
+        matched = request;
+        break;
+      }
+    }
+    for (PendingRequest expiredRequest : expired) {
+      removeJoinRequest(
+          expiredRequest.getTeamId(),
+          expiredRequest.getPlayerId(),
+          JoinRequestRemovalCause.EXPIRED,
+          null,
+          null,
+          team);
+    }
+    return matched;
+  }
+
+  private @Nullable PendingRequest removeJoinRequest(
+      @NotNull UUID teamId,
+      @NotNull UUID playerId,
+      @NotNull JoinRequestRemovalCause cause,
+      @Nullable String actorName,
+      @Nullable UUID actorId,
+      @Nullable Team providedTeam) {
+    Map<UUID, PendingRequest> byTeam = joinRequestsByTeam.get(teamId);
+    if (byTeam == null) {
+      return null;
+    }
+    PendingRequest request = byTeam.remove(playerId);
+    if (request == null) {
+      return null;
+    }
+    if (byTeam.isEmpty()) {
+      joinRequestsByTeam.remove(teamId);
+    }
+    joinRequestsByPlayer.computeIfPresent(
+        playerId,
+        (id, requests) -> {
+          requests.remove(teamId);
+          return requests.isEmpty() ? null : requests;
+        });
+    Team team = providedTeam;
+    if (team == null) {
+      team = storage.getTeams().get(teamId);
+    }
+    notifyJoinRequestRemoval(request, cause, actorName, actorId, team);
+    return request;
+  }
+
+  private void clearJoinRequests(
+      @NotNull Team team,
+      @NotNull JoinRequestRemovalCause cause,
+      @Nullable String actorName) {
+    Map<UUID, PendingRequest> requests = joinRequestsByTeam.remove(team.getId());
+    if (requests == null || requests.isEmpty()) {
+      return;
+    }
+    for (PendingRequest request : requests.values()) {
+      joinRequestsByPlayer.computeIfPresent(
+          request.getPlayerId(),
+          (id, playerRequests) -> {
+            playerRequests.remove(request.getTeamId());
+            return playerRequests.isEmpty() ? null : playerRequests;
+          });
+      notifyJoinRequestRemoval(request, cause, actorName, team.getLeaderId(), team);
+    }
+  }
+
+  private void notifyJoinRequestRemoval(
+      @NotNull PendingRequest request,
+      @NotNull JoinRequestRemovalCause cause,
+      @Nullable String actorName,
+      @Nullable UUID actorId,
+      @Nullable Team team) {
+    Player applicant = plugin.getServer().getPlayer(request.getPlayerId());
+    Player leader = null;
+    UUID leaderId = team != null ? team.getLeaderId() : null;
+    if (leaderId != null) {
+      leader = plugin.getServer().getPlayer(leaderId);
+    }
+
+    switch (cause) {
+      case APPROVED -> {
+        if (applicant != null) {
+          TeamMessageUtils.sendTeamMessage(
+              applicant, TeamMessageUtils.joinRequestApprovedPlayerMessage(request.getTeamName()));
+        }
+        if (leader != null) {
+          TeamMessageUtils.sendTeamMessage(
+              leader,
+              TeamMessageUtils.joinRequestApprovedLeaderMessage(
+                  request.getPlayerName(), request.getTeamName()));
+        }
+      }
+      case DENIED -> {
+        if (applicant != null) {
+          TeamMessageUtils.sendTeamMessage(
+              applicant, TeamMessageUtils.joinRequestDeniedPlayerMessage(request.getTeamName()));
+        }
+        if (leader != null) {
+          TeamMessageUtils.sendTeamMessage(
+              leader,
+              TeamMessageUtils.joinRequestDeniedLeaderMessage(
+                  request.getPlayerName(), request.getTeamName(), actorName));
+        }
+      }
+      case CANCELLED -> {
+        if (applicant != null) {
+          TeamMessageUtils.sendTeamMessage(
+              applicant, TeamMessageUtils.joinRequestCancelledPlayerMessage(request.getTeamName()));
+        }
+        if (leader != null) {
+          TeamMessageUtils.sendTeamMessage(
+              leader,
+              TeamMessageUtils.joinRequestCancelledLeaderMessage(request.getPlayerName(), actorName));
+        }
+      }
+      case EXPIRED -> {
+        if (applicant != null) {
+          TeamMessageUtils.sendTeamMessage(
+              applicant, TeamMessageUtils.joinRequestExpiredPlayerMessage(request.getTeamName()));
+        }
+        if (leader != null) {
+          TeamMessageUtils.sendTeamMessage(
+              leader,
+              TeamMessageUtils.joinRequestExpiredLeaderMessage(request.getPlayerName(), request.getTeamName()));
+        }
+      }
+      case JOINED -> {
+        if (leader != null && actorId != null && !leader.getUniqueId().equals(actorId)) {
+          TeamMessageUtils.sendTeamMessage(
+              leader,
+              TeamMessageUtils.joinRequestAutoClearedLeaderMessage(
+                  request.getPlayerName(), request.getTeamName()));
+        }
+      }
+    }
+  }
+
+  private Player resolveOnlineLeader(@NotNull Team team) {
+    UUID leaderId = team.getLeaderId();
+    if (leaderId == null) {
+      return null;
+    }
+    return plugin.getServer().getPlayer(leaderId);
+  }
+
+  private enum JoinRequestRemovalCause {
+    APPROVED,
+    DENIED,
+    CANCELLED,
+    EXPIRED,
+    JOINED
   }
 
   private @Nullable PendingInvite getActiveInvite(@NotNull UUID teamId, @NotNull UUID playerId) {

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -11,6 +11,7 @@ import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
 import org.example.listener.TeamChatListener;
 import org.example.model.PendingInvite;
+import org.example.model.PendingRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -228,8 +229,36 @@ public class TeamManager implements TeamService {
   }
 
   @Override
-  public void requestToJoinTeam(String teamName, @NotNull Player player) {
-    runWithTiming("requestToJoinTeam", () -> membership.requestToJoinTeam(teamName, player));
+  public void submitJoinRequest(String teamName, @NotNull Player player) {
+    runWithTiming("submitJoinRequest", () -> membership.submitJoinRequest(teamName, player));
+  }
+
+  @Override
+  public void cancelJoinRequest(String teamName, @NotNull Player player) {
+    runWithTiming("cancelJoinRequest", () -> membership.cancelJoinRequest(teamName, player));
+  }
+
+  @Override
+  public @NotNull List<PendingRequest> listJoinRequests(String teamName) {
+    return runWithTiming("listJoinRequests", () -> membership.listJoinRequests(teamName));
+  }
+
+  @Override
+  public @NotNull List<PendingRequest> getJoinRequestsForPlayer(@NotNull UUID playerId) {
+    return runWithTiming(
+        "getJoinRequestsForPlayer", () -> membership.getJoinRequestsForPlayer(playerId));
+  }
+
+  @Override
+  public void approveJoinRequest(String teamName, @NotNull Player leader, @NotNull String targetName) {
+    runWithTiming(
+        "approveJoinRequest", () -> membership.approveJoinRequest(teamName, leader, targetName));
+  }
+
+  @Override
+  public void denyJoinRequest(String teamName, @NotNull Player leader, @NotNull String targetName) {
+    runWithTiming(
+        "denyJoinRequest", () -> membership.denyJoinRequest(teamName, leader, targetName));
   }
 
   @Override

--- a/src/main/java/org/example/service/TeamService.java
+++ b/src/main/java/org/example/service/TeamService.java
@@ -9,6 +9,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
 import org.example.model.PendingInvite;
+import org.example.model.PendingRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -32,6 +33,26 @@ public interface TeamService {
    * @param player Игрок, которого нужно добавить
    */
   void addPlayerToTeam(String teamName, @NotNull Player player);
+
+  /** Отправляет заявку на вступление в команду. */
+  void submitJoinRequest(String teamName, @NotNull Player player);
+
+  /** Отзывает заявку на вступление в команду. */
+  void cancelJoinRequest(String teamName, @NotNull Player player);
+
+  /** Возвращает список заявок на вступление для команды. */
+  @NotNull
+  List<PendingRequest> listJoinRequests(String teamName);
+
+  /** Возвращает активные заявки игрока. */
+  @NotNull
+  List<PendingRequest> getJoinRequestsForPlayer(@NotNull UUID playerId);
+
+  /** Одобряет заявку на вступление. */
+  void approveJoinRequest(String teamName, @NotNull Player leader, @NotNull String targetName);
+
+  /** Отклоняет заявку на вступление. */
+  void denyJoinRequest(String teamName, @NotNull Player leader, @NotNull String targetName);
 
   /**
    * Удаляет игрока из указанной команды.
@@ -249,7 +270,9 @@ public interface TeamService {
    * @param teamName Название команды
    * @param player Игрок, отправляющий заявку
    */
-  void requestToJoinTeam(String teamName, @NotNull Player player);
+  default void requestToJoinTeam(String teamName, @NotNull Player player) {
+    submitJoinRequest(teamName, player);
+  }
 
   /**
    * Проверяет, отправлял ли игрок заявку в указанную команду.

--- a/src/main/java/org/example/util/TeamMessageUtils.java
+++ b/src/main/java/org/example/util/TeamMessageUtils.java
@@ -7,6 +7,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
 import org.bukkit.entity.Player;
 import org.example.model.PendingInvite;
+import org.example.model.PendingRequest;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -193,6 +194,11 @@ public class TeamMessageUtils {
    * @return информационное сообщение
    */
   public static Component joinRequestSentMessage(String teamName) {
+    return joinRequestSentPlayerMessage(teamName);
+  }
+
+  /** Уведомляет игрока о том, что заявка на вступление отправлена. */
+  public static Component joinRequestSentPlayerMessage(String teamName) {
     String name = (teamName == null || teamName.isBlank()) ? "команду" : teamName;
     return Component.text("ℹ️ Заявка на вступление в команду ", NamedTextColor.YELLOW)
         .append(Component.text(name, NamedTextColor.WHITE))
@@ -227,6 +233,180 @@ public class TeamMessageUtils {
         .append(Component.text(" хочет вступить в команду ", NamedTextColor.YELLOW))
         .append(Component.text(name, NamedTextColor.WHITE))
         .append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщает игроку об отсутствии активной заявки. */
+  public static Component joinRequestNotFoundMessage(String teamName) {
+    return Component.text("❌ Активная заявка в команду ", NamedTextColor.RED)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" не найдена.", NamedTextColor.RED));
+  }
+
+  /** Сообщение для лидера о том, что заявка не найдена. */
+  public static Component joinRequestNotFoundLeaderMessage(String playerName) {
+    return Component.text("❌ Заявка от игрока ", NamedTextColor.RED)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" не найдена.", NamedTextColor.RED));
+  }
+
+  /** Сообщает лидеру, что игрок не в сети для утверждения заявки. */
+  public static Component joinRequestTargetOfflineMessage(String playerName) {
+    return Component.text("❌ Игрок ", NamedTextColor.RED)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" не в сети.", NamedTextColor.RED));
+  }
+
+  /** Сообщает игроку об одобрении заявки лидером. */
+  public static Component joinRequestApprovedPlayerMessage(String teamName) {
+    return Component.text("✅ Заявка в команду ", NamedTextColor.GREEN)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" одобрена!", NamedTextColor.GREEN));
+  }
+
+  /** Сообщает лидеру об успешном одобрении заявки. */
+  public static Component joinRequestApprovedLeaderMessage(String playerName, String teamName) {
+    return Component.text("✅ Вы одобрили заявку игрока ", NamedTextColor.GREEN)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" в команду ", NamedTextColor.GREEN))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(".", NamedTextColor.GREEN));
+  }
+
+  /** Сообщение игроку об отклонении заявки. */
+  public static Component joinRequestDeniedPlayerMessage(String teamName) {
+    return Component.text("❌ Заявка в команду ", NamedTextColor.RED)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" отклонена.", NamedTextColor.RED));
+  }
+
+  /** Сообщение лидеру об отклонении заявки. */
+  public static Component joinRequestDeniedLeaderMessage(
+      String playerName, String teamName, @Nullable String actorName) {
+    Component base =
+        Component.text("ℹ️ Заявка игрока ", NamedTextColor.YELLOW)
+            .append(Component.text(playerName, NamedTextColor.WHITE))
+            .append(Component.text(" в команду ", NamedTextColor.YELLOW))
+            .append(Component.text(teamName, NamedTextColor.WHITE))
+            .append(Component.text(" отклонена", NamedTextColor.YELLOW));
+    if (actorName != null && !actorName.isBlank()) {
+      base =
+          base.append(Component.text(" игроком ", NamedTextColor.YELLOW))
+              .append(Component.text(actorName, NamedTextColor.WHITE));
+    }
+    return base.append(Component.text(".", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщение игроку об отзыве собственной заявки. */
+  public static Component joinRequestCancelledPlayerMessage(String teamName) {
+    return Component.text("ℹ️ Заявка в команду ", NamedTextColor.YELLOW)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" отозвана.", NamedTextColor.YELLOW));
+  }
+
+  /** Уведомляет лидера об отзыве заявки игроком. */
+  public static Component joinRequestCancelledLeaderMessage(
+      String playerName, @Nullable String actorName) {
+    String displayName = actorName != null ? actorName : playerName;
+    return Component.text("ℹ️ Игрок ", NamedTextColor.YELLOW)
+        .append(Component.text(displayName, NamedTextColor.WHITE))
+        .append(Component.text(" отозвал свою заявку.", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщение игроку о том, что заявка истекла или команда распущена. */
+  public static Component joinRequestExpiredPlayerMessage(String teamName) {
+    return Component.text("ℹ️ Заявка в команду ", NamedTextColor.YELLOW)
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" больше не действует.", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщение лидеру об автоматическом удалении заявки. */
+  public static Component joinRequestExpiredLeaderMessage(String playerName, String teamName) {
+    return Component.text("ℹ️ Заявка игрока ", NamedTextColor.YELLOW)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" в команду ", NamedTextColor.YELLOW))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" истекла.", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщает лидеру, что заявка очищена автоматически после вступления. */
+  public static Component joinRequestAutoClearedLeaderMessage(String playerName, String teamName) {
+    return Component.text("ℹ️ Заявка игрока ", NamedTextColor.YELLOW)
+        .append(Component.text(playerName, NamedTextColor.WHITE))
+        .append(Component.text(" в команду ", NamedTextColor.YELLOW))
+        .append(Component.text(teamName, NamedTextColor.WHITE))
+        .append(Component.text(" закрыта автоматически.", NamedTextColor.YELLOW));
+  }
+
+  /** Заголовок списка заявок для игрока. */
+  public static Component joinRequestsHeaderMessage() {
+    return Component.text("📨 Ваши заявки:", NamedTextColor.AQUA);
+  }
+
+  /** Заголовок списка заявок для лидера команды. */
+  public static Component joinRequestsTeamHeaderMessage(String teamName) {
+    return Component.text("📨 Заявки на вступление в команду ", NamedTextColor.AQUA)
+        .append(Component.text(teamName, NamedTextColor.GOLD))
+        .append(Component.text(":", NamedTextColor.AQUA));
+  }
+
+  /** Пункт списка заявок с кнопкой для отмены. */
+  public static Component joinRequestListEntry(
+      @NotNull PendingRequest request, String cancelCommand) {
+    Component entry =
+        Component.text("• ", NamedTextColor.GRAY)
+            .append(Component.text(request.getTeamName(), NamedTextColor.GOLD))
+            .append(Component.text(" (", NamedTextColor.GRAY))
+            .append(Component.text(request.getPlayerName(), NamedTextColor.WHITE))
+            .append(Component.text(")", NamedTextColor.GRAY));
+    if (request.getExpiresAt() != null) {
+      entry = entry.append(expiryInfo(request.getExpiresAt()));
+    }
+    return entry
+        .append(Component.space())
+        .append(
+            clickableAction(
+                "[Отозвать]",
+                NamedTextColor.RED,
+                cancelCommand,
+                "Отозвать заявку"));
+  }
+
+  /** Элемент списка заявок для лидера с кнопками одобрения и отказа. */
+  public static Component joinRequestTeamListEntry(
+      @NotNull PendingRequest request, String acceptCommand, String denyCommand) {
+    Component entry =
+        Component.text("• ", NamedTextColor.GRAY)
+            .append(Component.text(request.getPlayerName(), NamedTextColor.WHITE));
+    if (request.getExpiresAt() != null) {
+      entry = entry.append(expiryInfo(request.getExpiresAt()));
+    }
+    return entry
+        .append(Component.space())
+        .append(
+            clickableAction(
+                "[Одобрить]",
+                NamedTextColor.GREEN,
+                acceptCommand,
+                "Одобрить заявку"))
+        .append(Component.space())
+        .append(
+            clickableAction(
+                "[Отклонить]",
+                NamedTextColor.RED,
+                denyCommand,
+                "Отклонить заявку"));
+  }
+
+  /** Сообщение для лидера после очистки всех заявок. */
+  public static Component joinRequestsClearedLeaderMessage(int count) {
+    return Component.text("ℹ️ Очищено ", NamedTextColor.YELLOW)
+        .append(Component.text(count, NamedTextColor.WHITE))
+        .append(Component.text(" заявок.", NamedTextColor.YELLOW));
+  }
+
+  /** Сообщение об отсутствии заявок. */
+  public static Component noJoinRequestsMessage() {
+    return Component.text("ℹ️ У вас нет активных заявок.", NamedTextColor.YELLOW);
   }
 
   /**

--- a/src/test/java/org/example/listener/TeamChatListenerTest.java
+++ b/src/test/java/org/example/listener/TeamChatListenerTest.java
@@ -502,6 +502,39 @@ class TeamChatListenerTest extends MockBukkitTestBase {
     }
 
     @Override
+    public void submitJoinRequest(String teamName, org.bukkit.entity.Player player) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void cancelJoinRequest(String teamName, org.bukkit.entity.Player player) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public java.util.List<org.example.model.PendingRequest> listJoinRequests(String teamName) {
+      return java.util.List.of();
+    }
+
+    @Override
+    public java.util.List<org.example.model.PendingRequest> getJoinRequestsForPlayer(
+        java.util.UUID playerId) {
+      return java.util.List.of();
+    }
+
+    @Override
+    public void approveJoinRequest(
+        String teamName, org.bukkit.entity.Player leader, String targetName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void denyJoinRequest(
+        String teamName, org.bukkit.entity.Player leader, String targetName) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void requestToJoinTeam(String teamName, org.bukkit.entity.Player player) {
       throw new UnsupportedOperationException();
     }

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.example.MockBukkitTestBase;
@@ -494,19 +495,19 @@ class MembershipServiceTest extends MockBukkitTestBase {
   }
 
   @Test
-  void requestToJoinTeamStoresPendingRequest() {
+  void submitJoinRequestStoresPendingRequest() {
     PlayerMock leader = server.addPlayer("JoinLeader");
     membership.createTeam("JoinTeam", "JT", "red", leader);
     drainMessages(leader);
 
     PlayerMock applicant = server.addPlayer("JoinApplicant");
-    membership.requestToJoinTeam("JoinTeam", applicant);
+    membership.submitJoinRequest("JoinTeam", applicant);
 
     assertTrue(
         membership.hasPendingJoinRequest("JoinTeam", applicant.getUniqueId()),
         "Заявка должна быть сохранена");
     assertEquals(
-        TeamMessageUtils.joinRequestSentMessage("JoinTeam"),
+        TeamMessageUtils.joinRequestSentPlayerMessage("JoinTeam"),
         applicant.nextComponentMessage(),
         "Игрок получает уведомление о заявке");
     assertEquals(
@@ -516,18 +517,18 @@ class MembershipServiceTest extends MockBukkitTestBase {
   }
 
   @Test
-  void requestToJoinTeamPreventsDuplicateRequests() {
+  void submitJoinRequestPreventsDuplicateRequests() {
     PlayerMock leader = server.addPlayer("JoinLeaderDup");
     membership.createTeam("JoinDup", "JD", "red", leader);
     drainMessages(leader);
 
     PlayerMock applicant = server.addPlayer("JoinApplicantDup");
-    membership.requestToJoinTeam("JoinDup", applicant);
+    membership.submitJoinRequest("JoinDup", applicant);
     // Сбрасываем сообщения из первой заявки
     applicant.nextComponentMessage();
     leader.nextComponentMessage();
 
-    membership.requestToJoinTeam("JoinDup", applicant);
+    membership.submitJoinRequest("JoinDup", applicant);
 
     assertTrue(
         membership.hasPendingJoinRequest("JoinDup", applicant.getUniqueId()),
@@ -536,6 +537,68 @@ class MembershipServiceTest extends MockBukkitTestBase {
         TeamMessageUtils.joinRequestAlreadySentMessage("JoinDup"),
         applicant.nextComponentMessage(),
         "Игрок информируется о повторной заявке");
+  }
+
+  @Test
+  void approveJoinRequestAddsPlayerAndNotifies() {
+    PlayerMock leader = server.addPlayer("JoinLeaderApprove");
+    membership.createTeam("ApproveTeam", "AT", "red", leader);
+    drainMessages(leader);
+
+    PlayerMock applicant = server.addPlayer("JoinApplicantApprove");
+    membership.submitJoinRequest("ApproveTeam", applicant);
+    applicant.nextComponentMessage();
+    leader.nextComponentMessage();
+
+    membership.approveJoinRequest("ApproveTeam", leader, applicant.getName());
+
+    Team team = storage.getTeamByName("ApproveTeam");
+    assertNotNull(team);
+    assertTrue(team.hasMember(applicant.getUniqueId()), "Игрок становится участником");
+    assertFalse(
+        membership.hasPendingJoinRequest("ApproveTeam", applicant.getUniqueId()),
+        "Заявка удаляется после одобрения");
+
+    assertEquals(
+        TeamMessageUtils.joinRequestApprovedPlayerMessage("ApproveTeam"),
+        applicant.nextComponentMessage(),
+        "Игрок получает уведомление об одобрении");
+    assertEquals(
+        Component.text("✅ Вы вступили в команду", NamedTextColor.GREEN),
+        applicant.nextComponentMessage(),
+        "Игрок получает стандартное сообщение о вступлении");
+    assertEquals(
+        TeamMessageUtils.joinRequestApprovedLeaderMessage(
+            applicant.getName(), "ApproveTeam"),
+        leader.nextComponentMessage(),
+        "Лидер получает подтверждение об одобрении");
+  }
+
+  @Test
+  void denyJoinRequestNotifiesBothSides() {
+    PlayerMock leader = server.addPlayer("JoinLeaderDeny");
+    membership.createTeam("DenyTeam", "DT", "red", leader);
+    drainMessages(leader);
+
+    PlayerMock applicant = server.addPlayer("JoinApplicantDeny");
+    membership.submitJoinRequest("DenyTeam", applicant);
+    applicant.nextComponentMessage();
+    leader.nextComponentMessage();
+
+    membership.denyJoinRequest("DenyTeam", leader, applicant.getName());
+
+    assertFalse(
+        membership.hasPendingJoinRequest("DenyTeam", applicant.getUniqueId()),
+        "Заявка удаляется после отказа");
+    assertEquals(
+        TeamMessageUtils.joinRequestDeniedPlayerMessage("DenyTeam"),
+        applicant.nextComponentMessage(),
+        "Игроку сообщают об отказе");
+    assertEquals(
+        TeamMessageUtils.joinRequestDeniedLeaderMessage(
+            applicant.getName(), "DenyTeam", leader.getName()),
+        leader.nextComponentMessage(),
+        "Лидер получает подтверждение об отказе");
   }
 
   private void drainMessages(PlayerMock player) {

--- a/src/test/java/org/example/service/TeamManagerTest.java
+++ b/src/test/java/org/example/service/TeamManagerTest.java
@@ -78,6 +78,24 @@ class TeamManagerTest extends MockBukkitTestBase {
 
       manager.updatePlayerPrefixes("Alpha");
       verify(membership).updatePlayerPrefixes("Alpha");
+
+      manager.submitJoinRequest("Alpha", member);
+      verify(membership).submitJoinRequest("Alpha", member);
+
+      manager.cancelJoinRequest("Alpha", member);
+      verify(membership).cancelJoinRequest("Alpha", member);
+
+      manager.listJoinRequests("Alpha");
+      verify(membership).listJoinRequests("Alpha");
+
+      manager.getJoinRequestsForPlayer(member.getUniqueId());
+      verify(membership).getJoinRequestsForPlayer(member.getUniqueId());
+
+      manager.approveJoinRequest("Alpha", leader, member.getName());
+      verify(membership).approveJoinRequest("Alpha", leader, member.getName());
+
+      manager.denyJoinRequest("Alpha", leader, member.getName());
+      verify(membership).denyJoinRequest("Alpha", leader, member.getName());
     }
   }
 


### PR DESCRIPTION
## Summary
- add dedicated PendingRequest model and track join requests in MembershipService with new lifecycle operations
- expose join request APIs through TeamService/TeamManager and add player/admin commands and messaging for managing requests
- expand unit tests to cover join request submission, approval, denial, and delegation

## Testing
- ./gradlew test --console=plain --stacktrace

------
https://chatgpt.com/codex/tasks/task_e_68f789518b4c832eae4b062d8545dff3