### PR TITLE
Clear pending join requests when players join a team

### DIFF
--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -104,6 +104,7 @@ public class MembershipService {
     team.addMember(player.getUniqueId());
     storage.assignPlayerToTeam(player.getUniqueId(), team);
     clearInvitesForPlayer(player.getUniqueId());
+    clearJoinRequestsForPlayer(player.getUniqueId(), team.getLeaderId());
     removeJoinRequest(
         team.getId(),
         player.getUniqueId(),
@@ -990,6 +991,25 @@ public class MembershipService {
     }
     notifyJoinRequestRemoval(request, cause, actorName, actorId, team);
     return request;
+  }
+
+  private void clearJoinRequestsForPlayer(@NotNull UUID playerId, @Nullable UUID actorId) {
+    Map<UUID, PendingRequest> requests = joinRequestsByPlayer.remove(playerId);
+    if (requests == null || requests.isEmpty()) {
+      return;
+    }
+    for (PendingRequest request : requests.values()) {
+      Map<UUID, PendingRequest> byTeam = joinRequestsByTeam.get(request.getTeamId());
+      if (byTeam != null) {
+        byTeam.remove(playerId);
+        if (byTeam.isEmpty()) {
+          joinRequestsByTeam.remove(request.getTeamId());
+        }
+      }
+      Team requestTeam = storage.getTeams().get(request.getTeamId());
+      notifyJoinRequestRemoval(
+          request, JoinRequestRemovalCause.JOINED, null, actorId, requestTeam);
+    }
   }
 
   private void clearJoinRequests(

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -675,6 +675,54 @@ class MembershipServiceTest extends MockBukkitTestBase {
         "Заявка удаляется после отмены по новому имени");
   }
 
+  @Test
+  void joiningTeamClearsOtherPendingJoinRequests() {
+    PlayerMock leaderOne = server.addPlayer("JoinLeaderOne");
+    PlayerMock leaderTwo = server.addPlayer("JoinLeaderTwo");
+    membership.createTeam("FirstTeam", "F1", "red", leaderOne);
+    membership.createTeam("SecondTeam", "S2", "blue", leaderTwo);
+
+    PlayerMock applicant = server.addPlayer("JoinMultiple");
+
+    drainMessages(leaderOne);
+    drainMessages(leaderTwo);
+    drainMessages(applicant);
+
+    membership.submitJoinRequest("FirstTeam", applicant);
+    applicant.nextComponentMessage();
+    leaderOne.nextComponentMessage();
+
+    membership.submitJoinRequest("SecondTeam", applicant);
+    applicant.nextComponentMessage();
+    leaderTwo.nextComponentMessage();
+
+    assertEquals(
+        2,
+        membership.getJoinRequestsForPlayer(applicant.getUniqueId()).size(),
+        "Игрок должен иметь две активные заявки");
+
+    membership.addPlayerToTeam("FirstTeam", applicant);
+
+    Team firstTeam = storage.getTeamByName("FirstTeam");
+    assertNotNull(firstTeam, "Команда должна существовать после вступления");
+    assertTrue(
+        firstTeam.hasMember(applicant.getUniqueId()),
+        "Игрок должен стать участником выбранной команды");
+
+    assertTrue(
+        membership.listJoinRequests("SecondTeam").isEmpty(),
+        "Заявка в другую команду должна удаляться после вступления");
+    assertTrue(
+        membership.getJoinRequestsForPlayer(applicant.getUniqueId()).isEmpty(),
+        "У игрока не должно оставаться заявок после вступления");
+
+    assertEquals(
+        TeamMessageUtils.joinRequestAutoClearedLeaderMessage(
+            applicant.getName(), "SecondTeam"),
+        leaderTwo.nextComponentMessage(),
+        "Лидер второй команды получает уведомление об очистке заявки");
+  }
+
   private void drainMessages(PlayerMock player) {
     Component message;
     do {


### PR DESCRIPTION
## Summary
- add a helper to clear a player's outstanding join requests when they join a team
- invoke the helper during team joins to notify other leaders their requests were cleared
- cover the scenario with a unit test ensuring other join requests are removed

## Testing
- ./gradlew test --console=plain


------
https://chatgpt.com/codex/tasks/task_e_690495f40aa0832e84a889517a3ab139