### PR TITLE
Refresh pending invites and requests on team rename

### DIFF
--- a/src/main/java/org/example/model/PendingRequest.java
+++ b/src/main/java/org/example/model/PendingRequest.java
@@ -29,6 +29,21 @@ public final class PendingRequest {
     this.expiresAt = expiresAt;
   }
 
+  private PendingRequest(
+      @NotNull UUID teamId,
+      @NotNull UUID playerId,
+      @NotNull String teamName,
+      @NotNull String playerName,
+      long createdAt,
+      @Nullable Long expiresAt) {
+    this.teamId = teamId;
+    this.playerId = playerId;
+    this.teamName = teamName;
+    this.playerName = playerName;
+    this.createdAt = createdAt;
+    this.expiresAt = expiresAt;
+  }
+
   public @NotNull UUID getTeamId() {
     return teamId;
   }
@@ -55,5 +70,10 @@ public final class PendingRequest {
 
   public boolean isExpired() {
     return expiresAt != null && expiresAt <= System.currentTimeMillis();
+  }
+
+  public PendingRequest withTeamName(@NotNull String updatedTeamName) {
+    return new PendingRequest(
+        teamId, playerId, updatedTeamName, playerName, createdAt, expiresAt);
   }
 }

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -811,6 +811,8 @@ public class MembershipService {
           team.getMembers(),
           TeamMessageUtils.teamRenamedMemberMessage(previousName, team.getName()),
           leader.getUniqueId());
+      refreshPendingInvitesForRenamedTeam(team);
+      refreshPendingRequestsForRenamedTeam(team);
     }
     return RenameResult.SUCCESS;
   }
@@ -1158,6 +1160,67 @@ public class MembershipService {
             playerInvites.remove(teamId);
             return playerInvites.isEmpty() ? null : playerInvites;
           });
+    }
+  }
+
+  private void refreshPendingInvitesForRenamedTeam(@NotNull Team team) {
+    Map<UUID, PendingInvite> invites = invitesByTeam.get(team.getId());
+    if (invites == null || invites.isEmpty()) {
+      return;
+    }
+
+    List<PendingInvite> existingInvites = new ArrayList<>(invites.values());
+    invitesByTeam.put(team.getId(), new ConcurrentHashMap<>());
+    for (PendingInvite invite : existingInvites) {
+      invitesByPlayer.computeIfPresent(
+          invite.getTargetPlayerId(),
+          (playerId, playerInvites) -> {
+            playerInvites.remove(team.getId());
+            return playerInvites.isEmpty() ? null : playerInvites;
+          });
+    }
+
+    for (PendingInvite invite : existingInvites) {
+      PendingInvite updatedInvite = invite.withUpdatedNames(team.getName(), invite.getTargetName());
+      storeInvite(updatedInvite);
+      Player target = plugin.getServer().getPlayer(updatedInvite.getTargetPlayerId());
+      if (target != null) {
+        String acceptCommand = "/team accept " + updatedInvite.getTeamName();
+        String declineCommand = "/team decline " + updatedInvite.getTeamName();
+        TeamMessageUtils.sendTeamMessage(
+            target,
+            TeamMessageUtils.inviteReceivedMessage(
+                updatedInvite.getTeamName(),
+                updatedInvite.getInviterName(),
+                updatedInvite.getExpiresAt(),
+                acceptCommand,
+                declineCommand));
+        TeamMessageUtils.sendTeamMessage(
+            target,
+            TeamMessageUtils.inviteListEntry(updatedInvite, acceptCommand, declineCommand));
+      }
+    }
+  }
+
+  private void refreshPendingRequestsForRenamedTeam(@NotNull Team team) {
+    Map<UUID, PendingRequest> requests = joinRequestsByTeam.get(team.getId());
+    if (requests == null || requests.isEmpty()) {
+      return;
+    }
+
+    List<PendingRequest> existingRequests = new ArrayList<>(requests.values());
+    joinRequestsByTeam.put(team.getId(), new ConcurrentHashMap<>());
+    for (PendingRequest request : existingRequests) {
+      joinRequestsByPlayer.computeIfPresent(
+          request.getPlayerId(),
+          (playerId, playerRequests) -> {
+            playerRequests.remove(team.getId());
+            return playerRequests.isEmpty() ? null : playerRequests;
+          });
+    }
+
+    for (PendingRequest request : existingRequests) {
+      storeJoinRequest(request.withTeamName(team.getName()));
     }
   }
 

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -16,7 +16,9 @@ import org.example.MockBukkitTestBase;
 import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
 import org.example.model.PendingInvite;
