### PR TITLE
Add uninvite subcommand and tests for invite revocation

### DIFF
--- a/src/main/java/org/example/command/TeamCommand.java
+++ b/src/main/java/org/example/command/TeamCommand.java
@@ -27,6 +27,7 @@ import org.example.command.sub.InviteSubCommand;
 import org.example.command.sub.InvitesSubCommand;
 import org.example.command.sub.RequestSubCommand;
 import org.example.command.sub.RequestsSubCommand;
+import org.example.command.sub.UninviteSubCommand;
 import org.example.command.sub.SubCommand;
 import org.example.config.PluginConfig;
 import org.example.config.JoinMode;
@@ -41,7 +42,7 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
   private final PluginConfig pluginConfig;
   private final Map<String, SubCommand> subCommands = new LinkedHashMap<>();
   private static final Set<String> INVITE_ONLY_SUB_COMMANDS =
-      Set.of("invite", "invites", "accept", "decline");
+      Set.of("invite", "invites", "accept", "decline", "uninvite");
   private static final Set<String> REQUEST_ONLY_SUB_COMMANDS =
       Set.of("request", "cancelrequest", "requests");
 
@@ -59,6 +60,7 @@ public class TeamCommand implements org.bukkit.command.CommandExecutor, TabCompl
     subCommands.put("members", new MembersSubCommand(teamManager, pluginConfig));
     subCommands.put("invite", new InviteSubCommand(teamManager));
     subCommands.put("invites", new InvitesSubCommand(teamManager));
+    subCommands.put("uninvite", new UninviteSubCommand(teamManager));
     subCommands.put("accept", new AcceptInviteSubCommand(teamManager));
     subCommands.put("decline", new DeclineInviteSubCommand(teamManager));
     subCommands.put("request", new RequestSubCommand(teamManager));

--- a/src/main/java/org/example/command/sub/HelpSubCommand.java
+++ b/src/main/java/org/example/command/sub/HelpSubCommand.java
@@ -26,7 +26,8 @@ public class HelpSubCommand implements SubCommand {
             Component.empty(),
             sectionHeading("Управление командой"),
             bullet("/team list", "показать список всех команд"),
-            bullet("/team members", "показать участников вашей команды"));
+            bullet("/team members", "показать участников вашей команды"),
+            bullet("/team uninvite <игрок>", "отозвать активное приглашение"));
 
     player.sendMessage(helpMessage);
     return true;

--- a/src/main/java/org/example/command/sub/UninviteSubCommand.java
+++ b/src/main/java/org/example/command/sub/UninviteSubCommand.java
@@ -1,0 +1,82 @@
+package org.example.command.sub;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.example.config.JoinMode;
+import org.example.service.TeamService;
+import org.example.util.TeamMessageUtils;
+import org.jetbrains.annotations.NotNull;
+
+/** Подкоманда /team uninvite. */
+public class UninviteSubCommand implements SubCommand {
+
+  private final TeamService teamService;
+
+  public UninviteSubCommand(@NotNull TeamService teamService) {
+    this.teamService = teamService;
+  }
+
+  @Override
+  public boolean execute(@NotNull Player player, @NotNull String[] args) {
+    if (teamService.getJoinMode() != JoinMode.INVITE_ONLY) {
+      TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesDisabledMessage());
+      return true;
+    }
+    if (args.length < 2) {
+      player.sendMessage(
+          Component.text("❌ Использование: /team uninvite <игрок>", NamedTextColor.RED));
+      return true;
+    }
+    String targetName = args[1];
+    teamService.revokeInvite(player, targetName);
+    return true;
+  }
+
+  @Override
+  public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String[] args) {
+    List<String> suggestions = new ArrayList<>();
+    if (!(sender instanceof Player player)) {
+      return suggestions;
+    }
+    if (teamService.getJoinMode() != JoinMode.INVITE_ONLY) {
+      return suggestions;
+    }
+    if (args.length == 2) {
+      String partial = args[1].toLowerCase(Locale.ROOT);
+      Set<String> invited =
+          teamService.getRevocableInviteTargets(player).stream()
+              .filter(name -> name != null && !name.isBlank())
+              .map(name -> name.toLowerCase(Locale.ROOT))
+              .collect(Collectors.toCollection(LinkedHashSet::new));
+      if (invited.isEmpty()) {
+        return suggestions;
+      }
+      teamService
+          .getPlugin()
+          .getServer()
+          .getOnlinePlayers()
+          .stream()
+          .filter(online -> !online.getUniqueId().equals(player.getUniqueId()))
+          .forEach(
+              online -> {
+                String name = online.getName();
+                if (name == null) {
+                  return;
+                }
+                String lower = name.toLowerCase(Locale.ROOT);
+                if (lower.startsWith(partial) && invited.contains(lower)) {
+                  suggestions.add(name);
+                }
+              });
+    }
+    return suggestions;
+  }
+}

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -443,6 +443,40 @@ public class MembershipService {
             invite.getInviterName(), invite.getTargetName(), invite.getTeamName()));
   }
 
