### PR TITLE
Persist pending invites and join requests

### DIFF
--- a/src/main/java/org/example/model/PendingInvite.java
+++ b/src/main/java/org/example/model/PendingInvite.java
@@ -111,5 +111,25 @@ public final class PendingInvite {
         createdAt,
         expiresAt);
   }
+
+  public static PendingInvite restored(
+      @NotNull UUID teamId,
+      @NotNull UUID targetPlayerId,
+      @NotNull UUID inviterId,
+      @NotNull String teamName,
+      @NotNull String inviterName,
+      @NotNull String targetName,
+      long createdAt,
+      @Nullable Long expiresAt) {
+    return new PendingInvite(
+        teamId,
+        targetPlayerId,
+        inviterId,
+        teamName,
+        inviterName,
+        targetName,
+        createdAt,
+        expiresAt);
+  }
 }
 

--- a/src/main/java/org/example/model/PendingRequest.java
+++ b/src/main/java/org/example/model/PendingRequest.java
@@ -76,4 +76,14 @@ public final class PendingRequest {
     return new PendingRequest(
         teamId, playerId, updatedTeamName, playerName, createdAt, expiresAt);
   }
+
+  public static PendingRequest restored(
+      @NotNull UUID teamId,
+      @NotNull UUID playerId,
+      @NotNull String teamName,
+      @NotNull String playerName,
+      long createdAt,
+      @Nullable Long expiresAt) {
+    return new PendingRequest(teamId, playerId, teamName, playerName, createdAt, expiresAt);
+  }
 }

--- a/src/main/java/org/example/service/MembershipService.java
+++ b/src/main/java/org/example/service/MembershipService.java
@@ -44,6 +44,26 @@ public class MembershipService {
     this.scheduler = scheduler;
   }
 
+  public void loadPendingInvites(@NotNull Collection<PendingInvite> invites) {
+    invitesByPlayer.clear();
+    invitesByTeam.clear();
+    for (PendingInvite invite : invites) {
+      if (invite != null && !invite.isExpired()) {
+        storeInvite(invite, false);
+      }
+    }
+  }
+
+  public void loadPendingRequests(@NotNull Collection<PendingRequest> requests) {
+    joinRequestsByTeam.clear();
+    joinRequestsByPlayer.clear();
+    for (PendingRequest request : requests) {
+      if (request != null && !request.isExpired()) {
+        storeJoinRequest(request, false);
+      }
+    }
+  }
+
   public void createTeam(String teamName, String prefix, String color, @NotNull Player leader) {
     String normalizedTeamName = teamName == null ? "" : teamName.trim();
     String normalizedPrefix = prefix == null ? "" : prefix.trim();
@@ -913,12 +933,38 @@ public class MembershipService {
   }
 
   private void storeJoinRequest(@NotNull PendingRequest request) {
+    storeJoinRequest(request, true);
+  }
+
+  private void storeJoinRequest(@NotNull PendingRequest request, boolean persist) {
     joinRequestsByTeam
         .computeIfAbsent(request.getTeamId(), id -> new ConcurrentHashMap<>())
         .put(request.getPlayerId(), request);
     joinRequestsByPlayer
         .computeIfAbsent(request.getPlayerId(), id -> new ConcurrentHashMap<>())
         .put(request.getTeamId(), request);
+    if (persist) {
+      persistJoinRequests();
+    }
+  }
+
+  private void persistJoinRequests() {
+    storage.saveRequests(snapshotJoinRequests());
+  }
+
+  private Collection<PendingRequest> snapshotJoinRequests() {
+    if (joinRequestsByTeam.isEmpty()) {
+      return List.of();
+    }
+    List<PendingRequest> requests = new ArrayList<>();
+    for (Map<UUID, PendingRequest> teamRequests : joinRequestsByTeam.values()) {
+      for (PendingRequest request : teamRequests.values()) {
+        if (request != null && !request.isExpired()) {
+          requests.add(request);
+        }
+      }
+    }
+    return requests.isEmpty() ? List.of() : List.copyOf(requests);
   }
 
   private @Nullable PendingRequest peekJoinRequest(@NotNull UUID teamId, @NotNull UUID playerId) {
@@ -990,6 +1036,7 @@ public class MembershipService {
       team = storage.getTeams().get(teamId);
     }
     notifyJoinRequestRemoval(request, cause, actorName, actorId, team);
+    persistJoinRequests();
     return request;
   }
 
@@ -1010,6 +1057,7 @@ public class MembershipService {
       notifyJoinRequestRemoval(
           request, JoinRequestRemovalCause.JOINED, null, actorId, requestTeam);
     }
+    persistJoinRequests();
   }
 
   private void clearJoinRequests(
@@ -1029,6 +1077,7 @@ public class MembershipService {
           });
       notifyJoinRequestRemoval(request, cause, actorName, team.getLeaderId(), team);
     }