+import org.example.model.PendingRequest;
 import org.example.model.Team;
+import org.example.service.RenameResult;
 import org.example.util.TeamMessageUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -599,6 +601,78 @@ class MembershipServiceTest extends MockBukkitTestBase {
             applicant.getName(), "DenyTeam", leader.getName()),
         leader.nextComponentMessage(),
         "Лидер получает подтверждение об отказе");
+  }
+
+  @Test
+  void renameTeamRefreshesPendingInvitesAndRequests() {
+    when(pluginConfig.getJoinMode()).thenReturn(JoinMode.INVITE_ONLY);
+    PlayerMock leader = server.addPlayer("RenameLeader");
+    membership.createTeam("OldName", "ON", "red", leader);
+
+    PlayerMock invitee = server.addPlayer("RenameInvitee");
+    PlayerMock applicant = server.addPlayer("RenameApplicant");
+
+    drainMessages(leader);
+    drainMessages(invitee);
+    drainMessages(applicant);
+
+    membership.sendInvite(leader, invitee, Duration.ofMinutes(5));
+    membership.submitJoinRequest("OldName", applicant);
+
+    drainMessages(invitee);
+    drainMessages(applicant);
+    drainMessages(leader);
+
+    RenameResult result = membership.renameTeam("OldName", "NewName", leader);
+    assertEquals(RenameResult.SUCCESS, result, "Переименование должно успешно завершиться");
+
+    List<PendingInvite> invites = membership.getInvitesForPlayer(invitee.getUniqueId());
+    assertEquals(1, invites.size(), "Приглашение должно сохраняться после переименования");
+    assertEquals("NewName", invites.get(0).getTeamName(), "Приглашение обновляется новым именем");
+
+    List<PendingRequest> requests = membership.getJoinRequestsForPlayer(applicant.getUniqueId());
+    assertEquals(1, requests.size(), "Заявка должна сохраняться после переименования");
+    assertEquals("NewName", requests.get(0).getTeamName(), "Заявка обновляется новым именем");
+
+    Component renameNotification = invitee.nextComponentMessage();
+    assertNotNull(
+        renameNotification, "Игрок должен получить повторное уведомление о приглашении");
+    String renameNotificationPlain =
+        PlainTextComponentSerializer.plainText().serialize(renameNotification);
+    assertTrue(
+        renameNotificationPlain.contains("NewName"),
+        "Повторное уведомление содержит новое имя команды");
+
+    Component renameListEntry = invitee.nextComponentMessage();
+    assertNotNull(renameListEntry, "Игрок получает обновлённую запись в списке приглашений");
+    String renameListEntryPlain =
+        PlainTextComponentSerializer.plainText().serialize(renameListEntry);
+    assertTrue(
+        renameListEntryPlain.contains("NewName"),
+        "Список приглашений отображает новое имя команды");
+
+    membership.acceptInvite(invitee, "NewName");
+    Team renamedTeam = storage.getTeamByName("NewName");
+    assertNotNull(renamedTeam, "Команда должна существовать после переименования");
+    assertTrue(
+        renamedTeam.hasMember(invitee.getUniqueId()),
+        "Игрок должен принять приглашение по новому имени");
+
+    invitee.nextComponentMessage();
+    assertEquals(
+        TeamMessageUtils.inviteAcceptedMessage("NewName"),
+        invitee.nextComponentMessage(),
+        "Игрок получает подтверждение с новым именем команды");
+
+    membership.cancelJoinRequest("NewName", applicant);
+    Component cancellationMessage = applicant.nextComponentMessage();
+    assertEquals(
+        TeamMessageUtils.joinRequestCancelledPlayerMessage("NewName"),
+        cancellationMessage,
+        "Отмена заявки использует новое имя команды");
+    assertFalse(
+        membership.hasPendingJoinRequest("NewName", applicant.getUniqueId()),
+        "Заявка удаляется после отмены по новому имени");
   }
 
   private void drainMessages(PlayerMock player) {


### PR DESCRIPTION
## Summary
- refresh pending invites and join requests after a team is renamed so messages and commands use the new name
- add helpers that rebuild invite/request caches and notify online players with updated commands
- extend membership service tests to cover accepting invites and cancelling requests after renaming a team

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_69046233e1a0832e891f48758c8d7e84