+  public @NotNull List<String> getRevocableInviteTargets(@NotNull Player leader) {
+    if (pluginConfig.getJoinMode() != JoinMode.INVITE_ONLY) {
+      return List.of();
+    }
+    UUID leaderId = leader.getUniqueId();
+    UUID teamId = storage.getPlayerTeams().get(leaderId);
+    if (teamId == null) {
+      return List.of();
+    }
+    Team team = storage.getTeams().get(teamId);
+    if (team == null || !team.isLeader(leaderId)) {
+      return List.of();
+    }
+    Map<UUID, PendingInvite> invites = invitesByTeam.get(teamId);
+    if (invites == null || invites.isEmpty()) {
+      return List.of();
+    }
+    List<PendingInvite> expired = new ArrayList<>();
+    List<String> names = new ArrayList<>();
+    for (PendingInvite invite : invites.values()) {
+      if (invite.isExpired()) {
+        expired.add(invite);
+        continue;
+      }
+      String storedName = invite.getTargetName();
+      String resolvedName = resolvePlayerName(invite.getTargetPlayerId(), storedName);
+      names.add(resolvedName != null ? resolvedName : storedName);
+    }
+    for (PendingInvite invite : expired) {
+      removeInvite(invite.getTeamId(), invite.getTargetPlayerId());
+    }
+    return names;
+  }
+
   public void acceptInvite(@NotNull Player player, @NotNull String teamName) {
     if (pluginConfig.getJoinMode() != JoinMode.INVITE_ONLY) {
       TeamMessageUtils.sendTeamMessage(player, TeamMessageUtils.invitesDisabledMessage());

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -185,6 +185,12 @@ public class TeamManager implements TeamService {
   }
 
   @Override
+  public @NotNull List<String> getRevocableInviteTargets(@NotNull Player leader) {
+    return runWithTiming(
+        "getRevocableInviteTargets", () -> membership.getRevocableInviteTargets(leader));
+  }
+
+  @Override
   public void acceptInvite(@NotNull Player player, @NotNull String teamName) {
     runWithTiming("acceptInvite", () -> membership.acceptInvite(player, teamName));
   }

--- a/src/main/java/org/example/service/TeamService.java
+++ b/src/main/java/org/example/service/TeamService.java
@@ -240,6 +240,16 @@ public interface TeamService {
   void revokeInvite(@NotNull Player leader, @NotNull String targetName);
 
   /**
+   * Возвращает список игроков, приглашения которых лидер может отозвать.
+   *
+   * @param leader лидер команды
+   * @return список имён игроков
+   */
+  default @NotNull List<String> getRevocableInviteTargets(@NotNull Player leader) {
+    return List.of();
+  }
+
+  /**
    * Принимает приглашение в указанную команду.
    *
    * @param player игрок, принимающий приглашение

--- a/src/test/java/org/example/command/TeamCommandTest.java
+++ b/src/test/java/org/example/command/TeamCommandTest.java
@@ -29,6 +29,7 @@ import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.scoreboard.Scoreboard;
 import org.example.MyPurpurPlugin;
+import org.example.config.JoinMode;
 import org.example.config.PluginConfig;
 import org.example.service.DeadlineScheduler;
 import org.example.service.TeamManager;
@@ -176,6 +177,62 @@ class TeamCommandTest {
     assertNotNull(playerListName, "Tab name should not be null");
     String playerListPlain = PlainTextComponentSerializer.plainText().serialize(playerListName);
     assertEquals("[AA] Leader", playerListPlain);
+  }
+
+  @Test
+  void leaderCanRevokeInviteAndSendItAgain() {
+    CommandMap commandMap = server.getCommandMap();
+    config.set(PluginConfig.Keys.Team.Membership.JOIN_MODE, JoinMode.INVITE_ONLY.name());
+
+    PlayerMock leader = server.addPlayer("InviteLeader");
+    leader.addAttachment(plugin, "mypurpurplugin.team", true);
+    PlayerMock recruit = server.addPlayer("InviteRecruit");
+    recruit.addAttachment(plugin, "mypurpurplugin.team", true);
+
+    assertTrue(commandMap.dispatch(leader, "team create Echo EE GREEN"));
+    drainMessages(leader);
+    drainMessages(recruit);
+
+    assertTrue(commandMap.dispatch(leader, "team invite InviteRecruit"));
+    Component firstLeaderMessage = leader.nextComponentMessage();
+    assertNotNull(firstLeaderMessage, "Leader should receive confirmation about the invite");
+    String firstLeaderPlain =
+        PlainTextComponentSerializer.plainText().serialize(firstLeaderMessage);
+    assertTrue(
+        firstLeaderPlain.contains("Приглашение отправлено"),
+        "Leader should be notified that the invite was sent");
+
+    Component inviteForRecruit = recruit.nextComponentMessage();
+    assertNotNull(inviteForRecruit, "Recruit should receive the invite message");
+    String invitePlain = PlainTextComponentSerializer.plainText().serialize(inviteForRecruit);
+    assertTrue(invitePlain.contains("Вас пригласили"));
+
+    assertTrue(commandMap.dispatch(leader, "team uninvite InviteRecruit"));
+    Component revokeLeaderMessage = leader.nextComponentMessage();
+    assertNotNull(revokeLeaderMessage, "Leader should receive confirmation about revocation");
+    String revokeLeaderPlain =
+        PlainTextComponentSerializer.plainText().serialize(revokeLeaderMessage);
+    assertTrue(revokeLeaderPlain.contains("отозвано"));
+
+    Component revokeRecruitMessage = recruit.nextComponentMessage();
+    assertNotNull(revokeRecruitMessage, "Recruit should learn the invite was revoked");
+    String revokeRecruitPlain =
+        PlainTextComponentSerializer.plainText().serialize(revokeRecruitMessage);
+    assertTrue(revokeRecruitPlain.contains("отозвано"));
+
+    assertTrue(commandMap.dispatch(leader, "team invite InviteRecruit"));
+    Component secondLeaderMessage = leader.nextComponentMessage();
+    assertNotNull(secondLeaderMessage, "Leader should be able to send another invite");
+    String secondLeaderPlain =
+        PlainTextComponentSerializer.plainText().serialize(secondLeaderMessage);
+    assertTrue(
+        secondLeaderPlain.contains("Приглашение отправлено"),
+        "The second invite should also report a successful send");
+
+    Component secondInvite = recruit.nextComponentMessage();
+    assertNotNull(secondInvite, "Recruit should receive the renewed invite");
+    String secondInvitePlain = PlainTextComponentSerializer.plainText().serialize(secondInvite);
+    assertTrue(secondInvitePlain.contains("Вас пригласили"));
   }
 
   @Test
@@ -609,5 +666,9 @@ class TeamCommandTest {
         "Из вашей команды удалено 2 участника(ов) из-за превышения лимита.",
         serializer.serialize(forcedMessage));
     assertNull(leader.nextComponentMessage());
+  }
+
+  private void drainMessages(PlayerMock player) {
+    while (player.nextComponentMessage() != null) {}
   }
 }


### PR DESCRIPTION
## Summary
- add an /team uninvite subcommand for invite-only servers, including player suggestions and usage messaging
- expose revocable invite lookups through the team service so tab completion can filter to pending invites
- document the new command in /team help and add an integration test covering invite revoke/resend flows

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_69046e3f3aa4832e90f85c5a57daea60