+    persistJoinRequests();
   }
 
   private void notifyJoinRequestRemoval(
@@ -1164,27 +1213,60 @@ public class MembershipService {
   }
 
   private void storeInvite(@NotNull PendingInvite invite) {
+    storeInvite(invite, true);
+  }
+
+  private void storeInvite(@NotNull PendingInvite invite, boolean persist) {
     invitesByPlayer
         .computeIfAbsent(invite.getTargetPlayerId(), id -> new ConcurrentHashMap<>())
         .put(invite.getTeamId(), invite);
     invitesByTeam
         .computeIfAbsent(invite.getTeamId(), id -> new ConcurrentHashMap<>())
         .put(invite.getTargetPlayerId(), invite);
+    if (persist) {
+      persistInvites();
+    }
   }
 
-  private void removeInvite(@NotNull UUID teamId, @NotNull UUID playerId) {
-    invitesByPlayer.computeIfPresent(
-        playerId,
-        (id, invites) -> {
-          invites.remove(teamId);
-          return invites.isEmpty() ? null : invites;
-        });
-    invitesByTeam.computeIfPresent(
-        teamId,
-        (id, invites) -> {
-          invites.remove(playerId);
-          return invites.isEmpty() ? null : invites;
-        });
+  private void persistInvites() {
+    storage.saveInvites(snapshotInvites());
+  }
+
+  private Collection<PendingInvite> snapshotInvites() {
+    if (invitesByTeam.isEmpty()) {
+      return List.of();
+    }
+    List<PendingInvite> invites = new ArrayList<>();
+    for (Map<UUID, PendingInvite> teamInvites : invitesByTeam.values()) {
+      for (PendingInvite invite : teamInvites.values()) {
+        if (invite != null && !invite.isExpired()) {
+          invites.add(invite);
+        }
+      }
+    }
+    return invites.isEmpty() ? List.of() : List.copyOf(invites);
+  }
+
+  private boolean removeInvite(@NotNull UUID teamId, @NotNull UUID playerId) {
+    boolean changed = false;
+    Map<UUID, PendingInvite> byPlayer = invitesByPlayer.get(playerId);
+    if (byPlayer != null) {
+      changed = byPlayer.remove(teamId) != null || changed;
+      if (byPlayer.isEmpty()) {
+        invitesByPlayer.remove(playerId);
+      }
+    }
+    Map<UUID, PendingInvite> byTeam = invitesByTeam.get(teamId);
+    if (byTeam != null) {
+      changed = byTeam.remove(playerId) != null || changed;
+      if (byTeam.isEmpty()) {
+        invitesByTeam.remove(teamId);
+      }
+    }
+    if (changed) {
+      persistInvites();
+    }
+    return changed;
   }
 
   private void clearInvitesForPlayer(@NotNull UUID playerId) {
@@ -1193,13 +1275,15 @@ public class MembershipService {
       return;
     }
     for (PendingInvite invite : invites.values()) {
-      invitesByTeam.computeIfPresent(
-          invite.getTeamId(),
-          (id, teamInvites) -> {
-            teamInvites.remove(playerId);
-            return teamInvites.isEmpty() ? null : teamInvites;
-          });
+      Map<UUID, PendingInvite> teamInvites = invitesByTeam.get(invite.getTeamId());
+      if (teamInvites != null) {
+        teamInvites.remove(playerId);
+        if (teamInvites.isEmpty()) {
+          invitesByTeam.remove(invite.getTeamId());
+        }
+      }
     }
+    persistInvites();
   }
 
   private void clearInvitesForTeam(@NotNull UUID teamId) {
@@ -1208,13 +1292,15 @@ public class MembershipService {
       return;
     }
     for (PendingInvite invite : invites.values()) {
-      invitesByPlayer.computeIfPresent(
-          invite.getTargetPlayerId(),
-          (id, playerInvites) -> {
-            playerInvites.remove(teamId);
-            return playerInvites.isEmpty() ? null : playerInvites;
-          });
+      Map<UUID, PendingInvite> playerInvites = invitesByPlayer.get(invite.getTargetPlayerId());
+      if (playerInvites != null) {
+        playerInvites.remove(teamId);
+        if (playerInvites.isEmpty()) {
+          invitesByPlayer.remove(invite.getTargetPlayerId());
+        }
+      }
     }
+    persistInvites();
   }
 
   private void refreshPendingInvitesForRenamedTeam(@NotNull Team team) {
@@ -1236,7 +1322,7 @@ public class MembershipService {
 
     for (PendingInvite invite : existingInvites) {
       PendingInvite updatedInvite = invite.withUpdatedNames(team.getName(), invite.getTargetName());
-      storeInvite(updatedInvite);
+      storeInvite(updatedInvite, false);
       Player target = plugin.getServer().getPlayer(updatedInvite.getTargetPlayerId());
       if (target != null) {
         String acceptCommand = "/team accept " + updatedInvite.getTeamName();
@@ -1253,6 +1339,9 @@ public class MembershipService {
             target,
             TeamMessageUtils.inviteListEntry(updatedInvite, acceptCommand, declineCommand));
       }
+    }
+    if (!existingInvites.isEmpty()) {
+      persistInvites();
     }
   }
 
@@ -1274,7 +1363,10 @@ public class MembershipService {
     }
 
     for (PendingRequest request : existingRequests) {
-      storeJoinRequest(request.withTeamName(team.getName()));
+      storeJoinRequest(request.withTeamName(team.getName()), false);
+    }
+    if (!existingRequests.isEmpty()) {
+      persistJoinRequests();
     }
   }
 

--- a/src/main/java/org/example/service/TeamManager.java
+++ b/src/main/java/org/example/service/TeamManager.java
@@ -30,11 +30,11 @@ public class TeamManager implements TeamService {
     this.pluginConfig = pluginConfig;
     this.storage = new TeamStorage(plugin, pluginConfig);
     this.scheduler = new DeadlineScheduler(plugin, pluginConfig, storage);
-    this.storage.loadTeams(scheduler.getDeadlines());
+    this.membership = new MembershipService(plugin, pluginConfig, storage, scheduler);
+    this.storage.loadTeams(scheduler.getDeadlines(), membership);
     this.scheduler.enforceTeamSizes(true);
     this.storage.startAutoSave(pluginConfig.getSaveIntervalSeconds(), scheduler.getDeadlines());
     this.scheduler.start();
-    this.membership = new MembershipService(plugin, pluginConfig, storage, scheduler);
   }
 
   private void runWithTiming(String methodName, Runnable action) {
@@ -216,7 +216,7 @@ public class TeamManager implements TeamService {
     storage.stopAutoSave();
     scheduler.stop();
     pluginConfig.reloadConfig();
-    storage.loadTeams(scheduler.getDeadlines());
+    storage.loadTeams(scheduler.getDeadlines(), membership);
     storage.getTeams().values().forEach(membership::updateTeamMembersPrefixes);
     scheduler.resetLeaderDisplays();
     scheduler.enforceTeamSizes(true);

--- a/src/main/java/org/example/service/TeamStorage.java
+++ b/src/main/java/org/example/service/TeamStorage.java
@@ -9,12 +9,15 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
 import net.kyori.adventure.text.format.NamedTextColor;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.bukkit.scheduler.BukkitTask;
 import org.example.config.PluginConfig;
+import org.example.model.PendingInvite;
+import org.example.model.PendingRequest;
 import org.example.model.Team;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -43,6 +46,10 @@ public class TeamStorage {
   private final Object saveLock = new Object();
   private Map<UUID, Long> deadlinesReference = Collections.emptyMap();
   private volatile boolean autoSaveEnabled;
+  private Collection<PendingInvite> pendingInvites = List.of();
+  private Collection<PendingRequest> pendingRequests = List.of();
+  private volatile boolean invitesDirty;
+  private volatile boolean requestsDirty;
 
   public TeamStorage(@NotNull JavaPlugin plugin, @NotNull PluginConfig pluginConfig) {
     this.plugin = plugin;
@@ -51,6 +58,10 @@ public class TeamStorage {
 
   /** Loads team information from teams.yml and fills provided deadlines map. */
   public void loadTeams(Map<UUID, Long> deadlines) {
+    loadTeams(deadlines, null);
+  }
+
+  public void loadTeams(Map<UUID, Long> deadlines, @Nullable MembershipService membershipService) {
     synchronized (saveLock) {
       deadlinesReference = deadlines;
       teamsFile = new File(plugin.getDataFolder(), "teams.yml");
@@ -160,10 +171,22 @@ public class TeamStorage {
           legacyDataUpdated = legacyDataUpdated || leaderFromName || result.convertedFromName();
         }
       }
+      PendingData<PendingInvite> inviteData = loadPendingInvites();
+      PendingData<PendingRequest> requestData = loadPendingRequests();
+      pendingInvites = List.copyOf(inviteData.values());
+      pendingRequests = List.copyOf(requestData.values());
+      if (membershipService != null) {
+        membershipService.loadPendingInvites(pendingInvites);
+        membershipService.loadPendingRequests(pendingRequests);
+      }
       dirtyTeams.clear();
       deadlinesDirty = false;
-      if (legacyDataUpdated) {
+      invitesDirty = false;
+      requestsDirty = false;
+      if (legacyDataUpdated || inviteData.updated() || requestData.updated()) {
         saveTeams(deadlines);
+        invitesDirty = false;
+        requestsDirty = false;
       }
     }
   }
@@ -190,12 +213,54 @@ public class TeamStorage {
           teamsConfig.set(path + ".deadline", deadline);
         }
       }
+      teamsConfig.set("invites", null);
+      for (PendingInvite invite : pendingInvites) {
+        String base = "invites." + invite.getTeamId() + "." + invite.getTargetPlayerId();
+        teamsConfig.set(base + ".teamName", invite.getTeamName());
+        teamsConfig.set(base + ".inviterId", invite.getInviterId().toString());
+        teamsConfig.set(base + ".inviterName", invite.getInviterName());
+        teamsConfig.set(base + ".targetName", invite.getTargetName());
+        teamsConfig.set(base + ".createdAt", invite.getCreatedAt());
+        if (invite.getExpiresAt() != null) {
+          teamsConfig.set(base + ".expiresAt", invite.getExpiresAt());
+        } else {
+          teamsConfig.set(base + ".expiresAt", null);
+        }
+      }
+      teamsConfig.set("requests", null);
+      for (PendingRequest request : pendingRequests) {
+        String base = "requests." + request.getTeamId() + "." + request.getPlayerId();
+        teamsConfig.set(base + ".teamName", request.getTeamName());
+        teamsConfig.set(base + ".playerName", request.getPlayerName());
+        teamsConfig.set(base + ".createdAt", request.getCreatedAt());
+        if (request.getExpiresAt() != null) {
+          teamsConfig.set(base + ".expiresAt", request.getExpiresAt());
+        } else {
+          teamsConfig.set(base + ".expiresAt", null);
+        }
+      }
       try {
         teamsConfig.save(teamsFile);
       } catch (IOException e) {
         plugin.getLogger().warning("Failed to save teams.yml: " + e.getMessage());
       }
     }
+  }
+
+  public void saveInvites(@NotNull Collection<PendingInvite> invites) {
+    synchronized (saveLock) {
+      pendingInvites = filterActiveInvites(invites);
+      invitesDirty = true;
+    }
+    scheduleImmediateSaveIfDisabled();
+  }
+
+  public void saveRequests(@NotNull Collection<PendingRequest> requests) {
+    synchronized (saveLock) {
+      pendingRequests = filterActiveRequests(requests);
+      requestsDirty = true;
+    }
+    scheduleImmediateSaveIfDisabled();
   }
 
   public @NotNull Map<UUID, Team> getTeams() {
@@ -380,16 +445,18 @@ public class TeamStorage {
   }
 
   public void flushIfDirty(Map<UUID, Long> deadlines) {
-    if (!deadlinesDirty && dirtyTeams.isEmpty()) {
+    if (!deadlinesDirty && dirtyTeams.isEmpty() && !invitesDirty && !requestsDirty) {
       return;
     }
     synchronized (saveLock) {
-      if (!deadlinesDirty && dirtyTeams.isEmpty()) {
+      if (!deadlinesDirty && dirtyTeams.isEmpty() && !invitesDirty && !requestsDirty) {
         return;
       }
       saveTeams(deadlines != null ? deadlines : deadlinesReference);
       dirtyTeams.clear();
       deadlinesDirty = false;
+      invitesDirty = false;
+      requestsDirty = false;
     }
   }
 
@@ -517,6 +584,146 @@ public class TeamStorage {
       markTeamDirty(team);
     }
     return new TeamLoadResult(team, convertedMembers);
+  }
+
+  private PendingData<PendingInvite> loadPendingInvites() {
+    if (teamsConfig == null) {
+      return new PendingData<>(List.of(), false);
+    }
+    ConfigurationSection invitesSection = teamsConfig.getConfigurationSection("invites");
+    if (invitesSection == null) {
+      return new PendingData<>(List.of(), false);
+    }
+    List<PendingInvite> invites = new ArrayList<>();
+    boolean updated = false;
+    for (String teamIdKey : invitesSection.getKeys(false)) {
+      UUID teamId = parseUuid(teamIdKey);
+      if (teamId == null) {
+        plugin
+            .getLogger()
+            .warning("Skipping invite section with invalid team id '" + teamIdKey + "'.");
+        updated = true;
+        continue;
+      }
+      ConfigurationSection teamInvites = invitesSection.getConfigurationSection(teamIdKey);
+      if (teamInvites == null) {
+        continue;
+      }
+      for (String playerIdKey : teamInvites.getKeys(false)) {
+        UUID playerId = parseUuid(playerIdKey);
+        if (playerId == null) {
+          plugin
+              .getLogger()
+              .warning(
+                  "Skipping invite entry for team "
+                      + teamId
+                      + " with invalid player id '"
+                      + playerIdKey
+                      + "'.");
+          updated = true;
+          continue;
+        }
+        String basePath = "invites." + teamIdKey + "." + playerIdKey;
+        String teamName = teamsConfig.getString(basePath + ".teamName");
+        String inviterIdRaw = teamsConfig.getString(basePath + ".inviterId");
+        UUID inviterId = parseUuid(inviterIdRaw);
+        String inviterName = teamsConfig.getString(basePath + ".inviterName");
+        String targetName = teamsConfig.getString(basePath + ".targetName");
+        long createdAt = teamsConfig.getLong(basePath + ".createdAt", 0L);
+        Long expiresAt = teamsConfig.isSet(basePath + ".expiresAt")
+            ? teamsConfig.getLong(basePath + ".expiresAt")
+            : null;
+        if (teamName == null
+            || inviterId == null
+            || inviterName == null
+            || targetName == null
+            || createdAt <= 0L) {
+          plugin
+              .getLogger()
+              .warning(
+                  "Skipping invite entry for team "
+                      + teamId
+                      + " because it lacks required fields.");
+          updated = true;
+          continue;
+        }
+        PendingInvite invite =
+            PendingInvite.restored(
+                teamId, playerId, inviterId, teamName, inviterName, targetName, createdAt, expiresAt);
+        if (invite.isExpired()) {
+          updated = true;
+          continue;
+        }
+        invites.add(invite);
+      }
+    }
+    return new PendingData<>(invites, updated);
+  }
+
+  private PendingData<PendingRequest> loadPendingRequests() {
+    if (teamsConfig == null) {
+      return new PendingData<>(List.of(), false);
+    }
+    ConfigurationSection requestsSection = teamsConfig.getConfigurationSection("requests");
+    if (requestsSection == null) {
+      return new PendingData<>(List.of(), false);
+    }
+    List<PendingRequest> requests = new ArrayList<>();
+    boolean updated = false;
+    for (String teamIdKey : requestsSection.getKeys(false)) {
+      UUID teamId = parseUuid(teamIdKey);
+      if (teamId == null) {
+        plugin
+            .getLogger()
+            .warning("Skipping requests section with invalid team id '" + teamIdKey + "'.");
+        updated = true;
+        continue;
+      }
+      ConfigurationSection teamRequests = requestsSection.getConfigurationSection(teamIdKey);
+      if (teamRequests == null) {
+        continue;
+      }
+      for (String playerIdKey : teamRequests.getKeys(false)) {
+        UUID playerId = parseUuid(playerIdKey);
+        if (playerId == null) {
+          plugin
+              .getLogger()
+              .warning(
+                  "Skipping request entry for team "
+                      + teamId
+                      + " with invalid player id '"
+                      + playerIdKey
+                      + "'.");
+          updated = true;
+          continue;
+        }
+        String basePath = "requests." + teamIdKey + "." + playerIdKey;
+        String teamName = teamsConfig.getString(basePath + ".teamName");
+        String playerName = teamsConfig.getString(basePath + ".playerName");
+        long createdAt = teamsConfig.getLong(basePath + ".createdAt", 0L);
+        Long expiresAt = teamsConfig.isSet(basePath + ".expiresAt")
+            ? teamsConfig.getLong(basePath + ".expiresAt")
+            : null;
+        if (teamName == null || playerName == null || createdAt <= 0L) {
+          plugin
+              .getLogger()
+              .warning(
+                  "Skipping request entry for team "
+                      + teamId
+                      + " because it lacks required fields.");
+          updated = true;
+          continue;
+        }
+        PendingRequest request =
+            PendingRequest.restored(teamId, playerId, teamName, playerName, createdAt, expiresAt);
+        if (request.isExpired()) {
+          updated = true;
+          continue;
+        }
+        requests.add(request);
+      }
+    }
+    return new PendingData<>(requests, updated);
   }
 
   private UUID resolvePlayerUuid(String value, java.util.function.Consumer<UUID> onResolved) {
@@ -668,6 +875,34 @@ public class TeamStorage {
       }
     }
   }
+
+  private List<PendingInvite> filterActiveInvites(Collection<PendingInvite> invites) {
+    if (invites.isEmpty()) {
+      return List.of();
+    }
+    List<PendingInvite> active = new ArrayList<>();
+    for (PendingInvite invite : invites) {
+      if (invite != null && !invite.isExpired()) {
+        active.add(invite);
+      }
+    }
+    return active.isEmpty() ? List.of() : List.copyOf(active);
+  }
+
+  private List<PendingRequest> filterActiveRequests(Collection<PendingRequest> requests) {
+    if (requests.isEmpty()) {
+      return List.of();
+    }
+    List<PendingRequest> active = new ArrayList<>();
+    for (PendingRequest request : requests) {
+      if (request != null && !request.isExpired()) {
+        active.add(request);
+      }
+    }
+    return active.isEmpty() ? List.of() : List.copyOf(active);
+  }
+
+  private record PendingData<T>(List<T> values, boolean updated) {}
 
   private static final class PendingTeamLoad {
     private final UUID teamId;

--- a/src/test/java/org/example/service/MembershipServiceTest.java
+++ b/src/test/java/org/example/service/MembershipServiceTest.java
@@ -4,7 +4,9 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import java.io.File;
 import java.time.Duration;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -136,6 +138,67 @@ class MembershipServiceTest extends MockBukkitTestBase {
         TeamMessageUtils.inviteExpiredMessage("ExpireTeam"),
         target.nextComponentMessage(),
         "Игрок информируется об истечении приглашения");
+  }
+
+  @Test
+  void pendingInvitesAndRequestsPersistAcrossReload() {
+    File teamsFile = new File(plugin.getDataFolder(), "teams.yml");
+    if (teamsFile.exists()) {
+      assertTrue(teamsFile.delete(), "Не удалось очистить предыдущее состояние teams.yml");
+    }
+    storage.loadTeams(new HashMap<>(), membership);
+
+    when(pluginConfig.getJoinMode()).thenReturn(JoinMode.INVITE_ONLY);
+    PlayerMock leader = server.addPlayer("PersistLeader");
+    PlayerMock inviteTarget = server.addPlayer("PersistTarget");
+    PlayerMock applicant = server.addPlayer("PersistApplicant");
+
+    membership.createTeam("PersistTeam", "PT", "red", leader);
+    drainMessages(leader);
+    drainMessages(inviteTarget);
+    drainMessages(applicant);
+
+    membership.sendInvite(leader, inviteTarget, Duration.ofMinutes(5));
+    assertEquals(
+        1,
+        membership.getInvitesForPlayer(inviteTarget.getUniqueId()).size(),
+        "Приглашение должно сохраняться до перезагрузки");
+
+    when(pluginConfig.getJoinMode()).thenReturn(JoinMode.REQUEST_TO_JOIN);
+    membership.submitJoinRequest("PersistTeam", applicant);
+    assertEquals(
+        1,
+        membership.getJoinRequestsForPlayer(applicant.getUniqueId()).size(),
+        "Заявка должна создаваться до перезагрузки");
+
+    storage.flushNow();
+
+    TeamStorage reloadedStorage = new TeamStorage(plugin, pluginConfig);
+    TestDeadlineScheduler reloadedScheduler =
+        new TestDeadlineScheduler(plugin, pluginConfig, reloadedStorage);
+    MembershipService reloadedMembership =
+        new MembershipService(plugin, pluginConfig, reloadedStorage, reloadedScheduler);
+    reloadedStorage.loadTeams(reloadedScheduler.getDeadlines(), reloadedMembership);
+
+    assertEquals(
+        1,
+        reloadedMembership.getInvitesForPlayer(inviteTarget.getUniqueId()).size(),
+        "Приглашение должно восстановиться из хранилища");
+    assertEquals(
+        "PersistTeam",
+        reloadedMembership.getInvitesForPlayer(inviteTarget.getUniqueId()).get(0).getTeamName(),
+        "Название команды в приглашении сохраняется после перезагрузки");
+
+    assertEquals(
+        1,
+        reloadedMembership.getJoinRequestsForPlayer(applicant.getUniqueId()).size(),
+        "Заявка должна восстановиться из хранилища");
+    assertEquals(
+        "PersistTeam",
+        reloadedMembership.getJoinRequestsForPlayer(applicant.getUniqueId()).get(0).getTeamName(),
+        "Название команды в заявке сохраняется после перезагрузки");
+
+    assertTrue(teamsFile.delete(), "teams.yml должен удаляться после теста");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- extend TeamStorage to load and save pending invites and join requests alongside teams
- integrate MembershipService with TeamStorage so invite/request changes trigger persistence and initial state restoration
- add a regression test covering invite/request persistence across reloads

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_690521ed81bc832ebf868e450f6526fb